### PR TITLE
Use a larger socketserver backlog [server-backlog]

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1365,7 +1365,8 @@ int main (int argc, char *argv[])
       }
 #endif
 
-      socketserver server(portnum);
+      const int backlog = 128;
+      socketserver server(portnum, backlog);
       if (server.good())
       {
          cout << "Waiting for data on port " << portnum << " ..." << endl;


### PR DESCRIPTION
Increasing the backlog should help in servicing requests from clients
running in parallel with large number of processes. While the value of
128 is still relatively small (and not the definitive cure for parallel
clients flooding the listening socket), it is usually the default maximum
in Linux and Darwin kernels:

$ uname
Linux
$ sysctl net.core.somaxconn
net.core.somaxconn = 128

$ uname
Darwin
$ sysctl kern.ipc.somaxconn
kern.ipc.somaxconn: 128