### PR TITLE
Fix a typo in the makefile in the setting for the multisample linewidth. [mac-linewidth-fix]

### DIFF
--- a/makefile
+++ b/makefile
@@ -97,7 +97,7 @@ NOTMAC := $(subst Darwin,,$(shell uname -s))
 
 # Default multisampling mode and multisampling line-width
 GLVIS_MULTISAMPLE  = 4
-GLVIS_MS_LINEWIDTH = $(if NOTMAC,1.4,0.01)
+GLVIS_MS_LINEWIDTH = $(if $(NOTMAC),1.4,0.01)
 GLVIS_FLAGS += -DGLVIS_MULTISAMPLE=$(GLVIS_MULTISAMPLE)\
  -DGLVIS_MS_LINEWIDTH=$(GLVIS_MS_LINEWIDTH)
 


### PR DESCRIPTION
In the makefile, fix the setting of the multisample linewidth on Mac.