### PR TITLE
Update reflecting the change in mfem::GeometryRefiner [geom-refiner-update]

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1139,7 +1139,7 @@ int main (int argc, char *argv[])
    int         multisample   = GetMultisample();
    double      line_width    = Get_LineWidth();
    double      ms_line_width = Get_MS_LineWidth();
-   int         geom_ref_type = 0;
+   int         geom_ref_type = Quadrature1D::ClosedUniform;
 
    OptionsParser args(argc, argv);
 
@@ -1171,7 +1171,7 @@ int main (int argc, char *argv[])
                   " or replace them with the processor rank.");
    args.AddOption(&geom_ref_type, "-grt", "--geometry-refiner-type",
                   "Set of points to use when refining geometry:"
-                  " 0 = uniform, 1 = Gauss-Lobatto.");
+                  " 3 = uniform, 1 = Gauss-Lobatto, (see mfem::Quadrature1D).");
    args.AddOption(&save_coloring, "-sc", "--save-coloring",
                   "-no-sc", "--dont-save-coloring",
                   "Save the mesh coloring generated when opening only a mesh.");


### PR DESCRIPTION
The types used by mfem::GeometryRefiner are now given by Quadrature1D constants.

This update should be merged in master after https://github.com/mfem/mfem/pull/313 is merged.
