### PR TITLE
Add capability to show element and vertex numberings in 2D [numberings-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,8 @@
 Development version, not released yet
 =====================================
 
+- Added capability to show element and vertex numbering in 2D (key 'n').
+
 - Added support for reading mesh and solution from the same file.
 
 - Added a CMake build system.

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -89,7 +89,7 @@ static void SolutionKeyHPressed()
         << "| F2 - Update colors, etc.           |" << endl
         << "| F3/F4 - Shrink/Zoom elements       |" << endl
         << "| F5 - Set level lines               |" << endl
-        << "| F6 - Palete options                |" << endl
+        << "| F6 - Palette options               |" << endl
         << "| F7 - Manually set min/max value    |" << endl
         << "| F8 - List of subdomains to show    |" << endl
         << "| F9/F10 - Walk through subdomains   |" << endl
@@ -1724,7 +1724,6 @@ void VisualizationSceneSolution::PrepareElementNumbering1()
    int ne = mesh->GetNE();
    for (int k = 0; k < ne; k++)
    {
-
       mesh->GetPointMatrix (k, pointmat);
       mesh->GetElementVertices (k, vertices);
       int nv = vertices.Size();

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -54,7 +54,7 @@ static void SolutionKeyHPressed()
         << "+------------------------------------+" << endl
         << "| a -  Displays/Hides the axes       |" << endl
         << "| A -  Turns antialiasing on/off     |" << endl
-        << "| b -  Displays/Hides the boundary   |" << endl
+        << "| b/B  Displays/Hides the boundary   |" << endl
         << "| c -  Toggle colorbar and caption   |" << endl
         << "| C -  Change the main plot caption  |" << endl
         << "| e -  Displays/Hides the elements   |" << endl
@@ -69,7 +69,7 @@ static void SolutionKeyHPressed()
         << "| l -  Turns on/off the light        |" << endl
         << "| L -  Toggle logarithmic scale      |" << endl
         << "| m -  Displays/Hides the mesh       |" << endl
-        << "| n -  Cycle through numberings      |" << endl
+        << "| n/N  Cycle through numberings      |" << endl
         << "| p/P  Cycle through color palettes  |" << endl
         << "| q -  Quits                         |" << endl
         << "| r -  Reset the plot to 3D view     |" << endl
@@ -1005,7 +1005,7 @@ void VisualizationSceneSolution::ToggleLogscale(bool print)
 void DrawNumberedMarker(const double x[3], double dx, int n)
 {
    glBegin(GL_LINES);
-   glColor4d(0, 0, 0, 0);
+   // glColor4d(0, 0, 0, 0);
    glVertex3d(x[0]-dx, x[1]-dx, x[2]);
    glVertex3d(x[0]+dx, x[1]+dx, x[2]);
    glVertex3d(x[0]+dx, x[1]-dx, x[2]);
@@ -2251,15 +2251,6 @@ void VisualizationSceneSolution::Draw()
          glDisable (GL_TEXTURE_1D);
       }
    }
-   if (drawnums)
-   {
-      if (1 == drawnums) {
-         glCallList(e_nums_list);
-      }
-      else if (2 == drawnums) {
-         glCallList(v_nums_list);
-      }
-   }
 
    if (MatAlpha < 1.0)
    {
@@ -2298,6 +2289,15 @@ void VisualizationSceneSolution::Draw()
    else if (drawmesh == 2)
    {
       glCallList(lcurvelist);
+   }
+   if (drawnums)
+   {
+      if (1 == drawnums) {
+         glCallList(e_nums_list);
+      }
+      else if (2 == drawnums) {
+         glCallList(v_nums_list);
+      }
    }
 
    if (draw_cp)

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -69,6 +69,7 @@ static void SolutionKeyHPressed()
         << "| l -  Turns on/off the light        |" << endl
         << "| L -  Toggle logarithmic scale      |" << endl
         << "| m -  Displays/Hides the mesh       |" << endl
+        << "| n -  Cycle through numberings      |" << endl
         << "| p/P  Cycle through color palettes  |" << endl
         << "| q -  Quits                         |" << endl
         << "| r -  Reset the plot to 3D view     |" << endl
@@ -226,6 +227,12 @@ static void KeyMPressed()
    SendExposeEvent();
 }
 
+static void KeyNPressed()
+{
+   vssol -> ToggleDrawNumberings();
+   SendExposeEvent();
+}
+
 static void KeyEPressed()
 {
    vssol -> ToggleDrawElems();
@@ -353,6 +360,7 @@ static void KeyF3Pressed()
       vssol->Prepare();
       vssol->PrepareLines();
       vssol->PrepareLevelCurves();
+      vssol->PrepareNumbering();
       SendExposeEvent();
    }
 }
@@ -365,6 +373,7 @@ static void KeyF4Pressed()
       vssol->Prepare();
       vssol->PrepareLines();
       vssol->PrepareLevelCurves();
+      vssol->PrepareNumbering();
       SendExposeEvent();
    }
 }
@@ -382,6 +391,7 @@ static void KeyF11Pressed()
       vssol->PrepareLines();
       vssol->PrepareBoundary();
       vssol->PrepareLevelCurves();
+      vssol->PrepareNumbering();
       SendExposeEvent();
    }
 }
@@ -399,6 +409,7 @@ static void KeyF12Pressed()
       vssol->PrepareLines();
       vssol->PrepareBoundary();
       vssol->PrepareLevelCurves();
+      vssol->PrepareNumbering();
       SendExposeEvent();
    }
 }
@@ -428,7 +439,8 @@ void VisualizationSceneSolution::Init()
 
    drawelems = shading = 1;
    drawmesh  = 0;
-
+   drawnums  = 0;
+   
    shrink = 1.0;
    shrinkmat = 1.0;
    bdrc.SetSize(2,0);
@@ -464,6 +476,9 @@ void VisualizationSceneSolution::Init()
       auxKeyFunc (AUX_m, KeyMPressed);
       auxKeyFunc (AUX_M, KeyMPressed);
 
+      auxKeyFunc (AUX_n, KeyNPressed);
+      auxKeyFunc (AUX_N, KeyNPressed);
+      
       auxKeyFunc (AUX_e, KeyEPressed);
       auxKeyFunc (AUX_E, KeyEPressed);
 
@@ -493,11 +508,14 @@ void VisualizationSceneSolution::Init()
    lcurvelist = glGenLists (1);
    bdrlist    = glGenLists (1);
    cp_list    = glGenLists (1);
-
+   e_nums_list  = glGenLists (1);
+   v_nums_list  = glGenLists (1);
+   
    Prepare();
    PrepareLines();
    PrepareLevelCurves();
    PrepareBoundary();
+   PrepareNumbering();
 }
 
 VisualizationSceneSolution::~VisualizationSceneSolution()
@@ -507,6 +525,8 @@ VisualizationSceneSolution::~VisualizationSceneSolution()
    glDeleteLists (lcurvelist, 1);
    glDeleteLists (bdrlist, 1);
    glDeleteLists (cp_list, 1);
+   glDeleteLists (e_nums_list, 1);
+   glDeleteLists (v_nums_list, 1);
 }
 
 void VisualizationSceneSolution::ToggleDrawElems()
@@ -534,6 +554,7 @@ void VisualizationSceneSolution::ToggleDrawElems()
       Prepare();
       PrepareLevelCurves();
       PrepareCP();
+      PrepareNumbering();
    }
 }
 
@@ -720,6 +741,7 @@ void VisualizationSceneSolution::SetShading(int s, bool print)
          PrepareBoundary();
          PrepareLevelCurves();
          PrepareCP();
+         PrepareNumbering();
       }
       else
       {
@@ -978,6 +1000,36 @@ void VisualizationSceneSolution::ToggleLogscale(bool print)
    {
       PrintLogscale(true);
    }
+}
+
+void DrawNumberedMarker(const double x[3], double dx, int n)
+{
+   glBegin(GL_LINES);
+   glColor4d(0, 0, 0, 0);
+   glVertex3d(x[0]-dx, x[1]-dx, x[2]);
+   glVertex3d(x[0]+dx, x[1]+dx, x[2]);
+   glVertex3d(x[0]+dx, x[1]-dx, x[2]);
+   glVertex3d(x[0]-dx, x[1]+dx, x[2]);
+   glEnd();
+   
+#ifndef GLVIS_USE_FREETYPE
+   glPushAttrib (GL_LIST_BIT);
+   glListBase (fontbase);
+#endif
+   
+   ostringstream buf;
+   buf << n;
+   
+   glRasterPos3d (x[0], x[1], x[2]);
+#ifndef GLVIS_USE_FREETYPE
+   glCallLists(buf.str().size(), GL_UNSIGNED_BYTE, buf.str().c_str());
+#else
+   DrawBitmapText(buf.str().c_str());
+#endif
+   
+#ifndef GLVIS_USE_FREETYPE
+   glPopAttrib();
+#endif
 }
 
 void DrawTriangle(const double pts[][3], const double cv[],
@@ -1370,6 +1422,7 @@ void VisualizationSceneSolution::Prepare()
 
    for (int d = 0; d < mesh -> attributes.Size(); d++)
    {
+      
       if (!el_attr_to_show[mesh -> attributes[d]-1]) { continue; }
 
       nx = 0.;
@@ -1408,6 +1461,7 @@ void VisualizationSceneSolution::Prepare()
          }
 
       for (i = 0; i < ne; i++)
+      {
          if (mesh -> GetAttribute(i) == mesh -> attributes[d])
          {
             switch (mesh->GetElementType(i))
@@ -1432,6 +1486,7 @@ void VisualizationSceneSolution::Prepare()
             }
             glEnd();
          }
+      }
    }
 
    glEndList();
@@ -1601,6 +1656,243 @@ void VisualizationSceneSolution::PrepareLines()
    }
 
    glEndList();
+}
+
+double VisualizationSceneSolution::GetElementLengthScale(int k)
+{
+   DenseMatrix pointmat;
+   Array<int> vertices;
+
+   mesh->GetPointMatrix(k, pointmat);
+   mesh->GetElementVertices(k, vertices);
+   
+   // Get length scale for x mark
+   double xmax = -numeric_limits<double>::infinity();
+   double ymax = -numeric_limits<double>::infinity();
+   double xmin = numeric_limits<double>::infinity();
+   double ymin = numeric_limits<double>::infinity();
+
+   int nv = vertices.Size();
+   for (int j = 0; j < nv; j++) {
+      double x = pointmat(0,j);
+      double y = pointmat(1,j);
+      if (x > xmax) xmax = x;
+      if (x < xmin) xmin = x;
+      if (y > ymax) ymax = y;
+      if (y < ymin) ymin = y;
+   }
+   double dx = xmax-xmin;
+   double dy = ymax-ymin;
+   double ds = std::min<double>(dx,dy);
+
+   return ds;
+}
+
+void VisualizationSceneSolution::PrepareElementNumbering()
+{
+   int ne = mesh -> GetNE();
+
+   if (ne > MAX_RENDER_NUMBERING) {
+      cout << "Element numbering disabled when #elements > "
+           << MAX_RENDER_NUMBERING << endl;
+      cout << "Rendering the text would be very slow." << endl;
+      return;
+   }
+
+   if (2 == shading) {
+      PrepareElementNumbering2();
+   }
+   else {
+      PrepareElementNumbering1();
+   }
+}
+
+void VisualizationSceneSolution::PrepareElementNumbering1()
+{
+   glNewList(e_nums_list, GL_COMPILE);
+
+   DenseMatrix pointmat;
+   Array<int> vertices;
+
+   int ne = mesh->GetNE();
+   for (int k = 0; k < ne; k++) {
+
+      mesh->GetPointMatrix (k, pointmat);
+      mesh->GetElementVertices (k, vertices);
+      int nv = vertices.Size();
+
+      ShrinkPoints(pointmat, k, 0, 0);
+
+      double xs = 0.0;
+      double ys = 0.0;
+      double us = 0.0;
+      for (int j = 0; j < nv; j++) {
+         xs += pointmat(0,j);
+         ys += pointmat(1,j);
+         us += LogVal((*sol)(vertices[j]));
+      }
+      xs /= nv;
+      ys /= nv;
+      us /= nv;
+
+      double ds = GetElementLengthScale(k);
+      double dx = 0.05*ds;
+
+      double xx[3] = {xs,ys,us};
+      DrawNumberedMarker(xx,dx,k);
+   }
+
+   glEndList();
+}
+
+void VisualizationSceneSolution::PrepareElementNumbering2()
+{
+   RefinedGeometry *RefG;
+   DenseMatrix pointmat;
+   Vector values;
+
+   glNewList(e_nums_list, GL_COMPILE);
+   
+   int ne = mesh->GetNE();
+   for (int i = 0; i < ne; i++)
+   {
+      if (!el_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
+
+      RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
+                                         TimesToRefine, EdgeRefineFactor);
+      GetRefinedValues (i, RefG->RefPts, values, pointmat);
+
+      double xc = 0.0;
+      double yc = 0.0;
+      double uc = 0.0;
+      for (int j = 0; j < values.Size(); j++) {
+      
+         double xv = pointmat(0, j);
+         double yv = pointmat(1, j);
+         double u = values[j];
+
+         xc += xv;
+         yc += yv;
+         uc += u;
+
+      }
+      xc /= values.Size();
+      yc /= values.Size();
+      uc /= values.Size();
+
+      double ds = GetElementLengthScale(i);
+      double dx = 0.05*ds;
+
+      double xx[3] = {xc,yc,uc};
+      DrawNumberedMarker(xx,dx,i);
+   }
+
+   glEndList();
+}
+
+void VisualizationSceneSolution::PrepareVertexNumbering()
+{
+   int nv = mesh->GetNV();
+
+   if (nv > MAX_RENDER_NUMBERING) {
+      cout << "Vertex numbering disabled when #vertices > "
+           << MAX_RENDER_NUMBERING << endl;
+      cout << "Rendering the text would be very slow." << endl;
+      return;
+   }
+
+   if (2 == shading) {
+      PrepareVertexNumbering2();
+   }
+   else {
+      PrepareVertexNumbering1();
+   }
+}
+
+void VisualizationSceneSolution::PrepareVertexNumbering1()
+{
+   glNewList(v_nums_list, GL_COMPILE);
+
+   DenseMatrix pointmat;
+   Array<int> vertices;
+
+   // Draw the vertices for each element.  This is redundant, except
+   // when the elements or domains are shrunk.
+
+   int ne = mesh->GetNE();
+   for (int k = 0; k < ne; k++) {
+
+      mesh->GetPointMatrix (k, pointmat);
+      mesh->GetElementVertices (k, vertices);
+      int nv = vertices.Size();
+
+      ShrinkPoints(pointmat, k, 0, 0);
+
+      double ds = GetElementLengthScale(k);
+      double xs = 0.05*ds;
+      
+      for (int j = 0; j < nv; j++) {
+         double x = pointmat(0,j);
+         double y = pointmat(1,j);
+         double u = LogVal((*sol)(vertices[j]));
+      
+         double xx[3] = {x,y,u};
+         DrawNumberedMarker(xx,xs,vertices[j]);
+      }
+   }
+
+   glEndList();
+}
+
+void VisualizationSceneSolution::PrepareVertexNumbering2()
+{
+   RefinedGeometry *RefG;
+   DenseMatrix pointmat;
+   Vector values;
+   Array<int> vertices;
+
+   glNewList(v_nums_list, GL_COMPILE);
+
+   int j2v[4] = {0,1,3,2}; // transform numbering convention for vertices
+   
+   int ne = mesh->GetNE();
+   for (int i = 0; i < ne; i++)
+   {
+      if (!el_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
+
+      mesh->GetElementVertices (i, vertices);
+
+      // We don't really need to refine here.  But we do want to pick
+      // up the correct values for the different element drawing modes
+      // from within GetRefinedValues.
+      
+      int refine_count = 1;
+      RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
+                                         refine_count, EdgeRefineFactor);
+      GetRefinedValues (i, RefG->RefPts, values, pointmat);
+
+      double ds = GetElementLengthScale(i);
+      double xs = 0.05*ds;
+      
+      for (int j = 0; j < values.Size(); j++) {
+      
+         double xv = pointmat(0, j);
+         double yv = pointmat(1, j);
+
+         double u = values[j];
+         
+         double xx[3] = {xv,yv,u};
+         DrawNumberedMarker(xx,xs,vertices[j2v[j]]);
+      }
+   }
+
+   glEndList();
+}
+
+void VisualizationSceneSolution::PrepareNumbering()
+{
+   PrepareElementNumbering();
+   PrepareVertexNumbering();
 }
 
 void VisualizationSceneSolution::PrepareLines2()
@@ -1957,6 +2249,15 @@ void VisualizationSceneSolution::Draw()
       if (GetUseTexture())
       {
          glDisable (GL_TEXTURE_1D);
+      }
+   }
+   if (drawnums)
+   {
+      if (1 == drawnums) {
+         glCallList(e_nums_list);
+      }
+      else if (2 == drawnums) {
+         glCallList(v_nums_list);
       }
    }
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -2290,6 +2290,8 @@ void VisualizationSceneSolution::Draw()
    {
       glCallList(lcurvelist);
    }
+
+   // draw numberings
    if (drawnums)
    {
       if (1 == drawnums) {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -440,7 +440,7 @@ void VisualizationSceneSolution::Init()
    drawelems = shading = 1;
    drawmesh  = 0;
    drawnums  = 0;
-   
+
    shrink = 1.0;
    shrinkmat = 1.0;
    bdrc.SetSize(2,0);
@@ -478,7 +478,7 @@ void VisualizationSceneSolution::Init()
 
       auxKeyFunc (AUX_n, KeyNPressed);
       auxKeyFunc (AUX_N, KeyNPressed);
-      
+
       auxKeyFunc (AUX_e, KeyEPressed);
       auxKeyFunc (AUX_E, KeyEPressed);
 
@@ -510,7 +510,7 @@ void VisualizationSceneSolution::Init()
    cp_list    = glGenLists (1);
    e_nums_list  = glGenLists (1);
    v_nums_list  = glGenLists (1);
-   
+
    Prepare();
    PrepareLines();
    PrepareLevelCurves();
@@ -532,7 +532,10 @@ VisualizationSceneSolution::~VisualizationSceneSolution()
 void VisualizationSceneSolution::ToggleDrawElems()
 {
    const char *modes[] =
-   { "none", "solution", "kappa + 1/kappa", "kappa", "1/det(J)", "det(J)", "attribute" };
+   {
+      "none", "solution", "kappa + 1/kappa", "kappa", "1/det(J)", "det(J)",
+      "attribute"
+   };
 
    drawelems = (drawelems + 6) % 7;
 
@@ -1011,22 +1014,22 @@ void DrawNumberedMarker(const double x[3], double dx, int n)
    glVertex3d(x[0]+dx, x[1]-dx, x[2]);
    glVertex3d(x[0]-dx, x[1]+dx, x[2]);
    glEnd();
-   
+
 #ifndef GLVIS_USE_FREETYPE
    glPushAttrib (GL_LIST_BIT);
    glListBase (fontbase);
 #endif
-   
+
    ostringstream buf;
    buf << n;
-   
+
    glRasterPos3d (x[0], x[1], x[2]);
 #ifndef GLVIS_USE_FREETYPE
    glCallLists(buf.str().size(), GL_UNSIGNED_BYTE, buf.str().c_str());
 #else
    DrawBitmapText(buf.str().c_str());
 #endif
-   
+
 #ifndef GLVIS_USE_FREETYPE
    glPopAttrib();
 #endif
@@ -1422,7 +1425,7 @@ void VisualizationSceneSolution::Prepare()
 
    for (int d = 0; d < mesh -> attributes.Size(); d++)
    {
-      
+
       if (!el_attr_to_show[mesh -> attributes[d]-1]) { continue; }
 
       nx = 0.;
@@ -1665,7 +1668,7 @@ double VisualizationSceneSolution::GetElementLengthScale(int k)
 
    mesh->GetPointMatrix(k, pointmat);
    mesh->GetElementVertices(k, vertices);
-   
+
    // Get length scale for x mark
    double xmax = -numeric_limits<double>::infinity();
    double ymax = -numeric_limits<double>::infinity();
@@ -1673,13 +1676,14 @@ double VisualizationSceneSolution::GetElementLengthScale(int k)
    double ymin = numeric_limits<double>::infinity();
 
    int nv = vertices.Size();
-   for (int j = 0; j < nv; j++) {
+   for (int j = 0; j < nv; j++)
+   {
       double x = pointmat(0,j);
       double y = pointmat(1,j);
-      if (x > xmax) xmax = x;
-      if (x < xmin) xmin = x;
-      if (y > ymax) ymax = y;
-      if (y < ymin) ymin = y;
+      if (x > xmax) { xmax = x; }
+      if (x < xmin) { xmin = x; }
+      if (y > ymax) { ymax = y; }
+      if (y < ymin) { ymin = y; }
    }
    double dx = xmax-xmin;
    double dy = ymax-ymin;
@@ -1692,17 +1696,20 @@ void VisualizationSceneSolution::PrepareElementNumbering()
 {
    int ne = mesh -> GetNE();
 
-   if (ne > MAX_RENDER_NUMBERING) {
+   if (ne > MAX_RENDER_NUMBERING)
+   {
       cout << "Element numbering disabled when #elements > "
            << MAX_RENDER_NUMBERING << endl;
       cout << "Rendering the text would be very slow." << endl;
       return;
    }
 
-   if (2 == shading) {
+   if (2 == shading)
+   {
       PrepareElementNumbering2();
    }
-   else {
+   else
+   {
       PrepareElementNumbering1();
    }
 }
@@ -1715,7 +1722,8 @@ void VisualizationSceneSolution::PrepareElementNumbering1()
    Array<int> vertices;
 
    int ne = mesh->GetNE();
-   for (int k = 0; k < ne; k++) {
+   for (int k = 0; k < ne; k++)
+   {
 
       mesh->GetPointMatrix (k, pointmat);
       mesh->GetElementVertices (k, vertices);
@@ -1726,7 +1734,8 @@ void VisualizationSceneSolution::PrepareElementNumbering1()
       double xs = 0.0;
       double ys = 0.0;
       double us = 0.0;
-      for (int j = 0; j < nv; j++) {
+      for (int j = 0; j < nv; j++)
+      {
          xs += pointmat(0,j);
          ys += pointmat(1,j);
          us += LogVal((*sol)(vertices[j]));
@@ -1752,7 +1761,7 @@ void VisualizationSceneSolution::PrepareElementNumbering2()
    Vector values;
 
    glNewList(e_nums_list, GL_COMPILE);
-   
+
    int ne = mesh->GetNE();
    for (int i = 0; i < ne; i++)
    {
@@ -1765,8 +1774,9 @@ void VisualizationSceneSolution::PrepareElementNumbering2()
       double xc = 0.0;
       double yc = 0.0;
       double uc = 0.0;
-      for (int j = 0; j < values.Size(); j++) {
-      
+      for (int j = 0; j < values.Size(); j++)
+      {
+
          double xv = pointmat(0, j);
          double yv = pointmat(1, j);
          double u = values[j];
@@ -1794,17 +1804,20 @@ void VisualizationSceneSolution::PrepareVertexNumbering()
 {
    int nv = mesh->GetNV();
 
-   if (nv > MAX_RENDER_NUMBERING) {
+   if (nv > MAX_RENDER_NUMBERING)
+   {
       cout << "Vertex numbering disabled when #vertices > "
            << MAX_RENDER_NUMBERING << endl;
       cout << "Rendering the text would be very slow." << endl;
       return;
    }
 
-   if (2 == shading) {
+   if (2 == shading)
+   {
       PrepareVertexNumbering2();
    }
-   else {
+   else
+   {
       PrepareVertexNumbering1();
    }
 }
@@ -1820,7 +1833,8 @@ void VisualizationSceneSolution::PrepareVertexNumbering1()
    // when the elements or domains are shrunk.
 
    int ne = mesh->GetNE();
-   for (int k = 0; k < ne; k++) {
+   for (int k = 0; k < ne; k++)
+   {
 
       mesh->GetPointMatrix (k, pointmat);
       mesh->GetElementVertices (k, vertices);
@@ -1830,12 +1844,13 @@ void VisualizationSceneSolution::PrepareVertexNumbering1()
 
       double ds = GetElementLengthScale(k);
       double xs = 0.05*ds;
-      
-      for (int j = 0; j < nv; j++) {
+
+      for (int j = 0; j < nv; j++)
+      {
          double x = pointmat(0,j);
          double y = pointmat(1,j);
          double u = LogVal((*sol)(vertices[j]));
-      
+
          double xx[3] = {x,y,u};
          DrawNumberedMarker(xx,xs,vertices[j]);
       }
@@ -1854,7 +1869,7 @@ void VisualizationSceneSolution::PrepareVertexNumbering2()
    glNewList(v_nums_list, GL_COMPILE);
 
    int j2v[4] = {0,1,3,2}; // transform numbering convention for vertices
-   
+
    int ne = mesh->GetNE();
    for (int i = 0; i < ne; i++)
    {
@@ -1865,7 +1880,7 @@ void VisualizationSceneSolution::PrepareVertexNumbering2()
       // We don't really need to refine here.  But we do want to pick
       // up the correct values for the different element drawing modes
       // from within GetRefinedValues.
-      
+
       int refine_count = 1;
       RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
                                          refine_count, EdgeRefineFactor);
@@ -1873,14 +1888,15 @@ void VisualizationSceneSolution::PrepareVertexNumbering2()
 
       double ds = GetElementLengthScale(i);
       double xs = 0.05*ds;
-      
-      for (int j = 0; j < values.Size(); j++) {
-      
+
+      for (int j = 0; j < values.Size(); j++)
+      {
+
          double xv = pointmat(0, j);
          double yv = pointmat(1, j);
 
          double u = values[j];
-         
+
          double xx[3] = {xv,yv,u};
          DrawNumberedMarker(xx,xs,vertices[j2v[j]]);
       }
@@ -2294,10 +2310,12 @@ void VisualizationSceneSolution::Draw()
    // draw numberings
    if (drawnums)
    {
-      if (1 == drawnums) {
+      if (1 == drawnums)
+      {
          glCallList(e_nums_list);
       }
-      else if (2 == drawnums) {
+      else if (2 == drawnums)
+      {
          glCallList(v_nums_list);
       }
    }

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -129,8 +129,8 @@ public:
    virtual void ToggleAttributes(Array<int> &attr_list);
 };
 
-void DrawNumberMarker(const double x[3], double dx, int n);
-   
+void DrawNumberedMarker(const double x[3], double dx, int n);
+
 void DrawTriangle(const double pts[][3], const double cv[],
                   const double minv, const double maxv);
 

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -15,10 +15,6 @@
 #include "mfem.hpp"
 using namespace mfem;
 
-// Rendering large numbers of text objects for element or vertex
-// numberings is slow.  Turn it off above some entity count.
-#define MAX_RENDER_NUMBERING 1000
-
 // Visualization header file
 
 class VisualizationSceneSolution : public VisualizationSceneScalarData
@@ -56,6 +52,10 @@ protected:
 
    // Used for drawing markers for element and vertex numberings
    double GetElementLengthScale(int k);
+
+   // Rendering large numbers of text objects for element or vertex
+   // numberings is slow.  Turn it off above some entity count.
+   static const int MAX_RENDER_NUMBERING = 1000;
 
 public:
    int shading, TimesToRefine, EdgeRefineFactor;

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -50,11 +50,11 @@ protected:
 
    int GetAutoRefineFactor();
 
-   // Used for drawing markers for element and vertex numberings
+   // Used for drawing markers for element and vertex numbering
    double GetElementLengthScale(int k);
 
-   // Rendering large numbers of text objects for element or vertex
-   // numberings is slow.  Turn it off above some entity count.
+   // Rendering large numbers of text objects for element or vertex numbering is
+   // slow.  Turn it off above some entity count.
    static const int MAX_RENDER_NUMBERING = 1000;
 
 public:

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -27,7 +27,7 @@ protected:
    int displlist, linelist, lcurvelist;
    int bdrlist, drawbdr, draw_cp, cp_list;
    int e_nums_list, v_nums_list;
-   
+
    void Init();
 
    void FindNewBox(double rx[], double ry[], double rval[]);
@@ -118,7 +118,7 @@ public:
    void ToggleDrawMesh() { drawmesh = (drawmesh+1)%3; }
 
    void ToggleDrawNumberings() { drawnums = (drawnums+1)%3; }
-   
+
    virtual void SetShading(int, bool);
    void ToggleShading();
 

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -15,6 +15,10 @@
 #include "mfem.hpp"
 using namespace mfem;
 
+// Rendering large numbers of text objects for element or vertex
+// numberings is slow.  Turn it off above some entity count.
+#define MAX_RENDER_NUMBERING 1000
+
 // Visualization header file
 
 class VisualizationSceneSolution : public VisualizationSceneScalarData
@@ -23,10 +27,11 @@ protected:
    Vector *v_normals;
    GridFunction *rsol;
 
-   int drawmesh, drawelems;
+   int drawmesh, drawelems, drawnums;
    int displlist, linelist, lcurvelist;
    int bdrlist, drawbdr, draw_cp, cp_list;
-
+   int e_nums_list, v_nums_list;
+   
    void Init();
 
    void FindNewBox(double rx[], double ry[], double rval[]);
@@ -48,6 +53,9 @@ protected:
                         int flat = 0);
 
    int GetAutoRefineFactor();
+
+   // Used for drawing markers for element and vertex numberings
+   double GetElementLengthScale(int k);
 
 public:
    int shading, TimesToRefine, EdgeRefineFactor;
@@ -90,6 +98,14 @@ public:
 
    void PrepareBoundary();
 
+   void PrepareNumbering();
+   void PrepareElementNumbering();
+   void PrepareElementNumbering1();
+   void PrepareElementNumbering2();
+   void PrepareVertexNumbering();
+   void PrepareVertexNumbering1();
+   void PrepareVertexNumbering2();
+
    void PrepareCP();
 
    virtual void Draw();
@@ -101,6 +117,8 @@ public:
 
    void ToggleDrawMesh() { drawmesh = (drawmesh+1)%3; }
 
+   void ToggleDrawNumberings() { drawnums = (drawnums+1)%3; }
+   
    virtual void SetShading(int, bool);
    void ToggleShading();
 
@@ -111,7 +129,8 @@ public:
    virtual void ToggleAttributes(Array<int> &attr_list);
 };
 
-
+void DrawNumberMarker(const double x[3], double dx, int n);
+   
 void DrawTriangle(const double pts[][3], const double cv[],
                   const double minv, const double maxv);
 

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -74,7 +74,7 @@ static void Solution3dKeyHPressed()
         << "| F2 - Update colors, etc.           |" << endl
         << "| F3/F4 - Shrink/Zoom bdr elements   |" << endl
         << "| F5 - Set level lines               |" << endl
-        << "| F6 - Palete options                |" << endl
+        << "| F6 - Palette options               |" << endl
         << "| F7 - Manually set min/max value    |" << endl
         << "| F8 - List of subdomains to show    |" << endl
         << "| F9/F10 - Walk through subdomains   |" << endl

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -29,6 +29,7 @@ static void VectorKeyHPressed()
         << "| a -  Displays/Hides the axes       |" << endl
         << "| A -  Turns antialiasing on/off     |" << endl
         << "| b -  Displacements step back       |" << endl
+        << "| B -  Displays/Hides the boundary   |" << endl
         << "| c -  Toggle colorbar and caption   |" << endl
         << "| C -  Change the main plot caption  |" << endl
         << "| d -  Displays/Hides displacements  |" << endl
@@ -36,6 +37,8 @@ static void VectorKeyHPressed()
         << "| f -  Smooth/Flat shading           |" << endl
         << "| g -  Toggle background             |" << endl
         << "| h -  Displays help menu            |" << endl
+        << "| i -  (De)refine elem. (NC shading) |" << endl
+        << "| I -  Switch 'i' func. (NC shading) |" << endl
         << "| j -  Turn on/off perspective       |" << endl
         << "| k/K  Adjust the transparency level |" << endl
         << "| ,/<  Adjust color transparency     |" << endl
@@ -43,6 +46,7 @@ static void VectorKeyHPressed()
         << "| L -  Toggle logarithmic scale      |" << endl
         << "| m -  Displays/Hides the mesh       |" << endl
         << "| n -  Displacements step forward    |" << endl
+        << "| N -  Cycle through numberings      |" << endl
         << "| p/P  Cycle through color palettes  |" << endl
         << "| q -  Quits                         |" << endl
         << "| r -  Reset the plot to 3D view     |" << endl
@@ -500,11 +504,8 @@ void VisualizationSceneVector::Init()
 
       auxKeyFunc (AUX_d, KeyDPressed);
       auxKeyFunc (AUX_D, KeyDPressed);
-      auxKeyFunc (AUX_n, KeyNPressed);
-      auxKeyFunc (AUX_N, KeyNPressed);
-      // auxKeyFunc (AUX_b, KeyBPressed);
+      auxKeyFuncReplace(AUX_n, KeyNPressed);
       auxKeyFuncReplace(AUX_b, KeyBPressed);
-      // auxKeyFunc (AUX_B, KeyBPressed);
       auxKeyFunc (AUX_v, KeyvPressed);
       auxKeyFunc (AUX_V, KeyVPressed);
       auxKeyFunc (AUX_u, KeyuPressed);

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -1062,6 +1062,17 @@ void VisualizationSceneVector::Draw()
       glCallList(lcurvelist);
    }
 
+   // draw numberings
+   if (drawnums)
+   {
+      if (1 == drawnums) {
+         glCallList(e_nums_list);
+      }
+      else if (2 == drawnums) {
+         glCallList(v_nums_list);
+      }
+   }
+
    if (drawvector == 1)
    {
       glCallList(vectorlist);

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -65,7 +65,7 @@ static void VectorKeyHPressed()
         << "| F2 - Update colors, etc.           |" << endl
         << "| F3/F4 - Shrink/Zoom elements       |" << endl
         << "| F5 - Set level lines               |" << endl
-        << "| F6 - Palete options                |" << endl
+        << "| F6 - Palette options               |" << endl
         << "| F7 - Manually set min/max value    |" << endl
         << "| F8 - List of subdomains to show    |" << endl
         << "| F9/F10 - Walk through subdomains   |" << endl

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -1065,10 +1065,12 @@ void VisualizationSceneVector::Draw()
    // draw numberings
    if (drawnums)
    {
-      if (1 == drawnums) {
+      if (1 == drawnums)
+      {
          glCallList(e_nums_list);
       }
-      else if (2 == drawnums) {
+      else if (2 == drawnums)
+      {
          glCallList(v_nums_list);
       }
    }

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -69,7 +69,7 @@ static void VectorKeyHPressed()
         << "| F1 - X window info and keystrokes  |" << endl
         << "| F2 - Update colors, etc.           |" << endl
         << "| F3/F4 - Shrink/Zoom bdr elements   |" << endl
-        << "| F6 - Palete options                |" << endl
+        << "| F6 - Palette options               |" << endl
         << "| F7 - Manually set min/max value    |" << endl
         << "| F8 - List of subdomains to show    |" << endl
         << "| F9/F10 - Walk through subdomains   |" << endl


### PR DESCRIPTION
Cycle through none, element, and vertex numberings with the 'n' key.

A few issues:
* There are some tricky issues with occlusion depending on what you are looking at.  It may be best not to fight this, but just to turn off the elements to work around this when needed.
* In parallel, vertex numberings overwrite one another.  Shrinking domains with F11 is a workaround for this.  The labels of both elements and vertices should follow any shrinking transformations.
* Not implemented in 3D.
* Text drawing gets quite slow for large numbers of entities.  I put in a cutoff above 1000 entities to just disable the feature.  I figure since this feature is probably most useful in a debugging context, this isn't a deal breaking compromise.  It can be increased if you are patient.
