### PR TITLE
some 3D fixes

### DIFF
--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -141,7 +141,7 @@ static void SwitchAttribute(int increment, int &attribute,
                             Array<int> &attribute_marker,
                             bool bdr)
 {
-   const char *attr_type = bdr ? "bdr" : "elememt";
+   const char *attr_type = bdr ? "bdr" : "element";
    if (attribute_marker.Size() == 0)
    {
       cout << "There are no " << attr_type << " attributes" << endl;

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -429,17 +429,26 @@ static void KeyF9Pressed()
       }
    if (n == 1)
    {
-      j = (j + 1) % attr_list.Size();
+      j = (j + 1) % (attr_list.Size() + 1);
    }
    else
    {
       j = 0;
    }
-   attr = attr_list[j];
-   attr_marker = 0;
-   attr_marker[attr-1] = 1;
-   cout << "Showing " << ((dim == 3) ? "bdr " : "") << "attribute "
-        << attr << endl;
+   if (j == attr_list.Size())
+   {
+      attr_marker = 1;
+      cout << "Showing all " << ((dim == 3) ? "bdr " : "") << "attributes "
+           << endl;
+   }
+   else
+   {
+      attr = attr_list[j];
+      attr_marker = 0;
+      attr_marker[attr-1] = 1;
+      cout << "Showing " << ((dim == 3) ? "bdr " : "") << "attribute "
+           << attr << endl;
+   }
    vssol3d -> PrepareLines();
    vssol3d -> Prepare();
    SendExposeEvent();
@@ -466,17 +475,26 @@ static void KeyF10Pressed()
       }
    if (n == 1)
    {
-      j = (j + attr_list.Size() - 1) % attr_list.Size();
+      j = (j + attr_list.Size()) % (attr_list.Size() + 1);
    }
    else
    {
       j = attr_list.Size() - 1;
    }
-   attr = attr_list[j];
-   attr_marker = 0;
-   attr_marker[attr-1] = 1;
-   cout << "Showing " << ((dim == 3) ? "bdr " : "") << "attribute "
-        << attr << endl;
+   if (j == attr_list.Size())
+   {
+      attr_marker = 1;
+      cout << "Showing all " << ((dim == 3) ? "bdr " : "") << "attributes "
+           << endl;
+   }
+   else
+   {
+      attr = attr_list[j];
+      attr_marker = 0;
+      attr_marker[attr-1] = 1;
+      cout << "Showing " << ((dim == 3) ? "bdr " : "") << "attribute "
+           << attr << endl;
+   }
    vssol3d -> PrepareLines();
    vssol3d -> Prepare();
    SendExposeEvent();

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -597,11 +597,21 @@ void VisualizationSceneSolution3d::Init()
 
    if (mesh->Dimension() == 3)
    {
-      bdr_attr_to_show.SetSize(mesh->bdr_attributes.Max());
+      if (!mesh->bdr_attributes.Size())
+      {
+         MFEM_WARNING("Missing boundary attributes!");
+      }
+      bdr_attr_to_show.SetSize(mesh->bdr_attributes.Size() > 0 ?
+                               mesh->bdr_attributes.Max() : 0);
    }
    else
    {
-      bdr_attr_to_show.SetSize(mesh->attributes.Max());
+      if (!mesh->attributes.Size())
+      {
+         MFEM_WARNING("Missing element attributes!");
+      }
+      bdr_attr_to_show.SetSize(mesh->attributes.Size() > 0 ?
+                               mesh->attributes.Max() : 0);
    }
    bdr_attr_to_show = 1;
 


### PR DESCRIPTION
Fixes the case of missing attributes
When cycling through subdomains (F9./F10), 2D shows the full mesh at the end of the cycle.
Instead, 3D keeps cycling. Now 2D and 3D cases are consistent