### PR TITLE
Switch to X.509 certificates for secure sockets authentication [gnutls-x509-dev]

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1342,16 +1342,22 @@ int main (int argc, char *argv[])
 
 #ifdef MFEM_USE_GNUTLS
       GnuTLS_global_state *state = NULL;
-      // state->set_log_level(1000);
       GnuTLS_session_params *params = NULL;
       if (secure)
       {
          state = new GnuTLS_global_state;
+         // state->set_log_level(1000);
          string home_dir(getenv("HOME"));
          string server_dir = home_dir + "/.config/glvis/server/";
+#ifndef MFEM_USE_GNUTLS_X509
          string pubkey  = server_dir + "pubring.gpg";
          string privkey = server_dir + "secring.gpg";
          string trustedkeys = server_dir + "trusted-clients.gpg";
+#else
+         string pubkey  = server_dir + "cert.pem";
+         string privkey = server_dir + "key.pem";
+         string trustedkeys = server_dir + "trusted-clients.pem";
+#endif
          params = new GnuTLS_session_params(
             *state, pubkey.c_str(), privkey.c_str(),
             trustedkeys.c_str(), GNUTLS_SERVER);


### PR DESCRIPTION
This PR also adds support for X.509 certificate generation in the script `glvis-keygen.sh` and makes it the default keytype to generate.

This is a companion PR to https://github.com/mfem/mfem/pull/377.

TODO:
- [ ] update CHANGELOG and INSTALL.