### PR TITLE
Fix the GLVis build when freetype + fontconfig are disabled [freetype-off-fix]

### DIFF
--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -21,6 +21,7 @@
 
 #include "openglvis.hpp"
 
+extern GLuint fontbase;
 extern float MatAlpha;
 extern float MatAlphaCenter;
 

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -24,8 +24,6 @@ using namespace std;
 
 #include "gl2ps.h"
 
-extern GLuint fontbase;
-
 const char *strings_off_on[] = { "off", "on" };
 
 void VisualizationSceneScalarData::FixValueRange()


### PR DESCRIPTION
This resolves #52.
