### PR TITLE
Improved cutting plane support for curved meshes [cut-plane-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@
 Version 3.4.1 (development)
 ===========================
 
+- Improved cutting plane algorithm for curved elements. The key 'I' can be used
+  to switch to the previous (faster) algorithm which is suitable for meshes with
+  planar faces.
+
 - Updated to support the display and slicing of meshes with wedge elements.
 
 - Added a key for setting the bounding box from the terminal (Shift+F7).

--- a/README
+++ b/README
@@ -170,6 +170,7 @@ F7 - Change the minimum and maximum values
 F8      - List of material subdomains to show
 F9/F10  - Walk through material subdomains
 F11/F12 - Shrink/Zoom material subdomains (to the centers of the attributes)
+Shift+F7 - Set the boundiing box from the terminal
 
 
 Advanced mouse functions
@@ -233,6 +234,10 @@ i   - Toggle clipping (cutting) plane
       The options are: -> none
                        -> cut through the elements
                        -> show only elements behind the clipping plane
+I   - Toggle the clipping plane algorithm used when the option "cut through the
+      elements" is selected. The two algorithms are:
+         -> slower, more accurate algorithm for curved meshes (default)
+         -> faster algorithm suitable for meshes with planar faces
 x/X - Rotate clipping plane (phi)
 y/Y - Rotate clipping plane (theta)
 z/Z - Translate clipping plane

--- a/README
+++ b/README
@@ -170,7 +170,7 @@ F7 - Change the minimum and maximum values
 F8      - List of material subdomains to show
 F9/F10  - Walk through material subdomains
 F11/F12 - Shrink/Zoom material subdomains (to the centers of the attributes)
-Shift+F7 - Set the boundiing box from the terminal
+Shift+F7 - Set the bounding box from the terminal
 
 
 Advanced mouse functions

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -23,6 +23,10 @@ protected:
    int displlist, linelist;
    int cplane, cplanelist, cplanelineslist, lsurflist;
    int cp_drawmesh, cp_drawelems, drawlsurf;
+   // Algorithm used to draw the cutting plane when shading is 2 and cplane is 1
+   // 0 - slower, more accurate algorithm for curved meshes (default)
+   // 1 - faster algorithm suitable for meshes with planar faces
+   int cp_algo;
 
    double *node_pos;
 
@@ -116,6 +120,13 @@ public:
    void FindNodePos();
 
    void CuttingPlaneFunc (int type);
+   // func: 0 - draw surface, 1 - draw level lines
+   void CutRefinedElement(const DenseMatrix &verts, const Vector &vert_dist,
+                          const Vector &vals, const Geometry::Type geom,
+                          const int *elems, int num_elems, int func);
+   void CutRefinedFace(const DenseMatrix &verts, const Vector &vert_dist,
+                       const Vector &vals, const Geometry::Type geom,
+                       const int *faces, int num_faces);
    void CPPrepare();
    void CPMoved();
    void PrepareFlat2();
@@ -128,6 +139,7 @@ public:
    void ToggleCuttingPlane();
    void ToggleCPDrawElems();
    void ToggleCPDrawMesh();
+   void ToggleCPAlgorithm();
    void MoveLevelSurf(int);
    void NumberOfLevelSurf(int);
    virtual void EventUpdateColors();


### PR DESCRIPTION
Implement a new algorithm for drawing the cutting plane when subdivision mode is enabled:
* when drawing the cross-section surface or the level lines in the cross-section, all 3D elements are subdivided and tested for intersection with the cutting plane
* when drawing the boundaries of the cut elements, all face elements are subdivided and tested for intersection with the cutting plane.

The new algorithm is now the default. The previous faster algorithm, which is suitable for meshes with planar faces, is still available through the new/modified key `'I'` which switches between the two algorithms.
