### PR TITLE
Make makefile customizable without editing it

### DIFF
--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -544,8 +544,8 @@ void VisualizationSceneScalarData::DrawCaption()
       caption += " (" + extra_caption + ")";
    }
 
-   int width = 0, height = 0;
 #ifdef GLVIS_USE_FREETYPE
+   int width = 0, height = 0;
    RenderBitmapText(caption.c_str(), width, height);
 #endif
 

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3037,9 +3037,8 @@ void VisualizationSceneSolution3d::DrawRefinedWedgeLevelSurf(
    double vs_data[7], pm_data[3*7], gd_data[3*7];
    Vector vs(vs_data, 7);
    DenseMatrix pm(pm_data, 3, 7), gd(gd_data, 3, 7);
-   int l0, l1;
 
-   for (int k = 0; k < np; k++)
+   for (int k = 0, l0 = -1, l1 = -1; k < np; k++)
    {
       const int pk = k % (n*n);
       if (pk == 0)


### PR DESCRIPTION
I'm adding automatic builds in PETSc of GLVis and MFEM
With this patch, the relevant variables are all customizable, either from command line, or using a configuration file