### PR TITLE
Fix missing "key++" in aux_vis::CallKeySequence

### DIFF
--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -326,6 +326,7 @@ void CallKeySequence(const char *seq)
       }
       else
       {
+         key++;
          switch (*key)
          {
             case 'l': // left arrow


### PR DESCRIPTION
I believe there's a missing "key++" here.  From what I can tell, the point of this if-statement is to be able to use the ~ character to denote keystroke inputs such as the arrow keys that would otherwise be difficult/impossible to place in a script.