### PR TITLE
Display an element ordering curve using the o key [element-ordering-curve-dev]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ Version 3.4.1 (development)
 
 - Added a key for setting the bounding box from the terminal (Shift+F7).
 
-- Add support to visualize an element ordering curve (key 'ctrl+o').
+- Add support to visualize the element ordering curve with 'Ctrl+o'.
 
 Version 3.4, released on May 29, 2018
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ Version 3.4.1 (development)
 
 - Added a key for setting the bounding box from the terminal (Shift+F7).
 
-- Add support to visualize an element ordering curve in 2D (key 'o').
+- Add support to visualize an element ordering curve (key 'ctrl+o').
 
 Version 3.4, released on May 29, 2018
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Version 3.4.1 (development)
 
 - Added a key for setting the bounding box from the terminal (Shift+F7).
 
+- Add support to visualize an element ordering curve in 2D (key 'o').
 
 Version 3.4, released on May 29, 2018
 =====================================

--- a/README
+++ b/README
@@ -141,6 +141,7 @@ arrow keys        - Manual rotation
 1,2,3,4,5,6,7,8,9 - Manual rotation along coordinate axes
 Ctrl+arrow keys   - Translate the viewpoint
 
+o - Toggle an element ordering curve visualization in 2D
 w - Toggle clipping (cutting) plane in 2D (see also 'i' in 3D)
 y/Y - Rotate clipping plane (theta) in 2D
 z/Z - Translate clipping plane in 2D

--- a/README
+++ b/README
@@ -141,7 +141,7 @@ arrow keys        - Manual rotation
 1,2,3,4,5,6,7,8,9 - Manual rotation along coordinate axes
 Ctrl+arrow keys   - Translate the viewpoint
 
-o - Toggle an element ordering curve visualization in 2D
+Ctrl+o - Toggle an element ordering curve in 2D and 3D
 w - Toggle clipping (cutting) plane in 2D (see also 'i' in 3D)
 y/Y - Rotate clipping plane (theta) in 2D
 z/Z - Translate clipping plane in 2D

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -956,6 +956,7 @@ void KeyGPressed()
 {
    Toggle_Background();
    vsdata->PrepareAxes();
+   vsdata->EventUpdateBackground();
    SendExposeEvent();
 }
 

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -161,6 +161,7 @@ public:
    virtual void PrepareLines() = 0;
 
    void UpdateBoundingBox() { SetNewScalingFromBox(); PrepareAxes(); }
+   virtual void EventUpdateBackground() { };
    virtual void EventUpdateColors() { Prepare(); }
    virtual void UpdateLevelLines() = 0;
    virtual void UpdateValueRange(bool prepare) = 0;

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -1957,16 +1957,24 @@ void VisualizationSceneSolution::PrepareOrderingCurve1(int list, bool arrows)
 
       double dx = xs1-xs;
       double dy = ys1-ys;
-      double ds = sqrt(dx*dx+dy*dy);
-      if (arrows) {
-         Arrow3(xs,ys,LogVal(maxv),
-                dx,dy,0.0,
-                ds);
+      double du = us1-us;
+      double ds = sqrt(dx*dx+dy*dy+du*du);
+
+      SetUseTexture(0);
+      double a = minv+double(k)/ne*(maxv-minv);
+      MySetColor(a, minv, maxv);
+
+      if (arrows)
+      {
+	 Arrow3(xs,ys,us,
+		dx,dy,du,
+		ds);
       }
-      else {
-         Arrow3(xs,ys,LogVal(maxv),
-                dx,dy,0.0,
-                ds, 0.0);
+      else
+      {
+	 Arrow3(xs,ys,us,
+		dx,dy,du,
+		ds,0.0);
       }
    }
 
@@ -2392,10 +2400,10 @@ void VisualizationSceneSolution::Draw()
    if (draworder)
    {
       if (1 == draworder) {
-         glCallList(order_list);
+         glCallList(order_list_noarrow);
       }
       else if (2 == draworder) {
-         glCallList(order_list_noarrow);
+         glCallList(order_list);
       }
 
    }

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -1924,7 +1924,8 @@ void VisualizationSceneSolution::PrepareOrderingCurve()
    PrepareOrderingCurve1(order_list_noarrow, false, color);
 }
 
-void VisualizationSceneSolution::PrepareOrderingCurve1(int list, bool arrows, bool color)
+void VisualizationSceneSolution::PrepareOrderingCurve1(int list, bool arrows,
+                                                       bool color)
 {
    glNewList(list, GL_COMPILE);
 
@@ -1987,15 +1988,15 @@ void VisualizationSceneSolution::PrepareOrderingCurve1(int list, bool arrows, bo
 
       if (arrows)
       {
-	 Arrow3(xs,ys,us,
-		dx,dy,du,
-		ds,0.05);
+         Arrow3(xs,ys,us,
+                dx,dy,du,
+                ds,0.05);
       }
       else
       {
-	 Arrow3(xs,ys,us,
-		dx,dy,du,
-		ds,0.0);
+         Arrow3(xs,ys,us,
+                dx,dy,du,
+                ds,0.0);
       }
    }
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -2408,7 +2408,6 @@ void VisualizationSceneSolution::Draw()
       else if (2 == draworder) {
          glCallList(order_list);
       }
-
    }
 
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -233,10 +233,13 @@ static void KeyNPressed()
    SendExposeEvent();
 }
 
-static void KeyOPressed()
+static void KeyOPressed(GLenum state)
 {
-   vssol -> ToggleDrawOrdering();
-   SendExposeEvent();
+   if (state & ControlMask)
+   {
+      vssol -> ToggleDrawOrdering();
+      SendExposeEvent();
+   }
 }
 
 static void KeyEPressed()
@@ -487,8 +490,8 @@ void VisualizationSceneSolution::Init()
       auxKeyFunc (AUX_n, KeyNPressed);
       auxKeyFunc (AUX_N, KeyNPressed);
 
-      auxKeyFunc (AUX_o, KeyOPressed);
-      auxKeyFunc (AUX_O, KeyOPressed);
+      auxModKeyFunc (AUX_o, KeyOPressed);
+      auxModKeyFunc (AUX_O, KeyOPressed);
 
       auxKeyFunc (AUX_e, KeyEPressed);
       auxKeyFunc (AUX_E, KeyEPressed);

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -121,7 +121,7 @@ public:
 
    void ToggleDrawMesh() { drawmesh = (drawmesh+1)%3; }
 
-   // 0 - none, 1 - with arrows, 2 - no arrows
+   // 0 - none, 1 - no arrows, 2 - with arrows
    void ToggleDrawOrdering() {  draworder = (draworder+1)%3; }
 
    // 0 - none, 1 - elements, 2 - vertices

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -23,10 +23,11 @@ protected:
    Vector *v_normals;
    GridFunction *rsol;
 
-   int drawmesh, drawelems, drawnums;
+   int drawmesh, drawelems, drawnums, draworder;
    int displlist, linelist, lcurvelist;
    int bdrlist, drawbdr, draw_cp, cp_list;
    int e_nums_list, v_nums_list;
+   int order_list, order_list_noarrow;
 
    void Init();
 
@@ -98,6 +99,9 @@ public:
 
    void PrepareBoundary();
 
+   void PrepareOrderingCurve();
+   void PrepareOrderingCurve1(int list, bool arrows);
+
    void PrepareNumbering();
    void PrepareElementNumbering();
    void PrepareElementNumbering1();
@@ -117,6 +121,10 @@ public:
 
    void ToggleDrawMesh() { drawmesh = (drawmesh+1)%3; }
 
+   // 0 - none, 1 - with arrows, 2 - no arrows
+   void ToggleDrawOrdering() {  draworder = (draworder+1)%3; }
+
+   // 0 - none, 1 - elements, 2 - vertices
    void ToggleDrawNumberings() { drawnums = (drawnums+1)%3; }
 
    virtual void SetShading(int, bool);

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -82,6 +82,8 @@ public:
    virtual void FindMeshBox(bool prepare);
 
    virtual void ToggleLogscale(bool print);
+   virtual void EventUpdateBackground();
+   virtual void EventUpdateColors();
    virtual void UpdateLevelLines() { PrepareLevelCurves(); }
    virtual void UpdateValueRange(bool prepare);
 
@@ -100,7 +102,7 @@ public:
    void PrepareBoundary();
 
    void PrepareOrderingCurve();
-   void PrepareOrderingCurve1(int list, bool arrows);
+   void PrepareOrderingCurve1(int list, bool arrows, bool color);
 
    void PrepareNumbering();
    void PrepareElementNumbering();
@@ -121,8 +123,9 @@ public:
 
    void ToggleDrawMesh() { drawmesh = (drawmesh+1)%3; }
 
-   // 0 - none, 1 - no arrows, 2 - with arrows
-   void ToggleDrawOrdering() {  draworder = (draworder+1)%3; }
+   // 0 - none, 1 - no arrows (color), 2 - with arrows (color),
+   //           3 - no arrows (black), 4 - with arrows (black)
+   void ToggleDrawOrdering() { draworder = (draworder+1)%5; }
 
    // 0 - none, 1 - elements, 2 - vertices
    void ToggleDrawNumberings() { drawnums = (drawnums+1)%3; }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -68,6 +68,7 @@ static void Solution3dKeyHPressed()
         << "| y/Y  Rotate clipping plane (theta) |" << endl
         << "| z/Z  Translate clipping plane      |" << endl
         << "| Ctrl+p - Print to a PDF file       |" << endl
+        << "| Ctrl+o - Element ordering curve    |" << endl
         << "+------------------------------------+" << endl
         << "| Function keys                      |" << endl
         << "+------------------------------------+" << endl
@@ -118,15 +119,17 @@ static void KeyIPressed()
 
 void VisualizationSceneSolution3d::PrepareOrderingCurve()
 {
-   PrepareOrderingCurve1(order_list, true);
-   PrepareOrderingCurve1(order_list_noarrow, false);
+   bool color = draworder < 3;
+   PrepareOrderingCurve1(order_list, true, color);
+   PrepareOrderingCurve1(order_list_noarrow, false, color);
 }
 
 
-void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows)
+void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows, bool color)
 {
    glNewList(list, GL_COMPILE);
-   glLineWidth(3.0f);
+   glLineWidth(2.0f);
+
    DenseMatrix pointmat;
    Array<int> vertices;
 
@@ -177,15 +180,18 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows)
       double dz = zs1-zs;
       double ds = sqrt(dx*dx+dy*dy+dz*dz);
 
-      SetUseTexture(0);
-      double a = minv+double(k)/ne*(maxv-minv);
-      MySetColor(a, minv, maxv);
+      if (color)
+      {
+         SetUseTexture(0);
+         double a = minv+double(k)/ne*(maxv-minv);
+         MySetColor(a, minv, maxv);
+      }
 
       if (arrows)
       {
 	 Arrow3(xs,ys,zs,
 		dx,dy,dz,
-		ds);
+		ds,0.05);
       }
       else
       {
@@ -298,6 +304,7 @@ static void KeyoPressed(GLenum state)
    if (state & ControlMask)
    {
       vssol3d -> ToggleDrawOrdering();
+      vssol3d -> PrepareOrderingCurve();
       SendExposeEvent();
    }
    else {
@@ -1065,7 +1072,6 @@ void VisualizationSceneSolution3d::EventUpdateColors()
    {
       PrepareLines();
    }
-   
 }
 
 void VisualizationSceneSolution3d::UpdateValueRange(bool prepare)
@@ -3671,10 +3677,12 @@ void VisualizationSceneSolution3d::Draw()
    // draw ordering curve
    if (draworder)
    {
-      if (1 == draworder) {
+      if (1 == draworder || 3 == draworder)
+      {
          glCallList(order_list_noarrow);
       }
-      else if (2 == draworder) {
+      else if (2 == draworder || 4 == draworder)
+      {
          glCallList(order_list);
       }
    }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -125,7 +125,8 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve()
 }
 
 
-void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows, bool color)
+void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows,
+                                                         bool color)
 {
    glNewList(list, GL_COMPILE);
    glLineWidth(2.0f);
@@ -189,15 +190,15 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows, 
 
       if (arrows)
       {
-	 Arrow3(xs,ys,zs,
-		dx,dy,dz,
-		ds,0.05);
+         Arrow3(xs,ys,zs,
+                dx,dy,dz,
+                ds,0.05);
       }
       else
       {
-	 Arrow3(xs,ys,zs,
-		dx,dy,dz,
-		ds,0.0);
+         Arrow3(xs,ys,zs,
+                dx,dy,dz,
+                ds,0.0);
       }
    }
 
@@ -307,19 +308,20 @@ static void KeyoPressed(GLenum state)
       vssol3d -> PrepareOrderingCurve();
       SendExposeEvent();
    }
-   else {
+   else
+   {
       if (vssol3d -> TimesToRefine < 32)
       {
-	 cout << "Subdivision factor = " << ++vssol3d->TimesToRefine << endl;
-	 if (vssol3d -> GetShading() == 2)
-	 {
-	    vssol3d->DoAutoscale(false);
-	    vssol3d -> Prepare();
-	    vssol3d -> PrepareLines();
-	    vssol3d -> CPPrepare();
-	    vssol3d -> PrepareLevelSurf();
-	    SendExposeEvent();
-	 }
+         cout << "Subdivision factor = " << ++vssol3d->TimesToRefine << endl;
+         if (vssol3d -> GetShading() == 2)
+         {
+            vssol3d->DoAutoscale(false);
+            vssol3d -> Prepare();
+            vssol3d -> PrepareLines();
+            vssol3d -> CPPrepare();
+            vssol3d -> PrepareLevelSurf();
+            SendExposeEvent();
+         }
       }
    }
 }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -116,6 +116,89 @@ static void KeyIPressed()
    SendExposeEvent();
 }
 
+void VisualizationSceneSolution3d::PrepareOrderingCurve()
+{
+   PrepareOrderingCurve1(order_list, true);
+   PrepareOrderingCurve1(order_list_noarrow, false);
+}
+
+
+void VisualizationSceneSolution3d::PrepareOrderingCurve1(int list, bool arrows)
+{
+   glNewList(list, GL_COMPILE);
+   glLineWidth(3.0f);
+   DenseMatrix pointmat;
+   Array<int> vertices;
+
+   DenseMatrix pointmat1;
+   Array<int> vertices1;
+
+   int ne = mesh->GetNE();
+   for (int k = 0; k < ne-1; k++)
+   {
+      mesh->GetPointMatrix (k, pointmat);
+      mesh->GetElementVertices (k, vertices);
+      mesh->GetPointMatrix (k+1, pointmat1);
+      mesh->GetElementVertices (k+1, vertices1);
+      int nv = vertices.Size();
+      int nv1 = vertices1.Size();
+
+      ShrinkPoints(pointmat, k, 0, 0);
+      ShrinkPoints(pointmat1, k+1, 0, 0);
+
+      double xs = 0.0;
+      double ys = 0.0;
+      double zs = 0.0;
+      for (int j = 0; j < nv; j++)
+      {
+         xs += pointmat(0,j);
+         ys += pointmat(1,j);
+         zs += pointmat(2,j);
+      }
+      xs /= nv;
+      ys /= nv;
+      zs /= nv;
+
+      double xs1 = 0.0;
+      double ys1 = 0.0;
+      double zs1 = 0.0;
+      for (int j = 0; j < nv1; j++)
+      {
+         xs1 += pointmat1(0,j);
+         ys1 += pointmat1(1,j);
+         zs1 += pointmat1(2,j);
+      }
+      xs1 /= nv1;
+      ys1 /= nv1;
+      zs1 /= nv1;
+
+      double dx = xs1-xs;
+      double dy = ys1-ys;
+      double dz = zs1-zs;
+      double ds = sqrt(dx*dx+dy*dy+dz*dz);
+
+      SetUseTexture(0);
+      double a = minv+double(k)/ne*(maxv-minv);
+      MySetColor(a, minv, maxv);
+
+      if (arrows)
+      {
+	 Arrow3(xs,ys,zs,
+		dx,dy,dz,
+		ds);
+      }
+      else
+      {
+	 Arrow3(xs,ys,zs,
+		dx,dy,dz,
+		ds,0.0);
+      }
+   }
+
+   glLineWidth(1.0f);
+   glEndList();
+}
+
 void VisualizationSceneSolution3d::CPPrepare()
 {
    PrepareCuttingPlane();
@@ -210,19 +293,26 @@ static void KeyFPressed()
    SendExposeEvent();
 }
 
-static void KeyoPressed()
+static void KeyoPressed(GLenum state)
 {
-   if (vssol3d -> TimesToRefine < 32)
+   if (state & ControlMask)
    {
-      cout << "Subdivision factor = " << ++vssol3d->TimesToRefine << endl;
-      if (vssol3d -> GetShading() == 2)
+      vssol3d -> ToggleDrawOrdering();
+      SendExposeEvent();
+   }
+   else {
+      if (vssol3d -> TimesToRefine < 32)
       {
-         vssol3d->DoAutoscale(false);
-         vssol3d -> Prepare();
-         vssol3d -> PrepareLines();
-         vssol3d -> CPPrepare();
-         vssol3d -> PrepareLevelSurf();
-         SendExposeEvent();
+	 cout << "Subdivision factor = " << ++vssol3d->TimesToRefine << endl;
+	 if (vssol3d -> GetShading() == 2)
+	 {
+	    vssol3d->DoAutoscale(false);
+	    vssol3d -> Prepare();
+	    vssol3d -> PrepareLines();
+	    vssol3d -> CPPrepare();
+	    vssol3d -> PrepareLevelSurf();
+	    SendExposeEvent();
+	 }
       }
    }
 }
@@ -674,7 +764,7 @@ void VisualizationSceneSolution3d::Init()
       auxKeyFunc (AUX_i, KeyiPressed);
       auxKeyFunc (AUX_I, KeyIPressed);
 
-      auxKeyFunc (AUX_o, KeyoPressed);
+      auxModKeyFunc (AUX_o, KeyoPressed);
       auxKeyFunc (AUX_O, KeyOPressed);
 
       auxKeyFunc (AUX_w, KeywPressed);
@@ -711,11 +801,14 @@ void VisualizationSceneSolution3d::Init()
    cplanelist = glGenLists (1);
    cplanelineslist = glGenLists (1);
    lsurflist = glGenLists (1);
+   order_list = glGenLists (1);
+   order_list_noarrow = glGenLists (1);
 
    Prepare();
    PrepareLines();
    CPPrepare();
    PrepareLevelSurf();
+   PrepareOrderingCurve();
 }
 
 VisualizationSceneSolution3d::~VisualizationSceneSolution3d()
@@ -725,6 +818,8 @@ VisualizationSceneSolution3d::~VisualizationSceneSolution3d()
    glDeleteLists (cplanelist, 1);
    glDeleteLists (cplanelineslist, 1);
    glDeleteLists (lsurflist, 1);
+   glDeleteLists (order_list, 1);
+   glDeleteLists (order_list_noarrow, 1);
    delete [] node_pos;
 }
 
@@ -760,6 +855,7 @@ void VisualizationSceneSolution3d::NewMeshAndSolution(
    PrepareLines();
    CPPrepare();
    PrepareLevelSurf();
+   PrepareOrderingCurve();
 }
 
 void VisualizationSceneSolution3d::SetShading(int s, bool print)
@@ -819,6 +915,7 @@ void VisualizationSceneSolution3d::SetRefineFactors(int f, int ignored)
       Prepare();
       PrepareLines();
       CPPrepare();
+      PrepareOrderingCurve();
    }
 }
 
@@ -963,10 +1060,12 @@ void VisualizationSceneSolution3d::EventUpdateColors()
    Prepare();
    PrepareCuttingPlane();
    PrepareLevelSurf();
+   PrepareOrderingCurve();
    if (shading == 2 && drawmesh != 0 && FaceShiftScale != 0.0)
    {
       PrepareLines();
    }
+   
 }
 
 void VisualizationSceneSolution3d::UpdateValueRange(bool prepare)
@@ -1014,6 +1113,7 @@ void VisualizationSceneSolution3d::ToggleCuttingPlane()
    {
       Prepare();
       PrepareLines();
+      PrepareOrderingCurve();
    }
 }
 
@@ -3566,6 +3666,17 @@ void VisualizationSceneSolution3d::Draw()
    if (drawelems)
    {
       glCallList(displlist);
+   }
+
+   // draw ordering curve
+   if (draworder)
+   {
+      if (1 == draworder) {
+         glCallList(order_list_noarrow);
+      }
+      else if (2 == draworder) {
+         glCallList(order_list);
+      }
    }
 
    if (cplane && cp_drawelems)

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -19,8 +19,9 @@ class VisualizationSceneSolution3d : public VisualizationSceneScalarData
 {
 protected:
 
-   int drawmesh, drawelems, shading;
+   int drawmesh, drawelems, shading, draworder;
    int displlist, linelist;
+   int order_list, order_list_noarrow;
    int cplane, cplanelist, cplanelineslist, lsurflist;
    int cp_drawmesh, cp_drawelems, drawlsurf;
    // Algorithm used to draw the cutting plane when shading is 2 and cplane is 1
@@ -103,12 +104,17 @@ public:
    virtual void PrepareFlat();
    virtual void PrepareLines();
    virtual void Prepare();
+   virtual void PrepareOrderingCurve();
+   virtual void PrepareOrderingCurve1(int list, bool arrows);
    virtual void Draw();
 
    void ToggleDrawElems()
    { drawelems = !drawelems; Prepare(); }
 
    void ToggleDrawMesh();
+
+   // 0 - none, 1 - no arrows, 2 - with arrows
+   void ToggleDrawOrdering() {  draworder = (draworder+1)%3; }
 
    void ToggleShading();
    int GetShading() { return shading; };

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -105,7 +105,7 @@ public:
    virtual void PrepareLines();
    virtual void Prepare();
    virtual void PrepareOrderingCurve();
-   virtual void PrepareOrderingCurve1(int list, bool arrows);
+   virtual void PrepareOrderingCurve1(int list, bool arrows, bool color);
    virtual void Draw();
 
    void ToggleDrawElems()
@@ -113,8 +113,9 @@ public:
 
    void ToggleDrawMesh();
 
-   // 0 - none, 1 - no arrows, 2 - with arrows
-   void ToggleDrawOrdering() {  draworder = (draworder+1)%3; }
+   // 0 - none, 1 - no arrows (color), 2 - with arrows (color),
+   //           3 - no arrows (black), 4 - with arrows (black)
+   void ToggleDrawOrdering() { draworder = (draworder+1)%5; }
 
    void ToggleShading();
    int GetShading() { return shading; };


### PR DESCRIPTION

This is maybe a little specialized, but since I wrote it while working on element ordering, I thought I would push it up.  Use the 'o' key to display an element ordering curve on 2D meshes.

Examples:

With arrows (first 'o' press):
![star-mesh-ordering-curve-arrows](https://user-images.githubusercontent.com/11507994/71932632-130fb880-3155-11ea-96e8-f38cf1612fdb.png)

Without arrows (second 'o' press):
![star-mesh-ordering-curve-noarrows](https://user-images.githubusercontent.com/11507994/71932784-700b6e80-3155-11ea-9954-f762c4c23feb.png)

AMR mesh:
![amr-mesh-ordering-curve](https://user-images.githubusercontent.com/11507994/71933518-2facf000-3157-11ea-82a8-d3c1b21c6e28.png)

@jakubcerveny 
@tzanio 
<!--GHEX{"id":96,"author":"rw-anderson","editor":"tzanio","reviewers":["jakubcerveny","acfisher"],"assignment":"2020-04-25T13:07:59-07:00","approval":"2020-05-19T15:20:41.678Z","merge":"2020-05-19T15:20:43.230Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#96](https://github.com/glvis/glvis/pull/96) | @rw-anderson | @tzanio | @jakubcerveny + @acfisher | 04/25/20 | 05/19/20 | 05/19/20 | |
<!--ELBATXEHG-->