### PR TITLE
Small fix for the text rendering

### DIFF
--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -2095,7 +2095,10 @@ public:
                image[off + 0] = (unsigned char)(col[0]*255);
                image[off + 1] = (unsigned char)(col[1]*255);
                image[off + 2] = (unsigned char)(col[2]*255);
-               image[off + 3] = val;
+               // Blend the alpha channels since glyph bitmaps can overlap
+               const unsigned char old_val = image[off + 3];
+               image[off + 3] = val + old_val - (val*old_val)/255;
+               // note that: max(val,old_val) <= new_val <= 255
             }
          }
 


### PR DESCRIPTION
When rendering text, glyph bitmaps can overlap, so their alpha channels need to be blended.

<!--GHEX{"id":110,"author":"v-dobrev","editor":"tzanio","reviewers":["tzanio","jakubcerveny"],"assignment":"2020-10-12T11:33:54-07:00","approval":"2020-10-12T19:41:01.178Z","merge":"2020-10-12T19:41:02.146Z"}XEHG--><!--GHEXTABLE-->
 | PR | Author | Editor | Reviewers | Assignment | Approval | Merge| 
 | --- | --- | --- | --- | --- | --- | --- | 
| [#110](https://github.com/glvis/glvis/pull/110) | @v-dobrev | @tzanio | @tzanio + @jakubcerveny | 10/12/20 | 10/12/20 | 10/12/20 | |
<!--ELBATXEHG-->