### PR TITLE
Fix for GLM on LC Intel compilers

### DIFF
--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -19,6 +19,11 @@
 #include <iterator>
 #include <algorithm>
 
+#ifdef __INTEL_COMPILER
+// for some reason, icpc is choking on GLM's constexpr stuff - force it to use
+// only C++98 features as a workaround.
+#define GLM_FORCE_CXX98
+#endif
 #include <glm/mat4x4.hpp>
 #include <glm/vec3.hpp>
 #include <glm/gtc/matrix_access.hpp>


### PR DESCRIPTION
Workaround for an issue where icpc complains about various constexpr usages in GLM.