### PR TITLE
move mesh division in 2d to key 'o' for consistency with 3d

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,10 @@
 Version 3.4.1 (development)
 ===========================
 
+- Keystroke changes: cutting plane in 2D is now toggled with 'i' instead of 'w',
+  and 2D element subdivision is controlled with 'o/O' instead of 'i/I'. These
+  are the same as the corresponding keystrokes in 3D.
+
 - Overhauled rendering and window management backend, replacing X Windows with
   SDL for platform-native window and event handling. This allows for OpenGL 3+
   and HiDPI support on Mac OS X.

--- a/README
+++ b/README
@@ -141,7 +141,7 @@ arrow keys        - Manual rotation
 Ctrl+arrow keys   - Translate the viewpoint
 
 Ctrl+o - Toggle an element ordering curve in 2D and 3D
-w - Toggle clipping (cutting) plane in 2D (see also 'i' in 3D)
+i - Toggle cutting (clipping) plane in 2D
 y/Y - Rotate clipping plane (theta) in 2D
 z/Z - Translate clipping plane in 2D
 

--- a/README
+++ b/README
@@ -141,6 +141,7 @@ arrow keys        - Manual rotation
 Ctrl+arrow keys   - Translate the viewpoint
 
 Ctrl+o - Toggle an element ordering curve in 2D and 3D
+
 i - Toggle cutting (clipping) plane in 2D
 y/Y - Rotate clipping plane (theta) in 2D
 z/Z - Translate clipping plane in 2D

--- a/README
+++ b/README
@@ -108,18 +108,18 @@ f - Change the shading type (the way the elements and mesh are drawn)
                         at the vertices
                      -> multiple triangles / quads per element, also allowing
                         for the visualization of discontinuous functions and
-                        curvilinear elements (use i/I to control subdivisions)
+                        curvilinear elements (use o/O to control subdivisions)
 
-i/I - Control element subdivisions (2D)
+o/O - Control element subdivisions (2D)
       there are two subdivision factors: -> element subdivision factor s1
                                          -> boundary subdivision factor s2
-I - Cycle through the "subdivision functions", (prints a message in the
+O - Cycle through the "subdivision functions", (prints a message in the
     terminal when changed)
     The options are: -> Increase subdivision factor:      s1 += s2
                      -> Decrease subdivision factor:      s1 -= s2
                      -> Increase bdr subdivision factor:  s2++
                      -> Decrease bdr subdivision factor:  s2--
-i - perform the current "subdivision function"
+o - perform the current "subdivision function"
 
 A - Turn on/off the use of anti-aliasing/multi-sampling
 b - Display/Hide the boundary in 2D scalar mode. Use Shift+F9/F10 to cycle
@@ -242,7 +242,7 @@ z/Z - Translate clipping plane
 E   - Display/Hide the elements in the clipping plane
 M   - Display/Hide the mesh in the clipping plane
 
-o/O - Refine/de-refine elements (similar to i/I in 2D)
+o/O - Refine/de-refine elements
 
 u/U - Move level surface value up/down
 v/V - Add/Delete a level surface value

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -61,8 +61,8 @@ static void SolutionKeyHPressed()
         << "| f -  Smooth/Nonconf/Flat shading   |" << endl
         << "| g -  Toggle background             |" << endl
         << "| h -  Displays help menu            |" << endl
-        << "| i -  (De)refine elem. (NC shading) |" << endl
-        << "| I -  Switch 'i' func. (NC shading) |" << endl
+        << "| o -  (De)refine elem. (NC shading) |" << endl
+        << "| O -  Switch 'o' func. (NC shading) |" << endl
         << "| j -  Turn on/off perspective       |" << endl
         << "| k/K  Adjust the transparency level |" << endl
         << "| ,/<  Adjust color transparency     |" << endl

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -61,8 +61,7 @@ static void SolutionKeyHPressed()
         << "| f -  Smooth/Nonconf/Flat shading   |" << endl
         << "| g -  Toggle background             |" << endl
         << "| h -  Displays help menu            |" << endl
-        << "| o -  (De)refine elem. (NC shading) |" << endl
-        << "| O -  Switch 'o' func. (NC shading) |" << endl
+        << "| i -  Toggle the cutting plane      |" << endl
         << "| j -  Turn on/off perspective       |" << endl
         << "| k/K  Adjust the transparency level |" << endl
         << "| ,/<  Adjust color transparency     |" << endl
@@ -70,6 +69,8 @@ static void SolutionKeyHPressed()
         << "| L -  Toggle logarithmic scale      |" << endl
         << "| m -  Displays/Hides the mesh       |" << endl
         << "| n/N  Cycle through numberings      |" << endl
+        << "| o -  (De)refine elem. (NC shading) |" << endl
+        << "| O -  Switch 'o' func. (NC shading) |" << endl
         << "| p/P  Cycle through color palettes  |" << endl
         << "| q -  Quits                         |" << endl
         << "| r -  Reset the plot to 3D view     |" << endl
@@ -77,7 +78,6 @@ static void SolutionKeyHPressed()
         << "| s -  Turn on/off unit cube scaling |" << endl
         << "| S -  Take snapshot/Record a movie  |" << endl
         << "| t -  Cycle materials and lights    |" << endl
-        << "| w -  Toggle the clipping plane     |" << endl
         << "| y/Y  Rotate the clipping plane     |" << endl
         << "| z/Z  Move the clipping plane       |" << endl
         << "| \\ -  Set light source position     |" << endl
@@ -330,18 +330,13 @@ static void KeyFPressed()
 
 void KeyiPressed()
 {
-   // no-op, available
+   vssol->ToggleDrawCP();
+   SendExposeEvent();
 }
 
 void KeyIPressed()
 {
    // no-op, available
-}
-
-static void KeywPressed()
-{
-   vssol->ToggleDrawCP();
-   SendExposeEvent();
 }
 
 static void KeyyPressed()
@@ -513,7 +508,6 @@ void VisualizationSceneSolution::Init()
       wnd->setOnKeyDown('i', KeyiPressed);
       wnd->setOnKeyDown('I', KeyIPressed);
 
-      wnd->setOnKeyDown('w', KeywPressed);
       wnd->setOnKeyDown('y', KeyyPressed);
       wnd->setOnKeyDown('Y', KeyYPressed);
       wnd->setOnKeyDown('z', KeyzPressed);

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -234,7 +234,9 @@ static void KeyNPressed()
    SendExposeEvent();
 }
 
-static void KeyOPressed(GLenum state)
+int refine_func = 0;
+
+static void KeyoPressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -242,76 +244,61 @@ static void KeyOPressed(GLenum state)
       vssol -> PrepareOrderingCurve();
       SendExposeEvent();
    }
-}
-
-static void KeyEPressed()
-{
-   vssol -> ToggleDrawElems();
-   SendExposeEvent();
-}
-
-static void KeyFPressed()
-{
-   vssol -> ToggleShading();
-   SendExposeEvent();
-}
-
-int refine_func = 0;
-
-void KeyiPressed()
-{
-   int update = 1;
-   switch (refine_func)
+   else
    {
-      case 0:
-         vssol -> TimesToRefine += vssol -> EdgeRefineFactor;
-         break;
-      case 1:
-         if (vssol -> TimesToRefine > vssol -> EdgeRefineFactor)
-         {
-            vssol -> TimesToRefine -= vssol -> EdgeRefineFactor;
-         }
-         else
-         {
-            update = 0;
-         }
-         break;
-      case 2:
-         vssol -> TimesToRefine /= vssol -> EdgeRefineFactor;
-         vssol -> EdgeRefineFactor ++;
-         vssol -> TimesToRefine *= vssol -> EdgeRefineFactor;
-         break;
-      case 3:
-         if (vssol -> EdgeRefineFactor > 1)
-         {
+      int update = 1;
+      switch (refine_func)
+      {
+         case 0:
+            vssol -> TimesToRefine += vssol -> EdgeRefineFactor;
+            break;
+         case 1:
+            if (vssol -> TimesToRefine > vssol -> EdgeRefineFactor)
+            {
+               vssol -> TimesToRefine -= vssol -> EdgeRefineFactor;
+            }
+            else
+            {
+               update = 0;
+            }
+            break;
+         case 2:
             vssol -> TimesToRefine /= vssol -> EdgeRefineFactor;
-            vssol -> EdgeRefineFactor --;
+            vssol -> EdgeRefineFactor ++;
             vssol -> TimesToRefine *= vssol -> EdgeRefineFactor;
-         }
-         else
-         {
-            update = 0;
-         }
-         break;
+            break;
+         case 3:
+            if (vssol -> EdgeRefineFactor > 1)
+            {
+               vssol -> TimesToRefine /= vssol -> EdgeRefineFactor;
+               vssol -> EdgeRefineFactor --;
+               vssol -> TimesToRefine *= vssol -> EdgeRefineFactor;
+            }
+            else
+            {
+               update = 0;
+            }
+            break;
+      }
+      if (update && vssol -> shading == 2)
+      {
+         vssol -> DoAutoscale(false);
+         vssol -> PrepareLines();
+         vssol -> PrepareBoundary();
+         vssol -> Prepare();
+         vssol -> PrepareLevelCurves();
+         vssol -> PrepareCP();
+         SendExposeEvent();
+      }
+      cout << "Subdivision factors = " << vssol -> TimesToRefine
+           << ", " << vssol -> EdgeRefineFactor << endl;
    }
-   if (update && vssol -> shading == 2)
-   {
-      vssol -> DoAutoscale(false);
-      vssol -> PrepareLines();
-      vssol -> PrepareBoundary();
-      vssol -> Prepare();
-      vssol -> PrepareLevelCurves();
-      vssol -> PrepareCP();
-      SendExposeEvent();
-   }
-   cout << "Subdivision factors = " << vssol -> TimesToRefine
-        << ", " << vssol -> EdgeRefineFactor << endl;
 }
 
-void KeyIPressed()
+static void KeyOPressed(GLenum state)
 {
    refine_func = (refine_func+1)%4;
-   cout << "Key 'i' will: ";
+   cout << "Key 'o' will: ";
    switch (refine_func)
    {
       case 0:
@@ -327,6 +314,28 @@ void KeyIPressed()
          cout << "Decrease bdr subdivision factor" << endl;
          break;
    }
+}
+
+static void KeyEPressed()
+{
+   vssol -> ToggleDrawElems();
+   SendExposeEvent();
+}
+
+static void KeyFPressed()
+{
+   vssol -> ToggleShading();
+   SendExposeEvent();
+}
+
+void KeyiPressed()
+{
+   // no-op, available
+}
+
+void KeyIPressed()
+{
+   // no-op, available
 }
 
 static void KeywPressed()
@@ -492,7 +501,7 @@ void VisualizationSceneSolution::Init()
       wnd->setOnKeyDown('n', KeyNPressed);
       wnd->setOnKeyDown('N', KeyNPressed);
 
-      wnd->setOnKeyDown('o', KeyOPressed);
+      wnd->setOnKeyDown('o', KeyoPressed);
       wnd->setOnKeyDown('O', KeyOPressed);
 
       wnd->setOnKeyDown('e', KeyEPressed);


### PR DESCRIPTION

Changes the interface to be a little more consistent with 2d and 3d for refining elements.  Both now use o/O.

Addresses #99.