### PR TITLE
Fix for texturing in WebGL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,7 +30,7 @@ Unlike previous GLVis releases, this version requires a C++11 compiler.
   The modern OpenGL context is preferred by default; a new command-line argument
   "-oldgl" can be used to request the legacy backend.
 
-- Preliminary support for building GLVis to Javascript/WebAssembly using
+- Preliminary support for building GLVis to JavaScript/WebAssembly using
   Emscripten, see https://github.com/GLVis/glvis-js.
 
 - Documented project workflow and provided contribution guidelines in the new

--- a/lib/gl/renderer.cpp
+++ b/lib/gl/renderer.cpp
@@ -280,7 +280,9 @@ void GLDevice::init()
    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
    // generate a white default texture modulation with default texture will just
    // pass through input color
-   glBindTexture(GL_TEXTURE_2D, 0);
+   GLuint default_texture;
+   glGenTextures(1, &default_texture);
+   glBindTexture(GL_TEXTURE_2D, default_texture);
    int black_color = 0xFFFFFFFF;
    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                 &black_color);
@@ -288,6 +290,8 @@ void GLDevice::init()
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+   passthrough_texture = TextureHandle(default_texture);
 }
 
 void GLDevice::setViewport(GLsizei w, GLsizei h)

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -144,10 +144,18 @@ protected:
       glDeleteVertexArrays(1, &vao);
    }
 
+   static void texCleanup(GLuint tex)
+   {
+      glDeleteTextures(1, &tex);
+   }
+
    using BufObjHandle = Handle<boCleanup>;
    using DispListHandle = Handle<dspListCleanup>;
    using VtxArrayHandle = Handle<vaoCleanup>;
    using ShaderPrgmHandle = Handle<prgmCleanup>;
+   using TextureHandle = Handle<texCleanup>;
+
+   TextureHandle passthrough_texture;
 
 public:
 
@@ -165,7 +173,7 @@ public:
    void detachTexture(int tex_unit)
    {
       glActiveTexture(GL_TEXTURE0 + tex_unit);
-      glBindTexture(GL_TEXTURE_2D, 0);
+      glBindTexture(GL_TEXTURE_2D, passthrough_texture);
    }
    void attachTexture(int tex_unit, int tex_id)
    {

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -7708,16 +7708,6 @@ void paletteInit()
       }
       MaxTextureSize = std::min(MaxTextureSize, 4096);
       Init_Palettes();
-      //generate a black default texture
-      //modulation with default texture will just pass through input color
-      glBindTexture(GL_TEXTURE_2D, 0);
-      int black_color = 0xFFFFFFFF;
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                   &black_color);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
       glGenTextures(Num_RGB_Palettes * 2, &(palette_tex[0][0]));
       glGenTextures(1, &alpha_tex);


### PR DESCRIPTION
WebGL doesn't support putting data on the default texture "name" (id 0), so instead we have to create a new texture object to hold our passthrough value.

Should fix issues with the ruler showing up as pitch black, and the issues when using the black background (key 'g').