### PR TITLE
Emscripten Improvements

### DIFF
--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -14,10 +14,11 @@
 #include "stream_reader.hpp"
 #include <SDL2/SDL_hints.h>
 #include <emscripten/bind.h>
+#include <emscripten/html5.h>
 
 std::string plot_caption;
-std::string extra_caption;
-mfem::GeometryRefiner GLVisGeometryRefiner;
+std::string extra_caption; // used in extern context
+mfem::GeometryRefiner GLVisGeometryRefiner; // used in extern context
 
 namespace js
 {
@@ -52,6 +53,17 @@ bool startVisualization(const std::string input, const std::string data_type,
 {
    std::stringstream ss(input);
    const int field_type = ReadStream(ss, data_type);
+
+   std::string line;
+   while (ss >> line) {
+     if (line == "keys") {
+       std::cout << "parsing 'keys'" << std::endl;
+       ss >> stream_state.keys;
+     }
+     else {
+       std::cout << "unknown line '" << line << "'" << std::endl;
+     }
+   }
 
    if (field_type < 0 || field_type > 2)
    {
@@ -196,6 +208,12 @@ void iterVisualization()
    GetAppWindow()->mainIter();
 }
 
+void setCanvasId(const std::string & id)
+{
+   std::cout << "glvis: setting canvas id to " << id << std::endl;
+   GetAppWindow()->setCanvasId(id);
+}
+
 void disableKeyHandling()
 {
    SDL_EventState(SDL_KEYDOWN, SDL_DISABLE);
@@ -208,9 +226,22 @@ void enableKeyHandling()
    SDL_EventState(SDL_KEYUP, SDL_ENABLE);
 }
 
-void setKeyboardListeningElementId(const std::string & elem_id)
+void setKeyboardListeningElementId(const std::string & id)
 {
-   SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, elem_id.c_str());
+   SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, id.c_str());
+}
+
+void setupResizeEventCallback(const std::string & id) {
+  // typedef EM_BOOL (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent, void *userData);
+  std::cout << "glvis: adding resize callback for " << id << std::endl;
+  auto err = emscripten_set_resize_callback(id.c_str(), nullptr, true, [](int eventType, const EmscriptenUiEvent *uiEvent, void *userData) -> EM_BOOL {
+    std::cout << "got resize event" << std::endl;
+    return true;
+  });
+  // TODO: macro to wrap this
+  if (err != EMSCRIPTEN_RESULT_SUCCESS) {
+      std::cerr << "error (emscripten_set_resize_callback): " << err << std::endl;
+  }
 }
 } // namespace js
 
@@ -227,4 +258,6 @@ EMSCRIPTEN_BINDINGS(js_funcs)
    em::function("getTextureMode", &GetUseTexture);
    em::function("setTextureMode", &SetUseTexture);
    em::function("resizeWindow", &ResizeWindow);
+   em::function("setCanvasId", &js::setCanvasId);
+   em::function("setupResizeEventCallback", &js::setupResizeEventCallback);
 }

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -55,14 +55,17 @@ bool startVisualization(const std::string input, const std::string data_type,
    const int field_type = ReadStream(ss, data_type);
 
    std::string line;
-   while (ss >> line) {
-     if (line == "keys") {
-       std::cout << "parsing 'keys'" << std::endl;
-       ss >> stream_state.keys;
-     }
-     else {
-       std::cout << "unknown line '" << line << "'" << std::endl;
-     }
+   while (ss >> line)
+   {
+      if (line == "keys")
+      {
+         std::cout << "parsing 'keys'" << std::endl;
+         ss >> stream_state.keys;
+      }
+      else
+      {
+         std::cout << "unknown line '" << line << "'" << std::endl;
+      }
    }
 
    if (field_type < 0 || field_type > 2)
@@ -231,17 +234,22 @@ void setKeyboardListeningElementId(const std::string & id)
    SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, id.c_str());
 }
 
-void setupResizeEventCallback(const std::string & id) {
-  // typedef EM_BOOL (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent, void *userData);
-  std::cout << "glvis: adding resize callback for " << id << std::endl;
-  auto err = emscripten_set_resize_callback(id.c_str(), nullptr, true, [](int eventType, const EmscriptenUiEvent *uiEvent, void *userData) -> EM_BOOL {
-    std::cout << "got resize event" << std::endl;
-    return true;
-  });
-  // TODO: macro to wrap this
-  if (err != EMSCRIPTEN_RESULT_SUCCESS) {
+void setupResizeEventCallback(const std::string & id)
+{
+   // typedef EM_BOOL (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent, void *userData);
+   std::cout << "glvis: adding resize callback for " << id << std::endl;
+   auto err = emscripten_set_resize_callback(id.c_str(), nullptr,
+                                             true, [](int eventType, const EmscriptenUiEvent *uiEvent,
+                                                      void *userData) -> EM_BOOL
+   {
+      std::cout << "got resize event" << std::endl;
+      return true;
+   });
+   // TODO: macro to wrap this
+   if (err != EMSCRIPTEN_RESULT_SUCCESS)
+   {
       std::cerr << "error (emscripten_set_resize_callback): " << err << std::endl;
-  }
+   }
 }
 } // namespace js
 

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -20,6 +20,7 @@
 #include "gl/renderer_ff.hpp"
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#include <emscripten/html5.h>
 #endif
 #include "sdl_helper.hpp"
 #if defined(SDL_VIDEO_DRIVER_X11)
@@ -648,9 +649,7 @@ void SdlWindow::mainIter()
    }
    else
    {
-#ifndef __EMSCRIPTEN__
-      SDL_WaitEvent(NULL);
-#endif
+     // pass
    }
 #endif
    if (wnd_state == RenderState::ExposePending)
@@ -667,7 +666,7 @@ void SdlWindow::mainLoop()
    emscripten_set_main_loop_arg([](void* arg)
    {
       ((SdlWindow*) arg)->mainIter();
-   }, this, 0, 1);
+   }, this, 0, true);
 #else
    visualize = 1;
    while (running)
@@ -709,18 +708,24 @@ void SdlWindow::signalLoop()
 
 void SdlWindow::getWindowSize(int& w, int& h)
 {
+   w = 0;
+   h = 0;
    if (handle)
    {
 #ifdef __EMSCRIPTEN__
-      int is_fullscreen;
-      emscripten_get_canvas_size(&w, &h, &is_fullscreen);
-      // TODO: ^ is deprecated but we need to store the id somewhere
-      /*
-      EMSCRIPTEN_RESULT r = emscripten_get_canvas_element_size("#canvas", &w, &h);
-      if (r != EMSCRIPTEN_RESULT_SUCCESS) {
-        std::cerr << "emscripten error" << std::endl;
+      if (canvas_id_.empty()) {
+        std::cerr << "error: id is undefined: " << canvas_id_ << std::endl;
+        return;
       }
-      */
+      // maybe emscripten_get_element_css_size if we're using the pixel_scale
+      // but it looks like it is always 1
+      // double dw, dh;
+      //auto err = emscripten_get_element_css_size(canvas_id_.c_str(), &dw, &dh);
+      auto err = emscripten_get_canvas_element_size(canvas_id_.c_str(), &w, &h);
+      if (err != EMSCRIPTEN_RESULT_SUCCESS) {
+        std::cerr << "error (emscripten_get_element_css_size): " << err << std::endl;
+        return;
+      }
 #else
       SDL_GetWindowSize(handle->hwnd, &w, &h);
 #endif

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -649,7 +649,7 @@ void SdlWindow::mainIter()
    }
    else
    {
-     // pass
+      // pass
    }
 #endif
    if (wnd_state == RenderState::ExposePending)
@@ -713,18 +713,20 @@ void SdlWindow::getWindowSize(int& w, int& h)
    if (handle)
    {
 #ifdef __EMSCRIPTEN__
-      if (canvas_id_.empty()) {
-        std::cerr << "error: id is undefined: " << canvas_id_ << std::endl;
-        return;
+      if (canvas_id_.empty())
+      {
+         std::cerr << "error: id is undefined: " << canvas_id_ << std::endl;
+         return;
       }
       // maybe emscripten_get_element_css_size if we're using the pixel_scale
       // but it looks like it is always 1
       // double dw, dh;
       //auto err = emscripten_get_element_css_size(canvas_id_.c_str(), &dw, &dh);
       auto err = emscripten_get_canvas_element_size(canvas_id_.c_str(), &w, &h);
-      if (err != EMSCRIPTEN_RESULT_SUCCESS) {
-        std::cerr << "error (emscripten_get_element_css_size): " << err << std::endl;
-        return;
+      if (err != EMSCRIPTEN_RESULT_SUCCESS)
+      {
+         std::cerr << "error (emscripten_get_element_css_size): " << err << std::endl;
+         return;
       }
 #else
       SDL_GetWindowSize(handle->hwnd, &w, &h);

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -67,6 +67,10 @@ private:
 
    bool ctrlDown;
 
+#ifdef __EMSCRIPTEN__
+   std::string canvas_id_;
+#endif
+
    enum class RenderState
    {
       // window displayed is fully current (no events or backbuffer updates pending)
@@ -177,6 +181,11 @@ public:
 
    bool isSwapPending() { return wnd_state == RenderState::SwapPending; }
    bool isExposePending() { return wnd_state == RenderState::ExposePending; }
+
+#ifdef __EMSCRIPTEN__
+   std::string getCanvasId() const { return canvas_id_; }
+   void setCanvasId(std::string canvas_id) { canvas_id_ = canvas_id; }
+#endif
 };
 
 #endif

--- a/makefile
+++ b/makefile
@@ -90,6 +90,8 @@ GLVIS_LDFLAGS ?=
 EMCC      ?= emcc -std=c++11
 FONT_FILE ?= OpenSans.ttf
 EMCC_OPTS ?= -s USE_SDL=2 -s USE_FREETYPE=1
+# TODO: we don't want to have DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0
+# longterm but until the SDL layer supports non-default canvas ids we need this
 EMCC_LIBS ?= -s USE_SDL=2 --bind -s ALLOW_MEMORY_GROWTH=1 -s SINGLE_FILE=1 \
  --no-heap-copy -s ENVIRONMENT=web -s MODULARIZE=1 -s EXPORT_NAME=glvis \
  -s GL_ASSERTIONS=1 -s GL_DEBUG=1 -s USE_FREETYPE=1 -s USE_WEBGL2=1 \


### PR DESCRIPTION
Parses "keys" after `ReadStream` in _aux_js.cpp_ so files with "keys" render correctly
Adds `setCanvasId` so that we can stop using the deprecated `emscripten_get_canvas_size ` in `SdlWindow::getWindowSize`
Removes uncompilable code
Adds `setupResizeEventCallback`, not currently used