### PR TITLE
Improved Emscripten Stream Updates

### DIFF
--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -237,15 +237,7 @@ int updateVisualization(std::string data_type, std::string stream)
 
    auto * new_m = new Mesh(ss, 1, 0, stream_state.fix_elem_orient);
    auto * new_g = new GridFunction(new_m, ss);
-
    double mesh_range = -1.0;
-   /*
-   if (new_g == nullptr)
-   {
-      SetMeshSolution(new_m, new_g, false);
-      mesh_range = new_g->Max() + 1.0;
-   }
-   */
 
    if (new_m->SpaceDimension() == stream_state.mesh->SpaceDimension() &&
        new_g->VectorDim() == stream_state.grid_f->VectorDim())

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -83,8 +83,9 @@ bool startVisualization(const std::string input, const std::string data_type,
       return false;
    }
 
-
    delete vs;
+   vs = nullptr;
+
    double mesh_range = -1.0;
    if (field_type == 0 || field_type == 2)
    {

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -20,7 +20,7 @@ std::string plot_caption;
 std::string extra_caption; // used in extern context
 mfem::GeometryRefiner GLVisGeometryRefiner; // used in extern context
 
-static VisualizationSceneScalarData * vs{nullptr};
+static VisualizationSceneScalarData * vs = nullptr;
 
 namespace js
 {


### PR DESCRIPTION
Adds `updateVisualization` to available JS callbacks; used with web socket server for faster updates and to preserve keys
Delete `vs` with each `startVisualization`; seems to stop the current memory growth/leak issue

JS updates in this branch: https://github.com/GLVis/glvis-js/tree/improve-stream-updating , which builds on the changes in https://github.com/GLVis/glvis-js/pull/2