### PR TITLE
Fix visualization of 2D meshes

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -155,15 +155,12 @@ bool GLVisInitVis(int field_type)
          }
          if (field_type == 2)
          {
-            // Use the 'bone' palette when visualizing a 2D mesh only
-            paletteSet(4);
-         }
-         // Otherwise, the 'jet-like' palette is used in 2D see vssolution.cpp
-         if (field_type == 2)
-         {
             vs->OrthogonalProjection = 1;
             vs->SetLight(false);
             vs->Zoom(1.8);
+            // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
+            // the 'jet-like' palette is used in 2D, see vssolution.cpp).
+            paletteSet(4);
          }
       }
       else if (mesh->SpaceDimension() == 3)

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -106,6 +106,7 @@ void CloseInputStreams(bool);
 GridFunction *ProjectVectorFEGridFunction(GridFunction*);
 
 // Visualize the data in the global variables mesh, sol/grid_f, etc
+// 0 - scalar data, 1 - vector data, 2 - mesh only, (-1) - unknown
 bool GLVisInitVis(int field_type)
 {
    if (field_type < 0 || field_type > 2)
@@ -140,10 +141,6 @@ bool GLVisInitVis(int field_type)
       if (mesh->SpaceDimension() == 2)
       {
          VisualizationSceneSolution *vss;
-         if (field_type == 2)
-         {
-            paletteSet(4);
-         }
          if (normals.Size() > 0)
          {
             vs = vss = new VisualizationSceneSolution(*mesh, sol, &normals);
@@ -156,6 +153,12 @@ bool GLVisInitVis(int field_type)
          {
             vss->SetGridFunction(*grid_f);
          }
+         if (field_type == 2)
+         {
+            // Use the 'bone' palette when visualizing a 2D mesh only
+            paletteSet(4);
+         }
+         // Otherwise, the 'jet-like' palette is used in 2D see vssolution.cpp
          if (field_type == 2)
          {
             vs->OrthogonalProjection = 1;
@@ -175,13 +178,16 @@ bool GLVisInitVis(int field_type)
          {
             if (mesh->Dimension() == 3)
             {
+               // Use the 'white' palette when visualizing a 3D volume mesh only
                paletteSet(11);
                vss->SetLightMatIdx(4);
             }
             else
             {
+               // Use the 'bone' palette when visualizing a surface mesh only
                paletteSet(4);
             }
+            // Otherwise, the 'vivid' palette is used in 3D see vssolution3d.cpp
             vss->ToggleDrawAxes();
             vss->ToggleDrawMesh();
          }

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -54,6 +54,8 @@ bool startVisualization(const std::string input, const std::string data_type,
                         int w, int h)
 {
    std::stringstream ss(input);
+
+   // 0 - scalar data, 1 - vector data, 2 - mesh only, (-1) - unknown
    const int field_type = ReadStream(ss, data_type);
 
    // reset antialiasing
@@ -96,13 +98,6 @@ bool startVisualization(const std::string input, const std::string data_type,
       if (stream_state.mesh->SpaceDimension() == 2)
       {
          VisualizationSceneSolution * vss;
-         if (field_type == 2)
-         {
-            // Use the 'bone' palette when visualizing a 2D mesh only
-            paletteSet(4);
-         }
-         // Otherwise, the 'jet-like' palette is used in 2D see vssolution.cpp
-
          if (stream_state.normals.Size() > 0)
          {
             vs = vss = new VisualizationSceneSolution(*stream_state.mesh, stream_state.sol,
@@ -116,6 +111,12 @@ bool startVisualization(const std::string input, const std::string data_type,
          {
             vss->SetGridFunction(*stream_state.grid_f);
          }
+         if (field_type == 2)
+         {
+            // Use the 'bone' palette when visualizing a 2D mesh only
+            paletteSet(4);
+         }
+         // Otherwise, the 'jet-like' palette is used in 2D see vssolution.cpp
          if (field_type == 2)
          {
             vs->OrthogonalProjection = 1;

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -113,15 +113,12 @@ bool startVisualization(const std::string input, const std::string data_type,
          }
          if (field_type == 2)
          {
-            // Use the 'bone' palette when visualizing a 2D mesh only
-            paletteSet(4);
-         }
-         // Otherwise, the 'jet-like' palette is used in 2D see vssolution.cpp
-         if (field_type == 2)
-         {
             vs->OrthogonalProjection = 1;
             vs->SetLight(0);
             vs->Zoom(1.8);
+            // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
+            // the 'jet-like' palette is used in 2D, see vssolution.cpp).
+            paletteSet(4);
          }
       }
       else if (stream_state.mesh->SpaceDimension() == 3)


### PR DESCRIPTION
I broke the visualization of 2D meshes only, e.g. 

```
./glvis -m ../mfem/data/square-disc.mesh
```

in b470db978bb45db077e32c9df4748977847722a8.

This PR fixes it and adds some relevant comments.
