### PR TITLE
Palettes refactor (and some other stuff)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,8 @@ Version 4.0.1 (development)
 
 - Various bugfixes and improvements related to the JavaScript version.
 
+- Refactoring of palette handling code.
+
 
 Version 4.0, released on Dec 11, 2020
 =====================================

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -160,7 +160,7 @@ bool GLVisInitVis(int field_type)
             vs->Zoom(1.8);
             // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
             // the 'jet-like' palette is used in 2D, see vssolution.cpp).
-            paletteSet(4);
+            vs->GetPalette().SetPalette(4);
          }
       }
       else if (mesh->SpaceDimension() == 3)
@@ -176,13 +176,13 @@ bool GLVisInitVis(int field_type)
             if (mesh->Dimension() == 3)
             {
                // Use the 'white' palette when visualizing a 3D volume mesh only
-               paletteSet(11);
+               vss->GetPalette().SetPalette(11);
                vss->SetLightMatIdx(4);
             }
             else
             {
                // Use the 'bone' palette when visualizing a surface mesh only
-               paletteSet(4);
+               vss->GetPalette().SetPalette(4);
             }
             // Otherwise, the 'vivid' palette is used in 3D see vssolution3d.cpp
             vss->ToggleDrawAxes();
@@ -703,14 +703,16 @@ void ExecuteScriptCommand()
          int pal;
          scr >> pal;
          cout << "Script: palette: " << pal << endl;
-         paletteSet(pal-1);
+         vs->GetPalette().SetPalette(pal);
          MyExpose();
       }
       else if (word == "palette_repeat")
       {
-         scr >> RepeatPaletteTimes;
-         cout << "Script: palette_repeat: " << RepeatPaletteTimes << endl;
-         paletteInit();
+         int rpt_times;
+         scr >> rpt_times;
+         cout << "Script: palette_repeat: " << rpt_times << endl;
+         vs->GetPalette().SetRepeatTimes(rpt_times);
+         vs->GetPalette().Init();
          MyExpose();
       }
       else if (word == "toggle_attributes")

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -160,7 +160,7 @@ bool GLVisInitVis(int field_type)
             vs->Zoom(1.8);
             // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
             // the 'jet-like' palette is used in 2D, see vssolution.cpp).
-            vs->GetPalette().SetPalette(4);
+            vs->palette.SetIndex(4);
          }
       }
       else if (mesh->SpaceDimension() == 3)
@@ -176,13 +176,13 @@ bool GLVisInitVis(int field_type)
             if (mesh->Dimension() == 3)
             {
                // Use the 'white' palette when visualizing a 3D volume mesh only
-               vss->GetPalette().SetPalette(11);
+               vss->palette.SetIndex(11);
                vss->SetLightMatIdx(4);
             }
             else
             {
                // Use the 'bone' palette when visualizing a surface mesh only
-               vss->GetPalette().SetPalette(4);
+               vss->palette.SetIndex(4);
             }
             // Otherwise, the 'vivid' palette is used in 3D see vssolution3d.cpp
             vss->ToggleDrawAxes();
@@ -703,7 +703,7 @@ void ExecuteScriptCommand()
          int pal;
          scr >> pal;
          cout << "Script: palette: " << pal << endl;
-         vs->GetPalette().SetPalette(pal);
+         vs->palette.SetIndex(pal-1);
          MyExpose();
       }
       else if (word == "palette_repeat")
@@ -711,8 +711,8 @@ void ExecuteScriptCommand()
          int rpt_times;
          scr >> rpt_times;
          cout << "Script: palette_repeat: " << rpt_times << endl;
-         vs->GetPalette().SetRepeatTimes(rpt_times);
-         vs->GetPalette().Init();
+         vs->palette.SetRepeatTimes(rpt_times);
+         vs->palette.Init();
          MyExpose();
       }
       else if (word == "toggle_attributes")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND HEADERS
   gl/types.hpp
   aux_vis.hpp
   font.hpp
+  geom_utils.hpp
   logo.hpp
   material.hpp
   openglvis.hpp

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -124,7 +124,7 @@ bool startVisualization(const std::string input, const std::string data_type,
             vs->Zoom(1.8);
             // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
             // the 'jet-like' palette is used in 2D, see vssolution.cpp).
-            paletteSet(4);
+            vs->palette.SetIndex(4);
          }
       }
       else if (stream_state.mesh->SpaceDimension() == 3)
@@ -141,15 +141,15 @@ bool startVisualization(const std::string input, const std::string data_type,
             if (stream_state.mesh->Dimension() == 3)
             {
                // Use the 'white' palette when visualizing a 3D volume mesh only
-               // paletteSet(4);
-               paletteSet(11);
+               // vs->palette.SetIndex(4);
+               vs->palette.SetIndex(11);
                vss->SetLightMatIdx(4);
             }
             else
             {
                // Use the 'bone' palette when visualizing a surface mesh only
                // (the same as when visualizing a 2D mesh only)
-               paletteSet(4);
+               vs->palette.SetIndex(4);
             }
             // Otherwise, the 'vivid' palette is used in 3D see vssolution3d.cpp
 

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -317,7 +317,7 @@ void SetVisualizationScene(VisualizationScene * scene, int view,
       // SendKeySequence(keys);
       CallKeySequence(keys);
    }
-   wnd->getRenderer().setPalette(&locscene->GetPalette());
+   wnd->getRenderer().setPalette(&locscene->palette);
 }
 
 void RunVisualization()
@@ -377,8 +377,8 @@ void MyReshape(GLsizei w, GLsizei h)
 void MyExpose(GLsizei w, GLsizei h)
 {
    MyReshape (w, h);
-   GLuint color_tex = locscene->GetPalette().GetColorTexture();
-   GLuint alpha_tex = locscene->GetPalette().GetAlphaTexture();
+   GLuint color_tex = locscene->palette.GetColorTexture();
+   GLuint alpha_tex = locscene->palette.GetAlphaTexture();
    wnd->getRenderer().setColorTexture(color_tex);
    wnd->getRenderer().setAlphaTexture(alpha_tex);
    gl3::SceneInfo frame = locscene->GetSceneObjs();
@@ -1464,18 +1464,18 @@ void SetWindowTitle(const char *title)
 
 int GetUseTexture()
 {
-   return locscene->GetPalette().GetSmoothSetting();
+   return locscene->palette.GetSmoothSetting();
 }
 
 void SetUseTexture(int ut)
 {
    if (ut == 0)
    {
-      locscene->GetPalette().UseDiscrete();
+      locscene->palette.UseDiscrete();
    }
    else
    {
-      locscene->GetPalette().UseSmooth();
+      locscene->palette.UseSmooth();
    }
 }
 

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -82,8 +82,7 @@ int InitVisualization (const char name[], int x, int y, int w, int h)
    }
    else
    {
-      cout << "Error: visualization is already up." << endl;
-      return 1;
+      wnd->clearEvents();
    }
 
 #ifdef GLVIS_DEBUG

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -316,6 +316,7 @@ void SetVisualizationScene(VisualizationScene * scene, int view,
       // SendKeySequence(keys);
       CallKeySequence(keys);
    }
+   wnd->getRenderer().setPalette(&locscene->GetPalette());
 }
 
 void RunVisualization()
@@ -1451,32 +1452,6 @@ void ResizeWindow(int w, int h)
 void SetWindowTitle(const char *title)
 {
    wnd->setWindowTitle(title);
-}
-
-void GetColorFromVal(double val, float * rgba)
-{
-   int palSize = locscene->GetPalette().GetSize();
-   int RepeatPaletteTimes = locscene->GetPalette().GetRepeatTimes();
-   const double* palData = locscene->GetPalette().GetData();
-   val *= 0.999999999 * ( palSize - 1 ) * abs(RepeatPaletteTimes);
-   int i = (int) floor( val );
-   double t = val - i;
-
-   const double* pal;
-   if (((i / (palSize-1)) % 2 == 0 && RepeatPaletteTimes > 0) ||
-       ((i / (palSize-1)) % 2 == 1 && RepeatPaletteTimes < 0))
-   {
-      pal = palData + 3 * ( i % (palSize-1) );
-   }
-   else
-   {
-      pal = palData + 3 * ( (palSize-2) - i % (palSize-1) );
-      t = 1.0 - t;
-   }
-   rgba[0] = (1.0 - t) * pal[0] + t * pal[3];
-   rgba[1] = (1.0 - t) * pal[1] + t * pal[4];
-   rgba[2] = (1.0 - t) * pal[2] + t * pal[5];
-   rgba[3] = 1.f;
 }
 
 int GetUseTexture()

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -1453,30 +1453,6 @@ void SetWindowTitle(const char *title)
    wnd->setWindowTitle(title);
 }
 
-int MySetColorLogscale = 0;
-
-double GetColorCoord(double val, double min, double max)
-{
-   // static double eps = 1e-24;
-   static const double eps = 0.0;
-   if (MySetColorLogscale)
-   {
-      if (val < min)
-      {
-         val = min;
-      }
-      if (val > max)
-      {
-         val = max;
-      }
-      return log(fabs(val/(min+eps))) / (log(fabs(max/(min+eps)))+eps);
-   }
-   else
-   {
-      return ((val-min)/(max-min));
-   }
-}
-
 void GetColorFromVal(double val, float * rgba)
 {
    int palSize = locscene->GetPalette().GetSize();
@@ -1501,19 +1477,6 @@ void GetColorFromVal(double val, float * rgba)
    rgba[1] = (1.0 - t) * pal[1] + t * pal[4];
    rgba[2] = (1.0 - t) * pal[2] + t * pal[5];
    rgba[3] = 1.f;
-}
-
-void MySetColor (gl3::GlBuilder& builder, double val, double min, double max)
-{
-   MySetColor(builder, GetColorCoord(val, min, max));
-}
-
-void MySetColor (gl3::GlBuilder& builder, double val)
-{
-   if (val < 0.0) { val = 0.0; }
-   if (val > 1.0) { val = 1.0; }
-
-   builder.glTexCoord2f(val, 1.0);
 }
 
 int GetUseTexture()

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -107,11 +107,7 @@ void SendKeySequence(const char *seq);
 // update the visualization window.
 void CallKeySequence(const char *seq);
 
-extern int MySetColorLogscale;
-double GetColorCoord(double val, double min, double max);
 void GetColorFromVal(double val, float * rgba);
-void MySetColor(gl3::GlBuilder& builder, double val);
-void MySetColor(gl3::GlBuilder& builder, double val, double min, double max);
 
 void SetUseTexture(int ut);
 int GetUseTexture();

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -19,12 +19,6 @@
 #include "font.hpp"
 #include "openglvis.hpp"
 
-extern GLuint fontbase;
-extern float MatAlpha;
-extern float MatAlphaCenter;
-extern int RepeatPaletteTimes;
-extern int PaletteNumColors;
-
 /// Initializes the visualization and some keys.
 int InitVisualization(const char name[], int x, int y, int w, int h);
 

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -107,7 +107,6 @@ void SendKeySequence(const char *seq);
 // update the visualization window.
 void CallKeySequence(const char *seq);
 
-void GetColorFromVal(double val, float * rgba);
 
 void SetUseTexture(int ut);
 int GetUseTexture();

--- a/lib/geom_utils.hpp
+++ b/lib/geom_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/geom_utils.hpp
+++ b/lib/geom_utils.hpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_GEOM_UTILS_HPP
+#define GLVIS_GEOM_UTILS_HPP
+#include "mfem.hpp"
+
+// Some inline functions
+
+inline void LinearCombination(const double a, const double x[],
+                              const double b, const double y[], double z[])
+{
+   z[0] = a*x[0] + b*y[0];
+   z[1] = a*x[1] + b*y[1];
+   z[2] = a*x[2] + b*y[2];
+}
+
+inline double InnerProd(const double a[], const double b[])
+{
+   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+inline void CrossProd(const double a[], const double b[], double cp[])
+{
+   cp[0] = a[1] * b[2] - a[2] * b[1];
+   cp[1] = a[2] * b[0] - a[0] * b[2];
+   cp[2] = a[0] * b[1] - a[1] * b[0];
+}
+
+inline int Normalize(double v[])
+{
+   double len = sqrt(InnerProd(v, v));
+   if (len > 0.0)
+   {
+      len = 1.0 / len;
+   }
+   else
+   {
+      return 1;
+   }
+   for (int i = 0; i < 3; i++)
+   {
+      v[i] *= len;
+   }
+   return 0;
+}
+
+inline int Normalize(mfem::DenseMatrix &normals)
+{
+   int err = 0;
+   for (int i = 0; i < normals.Width(); i++)
+   {
+      err += Normalize(&normals(0, i));
+   }
+   return err;
+}
+// 'v' must define three vectors that add up to the zero vector
+// that is v[0], v[1], and v[2] are the sides of a triangle
+inline int UnitCrossProd(double v[][3], double nor[])
+{
+   // normalize the three vectors
+   for (int i = 0; i < 3; i++)
+      if (Normalize(v[i]))
+      {
+         return 1;
+      }
+
+   // find the pair that forms an angle closest to pi/2, i.e. having
+   // the longest cross product:
+   double cp[3][3], max_a = 0.;
+   int k = 0;
+   for (int i = 0; i < 3; i++)
+   {
+      CrossProd(v[(i+1)%3], v[(i+2)%3], cp[i]);
+      double a = sqrt(InnerProd(cp[i], cp[i]));
+      if (max_a < a)
+      {
+         max_a = a, k = i;
+      }
+   }
+   if (max_a == 0.)
+   {
+      return 1;
+   }
+   for (int i = 0; i < 3; i++)
+   {
+      nor[i] = cp[k][i] / max_a;
+   }
+
+   return 0;
+}
+
+inline int Compute3DUnitNormal(const double p1[], const double p2[],
+                               const double p3[], double nor[])
+{
+   double v[3][3];
+
+   for (int i = 0; i < 3; i++)
+   {
+      v[0][i] = p2[i] - p1[i];
+      v[1][i] = p3[i] - p2[i];
+      v[2][i] = p1[i] - p3[i];
+   }
+
+   return UnitCrossProd(v, nor);
+}
+
+inline int Compute3DUnitNormal (const double p1[], const double p2[],
+                                const double p3[], const double p4[], double nor[])
+{
+   double v[3][3];
+
+   for (int i = 0; i < 3; i++)
+   {
+      // cross product of the two diagonals:
+      /*
+        v[0][i] = p3[i] - p1[i];
+        v[1][i] = p4[i] - p2[i];
+        v[2][i] = (p1[i] + p2[i]) - (p3[i] + p4[i]);
+      */
+
+      // cross product of the two vectors connecting the midpoints of the
+      // two pairs of opposing sides; this gives the normal vector in the
+      // midpoint of the quad:
+      v[0][i] = 0.5 * ((p2[i] + p3[i]) - (p1[i] + p4[i]));
+      v[1][i] = 0.5 * ((p4[i] + p3[i]) - (p1[i] + p2[i]));
+      v[2][i] = p1[i] - p3[i];
+   }
+
+   return UnitCrossProd(v, nor);
+}
+
+inline int ProjectVector(double v[], const double n[])
+{
+   // project 'v' on the plane with normal given by 'n' and  then normalize 'v'
+   LinearCombination(InnerProd(n, n), v, -InnerProd(v, n), n, v);
+   return Normalize(v);
+}
+#endif // GLVIS_GEOM_UTILS_HPP

--- a/lib/gl/attr_traits.hpp
+++ b/lib/gl/attr_traits.hpp
@@ -125,9 +125,9 @@ AttrNormal<TV, decltype((void)TV::norm, 0)>>
    const static GLenum FFArrayIdx = GL_NORMAL_ARRAY;
    static void FFSetupFunc(GLint /*size*/, GLenum type, GLsizei stride,
                            const GLvoid* ptr)
-   {
-      glNormalPointer(type, stride, ptr);
-   }
+{
+   glNormalPointer(type, stride, ptr);
+}
 };
 
 template<typename TV>

--- a/lib/gl/attr_traits.hpp
+++ b/lib/gl/attr_traits.hpp
@@ -125,9 +125,9 @@ AttrNormal<TV, decltype((void)TV::norm, 0)>>
    const static GLenum FFArrayIdx = GL_NORMAL_ARRAY;
    static void FFSetupFunc(GLint /*size*/, GLenum type, GLsizei stride,
                            const GLvoid* ptr)
-{
-   glNormalPointer(type, stride, ptr);
-}
+   {
+      glNormalPointer(type, stride, ptr);
+   }
 };
 
 template<typename TV>

--- a/lib/gl/renderer.cpp
+++ b/lib/gl/renderer.cpp
@@ -351,13 +351,13 @@ CaptureBuffer MeshRenderer::capture(const RenderQueue& queue)
       device->attachTexture(GLDevice::SAMPLER_ALPHA, alpha_tex);
       for (auto buf : tex_bufs)
       {
-         device->captureXfbBuffer(cbuf, buf);
+         device->captureXfbBuffer(*pal, cbuf, buf);
       }
       device->detachTexture(GLDevice::SAMPLER_COLOR);
       device->detachTexture(GLDevice::SAMPLER_ALPHA);
       for (auto buf : no_tex_bufs)
       {
-         device->captureXfbBuffer(cbuf, buf);
+         device->captureXfbBuffer(*pal, cbuf, buf);
       }
       if (!params.contains_translucent)
       {

--- a/lib/gl/renderer.cpp
+++ b/lib/gl/renderer.cpp
@@ -115,15 +115,15 @@ void MeshRenderer::render(const RenderQueue& queue)
    {
       return !renderPair.first.contains_translucent;
    });
-   GLDevice::RenderBufHandle renderBufs[2];
-   GLDevice::FBOHandle msaaFb;
+   RenderBufHandle renderBufs[2];
+   FBOHandle msaaFb;
    if (feat_use_fbo_antialias && msaa_enable)
    {
       GLuint colorBuf, depthBuf;
       glGenRenderbuffers(1, &colorBuf);
       glGenRenderbuffers(1, &depthBuf);
-      renderBufs[0] = GLDevice::RenderBufHandle(colorBuf);
-      renderBufs[1] = GLDevice::RenderBufHandle(depthBuf);
+      renderBufs[0] = RenderBufHandle(colorBuf);
+      renderBufs[1] = RenderBufHandle(depthBuf);
 
       GLuint fbo;
       glGenFramebuffers(1, &fbo);
@@ -154,7 +154,7 @@ void MeshRenderer::render(const RenderQueue& queue)
       }
       else
       {
-         msaaFb = GLDevice::FBOHandle(fbo);
+         msaaFb = FBOHandle(fbo);
       }
 #ifndef __EMSCRIPTEN__
       glEnable(GL_MULTISAMPLE);
@@ -252,11 +252,11 @@ void MeshRenderer::render(const RenderQueue& queue)
       int height = vp[3];
       GLuint colorBufId;
       glGenRenderbuffers(1, &colorBufId);
-      GLDevice::RenderBufHandle colorBuf(colorBufId);
+      RenderBufHandle colorBuf(colorBufId);
 
       GLuint fboId;
       glGenFramebuffers(1, &fboId);
-      GLDevice::FBOHandle resolveFb(fboId);
+      FBOHandle resolveFb(fboId);
 
       glBindRenderbuffer(GL_RENDERBUFFER, colorBuf);
       glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -186,7 +186,8 @@ public:
    virtual void exitXfbMode() {}
    // Capture the next drawn vertex buffer to a feedback buffer instead of
    // drawing to screen.
-   virtual void captureXfbBuffer(PaletteState& pal, CaptureBuffer& capture, int hnd) = 0;
+   virtual void captureXfbBuffer(PaletteState& pal, CaptureBuffer& capture,
+                                 int hnd) = 0;
    // Capture the next text buffer instead of drawing to screen.
    void captureXfbBuffer(CaptureBuffer& capture, const TextBuffer& t_buf);
 

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -20,6 +20,7 @@
 #include "platform_gl.hpp"
 #include "types.hpp"
 #include "../material.hpp"
+#include "../palettes.hpp"
 
 namespace gl3
 {
@@ -185,7 +186,7 @@ public:
    virtual void exitXfbMode() {}
    // Capture the next drawn vertex buffer to a feedback buffer instead of
    // drawing to screen.
-   virtual void captureXfbBuffer(CaptureBuffer& capture, int hnd) = 0;
+   virtual void captureXfbBuffer(PaletteState& pal, CaptureBuffer& capture, int hnd) = 0;
    // Capture the next text buffer instead of drawing to screen.
    void captureXfbBuffer(CaptureBuffer& capture, const TextBuffer& t_buf);
 
@@ -198,6 +199,7 @@ class MeshRenderer
    int msaa_samples;
    GLuint color_tex, alpha_tex, font_tex;
    float line_w, line_w_aa;
+   PaletteState* pal;
 
    bool feat_use_fbo_antialias;
    void init();
@@ -222,6 +224,7 @@ public:
    {
       device.reset(new TDevice(device));
    }
+   void setPalette(PaletteState* pal) { this->pal = pal; }
 
    // Sets the texture handle of the color palette.
    void setColorTexture(GLuint tex_h) { color_tex = tex_h; }

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -24,6 +24,8 @@
 namespace gl3
 {
 
+using namespace resource;
+
 const int LIGHTS_MAX = 3;
 #ifdef GLVIS_MS_LINEWIDTH
 const float LINE_WIDTH_AA = GLVIS_MS_LINEWIDTH;
@@ -100,73 +102,6 @@ protected:
    glm::mat4 proj_mtx;
 
    std::array<float, 4> static_color;
-
-   // RAII scope guard for OpenGL handles.
-   template<void(*GLFinalizer)(GLuint)>
-   class Handle
-   {
-      GLuint hnd;
-   public:
-      Handle() : hnd{0} {}
-      Handle(GLuint h) : hnd{h} {}
-      ~Handle() { if (hnd) { GLFinalizer(hnd); } }
-      Handle(Handle&& other)
-         : hnd{other.hnd} { other.hnd = 0; }
-      Handle& operator = (Handle&& other) noexcept
-      {
-         if (this != &other)
-         {
-            hnd = other.hnd;
-            other.hnd = 0;
-         }
-         return *this;
-      }
-      operator GLuint() const { return hnd; }
-   };
-
-   static void boCleanup(GLuint vbo_hnd)
-   {
-      glDeleteBuffers(1, &vbo_hnd);
-   }
-
-   static void dspListCleanup(GLuint dlist)
-   {
-      glDeleteLists(dlist, 1);
-   }
-
-   static void prgmCleanup(GLuint prgm)
-   {
-      glDeleteProgram(prgm);
-   }
-
-   static void vaoCleanup(GLuint vao)
-   {
-      glDeleteVertexArrays(1, &vao);
-   }
-
-   static void texCleanup(GLuint tex)
-   {
-      glDeleteTextures(1, &tex);
-   }
-
-   static void fboCleanup(GLuint fbo)
-   {
-      glDeleteFramebuffers(1, &fbo);
-   }
-
-   static void rboCleanup(GLuint rbo)
-   {
-      glDeleteRenderbuffers(1, &rbo);
-   }
-public:
-
-   using BufObjHandle = Handle<boCleanup>;
-   using DispListHandle = Handle<dspListCleanup>;
-   using VtxArrayHandle = Handle<vaoCleanup>;
-   using ShaderPrgmHandle = Handle<prgmCleanup>;
-   using TextureHandle = Handle<texCleanup>;
-   using FBOHandle = Handle<fboCleanup>;
-   using RenderBufHandle = Handle<rboCleanup>;
 
 protected:
    TextureHandle passthrough_texture;

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -121,7 +121,7 @@ protected:
          }
          return *this;
       }
-      operator GLuint() { return hnd; }
+      operator GLuint() const { return hnd; }
    };
 
    static void boCleanup(GLuint vbo_hnd)

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -817,7 +817,7 @@ void CoreGLDevice::processLineXfbBuffer(CaptureBuffer& cbuf,
 
 
 void CoreGLDevice::captureXfbBuffer(
-   CaptureBuffer& cbuf, int hnd)
+   PaletteState& pal, CaptureBuffer& cbuf, int hnd)
 {
    if (hnd == 0) { return; }
    if (vbos[hnd].count == 0) { return; }

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -850,8 +850,8 @@ void CoreGLDevice::captureXfbBuffer(
 
 #else
 
-void CoreGLDevice::captureXfbBuffer(
-   CaptureBuffer& cbuf, int hnd)
+void CoreGLDevice::captureXfbBuffer(PaletteState & /*unused*/,
+                                    CaptureBuffer& /*unused*/, int /*unused*/)
 {
    std::cerr << "CoreGLDevice::captureXfbBuffer: "
              << "Not implemented for WebGL." << std::endl;

--- a/lib/gl/renderer_core.hpp
+++ b/lib/gl/renderer_core.hpp
@@ -113,7 +113,7 @@ public:
       initializeShaderState(RenderMode::Default);
       glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, 0);
    }
-   void captureXfbBuffer(CaptureBuffer& cbuf, int hnd) override;
+   void captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf, int hnd) override;
 };
 
 }

--- a/lib/gl/renderer_ff.cpp
+++ b/lib/gl/renderer_ff.cpp
@@ -326,7 +326,8 @@ void FFGLDevice::drawDeviceBuffer(const TextBuffer& buf)
    glPopMatrix();
 }
 
-void FFGLDevice::captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf, int hnd)
+void FFGLDevice::captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf,
+                                  int hnd)
 {
    if (hnd == 0) { return; }
    if (disp_lists[hnd].count == 0) { return; }

--- a/lib/gl/renderer_ff.cpp
+++ b/lib/gl/renderer_ff.cpp
@@ -326,7 +326,7 @@ void FFGLDevice::drawDeviceBuffer(const TextBuffer& buf)
    glPopMatrix();
 }
 
-void FFGLDevice::captureXfbBuffer(CaptureBuffer& cbuf, int hnd)
+void FFGLDevice::captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf, int hnd)
 {
    if (hnd == 0) { return; }
    if (disp_lists[hnd].count == 0) { return; }
@@ -401,8 +401,8 @@ void FFGLDevice::captureXfbBuffer(CaptureBuffer& cbuf, int hnd)
             if (fbStride == 11)
             {
                // get texture
-               GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
-               GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
             }
             cbuf.lines.emplace_back(coord0, color0);
             cbuf.lines.emplace_back(coord1, color1);
@@ -421,8 +421,8 @@ void FFGLDevice::captureXfbBuffer(CaptureBuffer& cbuf, int hnd)
             if (fbStride == 11)
             {
                // get texture
-               GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
-               GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
             }
             // decompose polygon into n-2 triangles [0 1 2] [0 2 3] ...
             for (int i = 0; i < n-2; i++)
@@ -433,7 +433,7 @@ void FFGLDevice::captureXfbBuffer(CaptureBuffer& cbuf, int hnd)
                glm::vec4 color2 = glm::make_vec4(&xfb_buf[tok_idx + 3 + vtxStart]);
                if (fbStride == 11)
                {
-                  GetColorFromVal(xfb_buf[tok_idx + 7 + vtxStart], glm::value_ptr(color2));
+                  pal.GetColorFromVal(xfb_buf[tok_idx + 7 + vtxStart], glm::value_ptr(color2));
                }
                cbuf.triangles.emplace_back(coord0, color0);
                cbuf.triangles.emplace_back(coord1, color1);

--- a/lib/gl/renderer_ff.hpp
+++ b/lib/gl/renderer_ff.hpp
@@ -57,7 +57,7 @@ public:
    void bufferToDevice(TextBuffer& t_buf) override;
    void drawDeviceBuffer(int hnd) override;
    void drawDeviceBuffer(const TextBuffer& t_buf) override;
-   void captureXfbBuffer(CaptureBuffer& cbuf, int hnd) override;
+   void captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf, int hnd) override;
 };
 
 }

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -38,6 +38,76 @@ using namespace std;
 namespace gl3
 {
 
+namespace resource
+{
+// RAII scope guard for OpenGL handles.
+template<void(*GLFinalizer)(GLuint)>
+class Handle
+{
+   GLuint hnd;
+public:
+   Handle() : hnd{0} {}
+   Handle(GLuint h) : hnd{h} {}
+   ~Handle() { if (hnd) { GLFinalizer(hnd); } }
+   Handle(Handle&& other)
+      : hnd{other.hnd} { other.hnd = 0; }
+   Handle& operator = (Handle&& other) noexcept
+   {
+      if (this != &other)
+      {
+         hnd = other.hnd;
+         other.hnd = 0;
+      }
+      return *this;
+   }
+   operator GLuint() const { return hnd; }
+};
+
+static void boCleanup(GLuint vbo_hnd)
+{
+   glDeleteBuffers(1, &vbo_hnd);
+}
+
+static void dspListCleanup(GLuint dlist)
+{
+   glDeleteLists(dlist, 1);
+}
+
+static void prgmCleanup(GLuint prgm)
+{
+   glDeleteProgram(prgm);
+}
+
+static void vaoCleanup(GLuint vao)
+{
+   glDeleteVertexArrays(1, &vao);
+}
+
+static void texCleanup(GLuint tex)
+{
+   glDeleteTextures(1, &tex);
+}
+
+static void fboCleanup(GLuint fbo)
+{
+   glDeleteFramebuffers(1, &fbo);
+}
+
+static void rboCleanup(GLuint rbo)
+{
+   glDeleteRenderbuffers(1, &rbo);
+}
+
+using BufObjHandle = Handle<boCleanup>;
+using DispListHandle = Handle<dspListCleanup>;
+using VtxArrayHandle = Handle<vaoCleanup>;
+using ShaderPrgmHandle = Handle<prgmCleanup>;
+using TextureHandle = Handle<texCleanup>;
+using FBOHandle = Handle<fboCleanup>;
+using RenderBufHandle = Handle<rboCleanup>;
+
+} // end namespace resource
+
 struct GlMatrix
 {
    glm::mat4 mtx;

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -197,10 +197,10 @@ struct alignas(16) Vertex
    std::array<float, 3> coord;
 
    static Vertex create(double * d)
-   {
-      return Vertex {(float) d[0], (float) d[1], (float) d[2]};
-   }
-   static const int layout = LAYOUT_VTX;
+{
+   return Vertex {(float) d[0], (float) d[1], (float) d[2]};
+}
+static const int layout = LAYOUT_VTX;
 };
 
 struct alignas(16) VertexColor

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -197,10 +197,10 @@ struct alignas(16) Vertex
    std::array<float, 3> coord;
 
    static Vertex create(double * d)
-{
-   return Vertex {(float) d[0], (float) d[1], (float) d[2]};
-}
-static const int layout = LAYOUT_VTX;
+   {
+      return Vertex {(float) d[0], (float) d[1], (float) d[2]};
+   }
+   static const int layout = LAYOUT_VTX;
 };
 
 struct alignas(16) VertexColor

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -73,10 +73,10 @@ glm::mat4 Camera::RotMatrix()
    double mat[16] =
    {
       -left[0], up[0], -dir[0], 0.0,
-         -left[1], up[1], -dir[1], 0.0,
-         -left[2], up[2], -dir[2], 0.0,
-         0.0, 0.0, 0.0, 1.0
-      };
+      -left[1], up[1], -dir[1], 0.0,
+      -left[2], up[2], -dir[2], 0.0,
+      0.0, 0.0, 0.0, 1.0
+   };
    return glm::make_mat4(mat);
 }
 
@@ -86,10 +86,10 @@ glm::mat4 Camera::TransposeRotMatrix()
    double mat_t[16] =
    {
       -left[0], -left[1], -left[2], 0.0,
-         up[0],    up[1],    up[2],   0.0,
-         -dir[0],  -dir[1],  -dir[2],  0.0,
-         0.0, 0.0, 0.0, 1.0
-      };
+      up[0],    up[1],    up[2],   0.0,
+      -dir[0],  -dir[1],  -dir[2],  0.0,
+      0.0, 0.0, 0.0, 1.0
+   };
    return glm::make_mat4(mat_t);
 }
 

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -125,6 +125,8 @@ VisualizationScene::VisualizationScene()
    _use_cust_l0_pos = false;
    light_mat_idx = 3;
    use_light = true;
+
+   palette.Init();
 }
 
 VisualizationScene::~VisualizationScene() {}

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -14,6 +14,8 @@
 #include "material.hpp"
 #include "aux_vis.hpp"
 
+using namespace mfem;
+
 const int NUM_MATERIALS = 5;
 extern Material materials[5];
 extern Light lights[];
@@ -130,6 +132,178 @@ VisualizationScene::VisualizationScene()
 }
 
 VisualizationScene::~VisualizationScene() {}
+
+void VisualizationScene
+     ::DrawTriangle(gl3::GlDrawable& buff,
+                    const double (&pts)[4][3], const double (&cv)[4],
+                    const double minv, const double maxv)
+{
+   double nor[3];
+   if (Compute3DUnitNormal(pts[0], pts[1], pts[2], nor))
+   {
+      return;
+   }
+
+   std::array<float, 2> texcoord[3];
+   std::array<float, 3> fpts[3];
+   std::array<float, 3> fnorm = {(float) nor[0], (float) nor[1], (float) nor[2]};
+
+   for (int i = 0; i < 3; i++)
+   {
+      float pal_coord = palette.GetColorCoord(cv[i], minv, maxv);
+      texcoord[i] = { pal_coord, 1.0 };
+      fpts[i] = {(float) pts[i][0], (float) pts[i][1], (float) pts[i][2]};
+   }
+   buff.addTriangle<gl3::VertexNormTex>(
+   {fpts[0], fnorm, texcoord[0]},
+   {fpts[1], fnorm, texcoord[1]},
+   {fpts[2], fnorm, texcoord[2]});
+}
+
+void VisualizationScene
+     ::DrawQuad(gl3::GlDrawable& buff,
+                const double (&pts)[4][3], const double (&cv)[4],
+                const double minv, const double maxv)
+{
+   double nor[3];
+   if (Compute3DUnitNormal(pts[0], pts[1], pts[2], nor))
+   {
+      return;
+   }
+
+   std::array<float, 2> texcoord[4];
+   std::array<float, 3> fpts[4];
+   std::array<float, 3> fnorm = {(float) nor[0], (float) nor[1], (float) nor[2]};
+
+   for (int i = 0; i < 4; i++)
+   {
+      float pal_coord = palette.GetColorCoord(cv[i], minv, maxv);
+      texcoord[i] = { pal_coord, 1.0 };
+      fpts[i] = {(float) pts[i][0], (float) pts[i][1], (float) pts[i][2]};
+   }
+   buff.addQuad<gl3::VertexNormTex>(
+   {fpts[0], fnorm, texcoord[0]},
+   {fpts[1], fnorm, texcoord[1]},
+   {fpts[2], fnorm, texcoord[2]},
+   {fpts[3], fnorm, texcoord[3]});
+}
+
+void VisualizationScene
+     ::DrawPatch(gl3::GlDrawable& drawable, const DenseMatrix &pts, Vector &vals,
+                 DenseMatrix &normals,
+                 const int n, const Array<int> &ind, const double minv,
+                 const double maxv, const int normals_opt)
+{
+   gl3::GlBuilder poly = drawable.createBuilder();
+   double na[3];
+
+   if (normals_opt == 1 || normals_opt == -2)
+   {
+      normals.SetSize(3, pts.Width());
+      normals = 0.;
+      for (int i = 0; i < ind.Size(); i += n)
+      {
+         int j;
+         if (n == 3)
+            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
+                                    &pts(0, ind[i+2]), na);
+         else
+            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
+                                    &pts(0, ind[i+2]), &pts(0, ind[i+3]), na);
+         if (j == 0)
+            for ( ; j < n; j++)
+               for (int k = 0; k < 3; k++)
+               {
+                  normals(k, ind[i+j]) += na[k];
+               }
+      }
+   }
+
+   if (normals_opt != 0 && normals_opt != -1)
+   {
+      std::vector<gl3::VertexNormTex> vertices;
+      std::vector<int> indices;
+      vertices.reserve(pts.Size());
+      indices.reserve(ind.Size());
+      for (int i = 0; i < pts.Width(); i++)
+      {
+         vertices.emplace_back(
+            gl3::VertexNormTex
+         {
+            {(float) pts(0, i), (float) pts(1, i), (float) pts(2, i)},
+            {(float) normals(0, i), (float) normals(1, i), (float) normals(2, i)},
+            {(float) palette.GetColorCoord(vals(i), minv, maxv), 1.0 }
+         });
+      }
+      if (normals_opt > 0)
+      {
+         for (int i = 0; i < ind.Size(); i++)
+         {
+            indices.emplace_back(ind[i]);
+         }
+      }
+      else
+      {
+         for (int i = ind.Size()-1; i >= 0; i--)
+         {
+            indices.emplace_back(ind[i]);
+         }
+      }
+      if (n == 3)
+      {
+         drawable.addTriangleIndexed(vertices, indices);
+      }
+      else
+      {
+         drawable.addQuadIndexed(vertices, indices);
+      }
+   }
+   else
+   {
+      if (n == 3)
+      {
+         poly.glBegin(GL_TRIANGLES);
+      }
+      else
+      {
+         poly.glBegin(GL_QUADS);
+      }
+      for (int i = 0; i < ind.Size(); i += n)
+      {
+         int j;
+         if (n == 3)
+            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
+                                    &pts(0, ind[i+2]), na);
+         else
+            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
+                                    &pts(0, ind[i+2]), &pts(0, ind[i+3]), na);
+         if (j == 0)
+         {
+            if (normals_opt == 0)
+            {
+               poly.glNormal3dv(na);
+               for ( ; j < n; j++)
+               {
+                  MySetColor(poly, vals(ind[i+j]), minv, maxv);
+                  poly.glVertex3dv(&pts(0, ind[i+j]));
+               }
+            }
+            else
+            {
+               poly.glNormal3d(-na[0], -na[1], -na[2]);
+               for (j = n-1; j >= 0; j--)
+               {
+                  MySetColor(poly, vals(ind[i+j]), minv, maxv);
+                  poly.glVertex3dv(&pts(0, ind[i+j]));
+               }
+            }
+         }
+      }
+      poly.glEnd();
+   }
+}
+
+
 
 gl3::RenderParams VisualizationScene::GetMeshDrawParams()
 {

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -73,10 +73,10 @@ glm::mat4 Camera::RotMatrix()
    double mat[16] =
    {
       -left[0], up[0], -dir[0], 0.0,
-      -left[1], up[1], -dir[1], 0.0,
-      -left[2], up[2], -dir[2], 0.0,
-      0.0, 0.0, 0.0, 1.0
-   };
+         -left[1], up[1], -dir[1], 0.0,
+         -left[2], up[2], -dir[2], 0.0,
+         0.0, 0.0, 0.0, 1.0
+      };
    return glm::make_mat4(mat);
 }
 
@@ -86,10 +86,10 @@ glm::mat4 Camera::TransposeRotMatrix()
    double mat_t[16] =
    {
       -left[0], -left[1], -left[2], 0.0,
-      up[0],    up[1],    up[2],   0.0,
-      -dir[0],  -dir[1],  -dir[2],  0.0,
-      0.0, 0.0, 0.0, 1.0
-   };
+         up[0],    up[1],    up[2],   0.0,
+         -dir[0],  -dir[1],  -dir[2],  0.0,
+         0.0, 0.0, 0.0, 1.0
+      };
    return glm::make_mat4(mat_t);
 }
 
@@ -134,9 +134,9 @@ VisualizationScene::VisualizationScene()
 VisualizationScene::~VisualizationScene() {}
 
 void VisualizationScene
-     ::DrawTriangle(gl3::GlDrawable& buff,
-                    const double (&pts)[4][3], const double (&cv)[4],
-                    const double minv, const double maxv)
+::DrawTriangle(gl3::GlDrawable& buff,
+               const double (&pts)[4][3], const double (&cv)[4],
+               const double minv, const double maxv)
 {
    double nor[3];
    if (Compute3DUnitNormal(pts[0], pts[1], pts[2], nor))
@@ -161,9 +161,9 @@ void VisualizationScene
 }
 
 void VisualizationScene
-     ::DrawQuad(gl3::GlDrawable& buff,
-                const double (&pts)[4][3], const double (&cv)[4],
-                const double minv, const double maxv)
+::DrawQuad(gl3::GlDrawable& buff,
+           const double (&pts)[4][3], const double (&cv)[4],
+           const double minv, const double maxv)
 {
    double nor[3];
    if (Compute3DUnitNormal(pts[0], pts[1], pts[2], nor))
@@ -189,10 +189,10 @@ void VisualizationScene
 }
 
 void VisualizationScene
-     ::DrawPatch(gl3::GlDrawable& drawable, const DenseMatrix &pts, Vector &vals,
-                 DenseMatrix &normals,
-                 const int n, const Array<int> &ind, const double minv,
-                 const double maxv, const int normals_opt)
+::DrawPatch(gl3::GlDrawable& drawable, const DenseMatrix &pts, Vector &vals,
+            DenseMatrix &normals,
+            const int n, const Array<int> &ind, const double minv,
+            const double maxv, const int normals_opt)
 {
    gl3::GlBuilder poly = drawable.createBuilder();
    double na[3];

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -17,56 +17,9 @@
 #include "gl/types.hpp"
 #include "material.hpp"
 #include "palettes.hpp"
+#include "geom_utils.hpp"
 
 // Visualization header file
-
-// Some inline functions
-
-inline void LinearCombination(const double a, const double x[],
-                              const double b, const double y[], double z[])
-{
-   z[0] = a*x[0] + b*y[0];
-   z[1] = a*x[1] + b*y[1];
-   z[2] = a*x[2] + b*y[2];
-}
-
-inline double InnerProd(const double a[], const double b[])
-{
-   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-}
-
-inline void CrossProd(const double a[], const double b[], double cp[])
-{
-   cp[0] = a[1] * b[2] - a[2] * b[1];
-   cp[1] = a[2] * b[0] - a[0] * b[2];
-   cp[2] = a[0] * b[1] - a[1] * b[0];
-}
-
-inline int Normalize(double v[])
-{
-   double len = sqrt(InnerProd(v, v));
-   if (len > 0.0)
-   {
-      len = 1.0 / len;
-   }
-   else
-   {
-      return 1;
-   }
-   for (int i = 0; i < 3; i++)
-   {
-      v[i] *= len;
-   }
-   return 0;
-}
-
-inline int ProjectVector(double v[], const double n[])
-{
-   // project 'v' on the plane with normal given by 'n' and  then normalize 'v'
-   LinearCombination(InnerProd(n, n), v, -InnerProd(v, n), n, v);
-   return Normalize(v);
-}
-
 
 class Camera
 {

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -16,6 +16,7 @@
 #include "sdl.hpp"
 #include "gl/types.hpp"
 #include "material.hpp"
+#include "palettes.hpp"
 
 // Visualization header file
 
@@ -132,6 +133,8 @@ protected:
    int light_mat_idx;
    bool use_light;
 
+   PaletteState palette;
+
    gl3::RenderParams GetMeshDrawParams();
    glm::mat4 GetModelViewMtx();
 
@@ -163,6 +166,9 @@ public:
    glm::mat4 rotmat;
    glm::mat4 translmat;
 
+   float matAlpha = 1.0;
+   float matAlphaCenter = 0.5;
+
    virtual gl3::SceneInfo GetSceneObjs() = 0;
 
    void SetView(double theta, double phi);
@@ -185,6 +191,10 @@ public:
 
    void SetLight0CustomPos(std::array<float, 4> pos);
    void ToggleBackground();
+
+   PaletteState& GetPalette() { return palette; }
+   void GenerateAlphaTexture()
+   { palette.GenerateAlphaTexture(matAlpha, matAlphaCenter); }
 
    /// This is set by SetVisualizationScene
    int view;

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -87,7 +87,6 @@ protected:
    int light_mat_idx;
    bool use_light;
 
-   PaletteState palette;
 
    gl3::RenderParams GetMeshDrawParams();
    glm::mat4 GetModelViewMtx();
@@ -140,6 +139,7 @@ public:
    double ViewCenterX, ViewCenterY;
 
    Camera cam;
+   PaletteState palette;
 
    /// Bounding box.
    double x[2], y[2], z[2];
@@ -173,7 +173,6 @@ public:
    void SetLight0CustomPos(std::array<float, 4> pos);
    void ToggleBackground();
 
-   PaletteState& GetPalette() { return palette; }
    void GenerateAlphaTexture()
    { palette.GenerateAlphaTexture(matAlpha, matAlphaCenter); }
 

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -17,6 +17,7 @@
 #include "gl/types.hpp"
 #include "material.hpp"
 #include "palettes.hpp"
+#include "mfem.hpp"
 #include "geom_utils.hpp"
 
 // Visualization header file
@@ -102,6 +103,33 @@ protected:
          return { 0.f, 0.f, 0.f, 1.f };
       }
    }
+
+   void MySetColor (gl3::GlBuilder& builder, double val, double min, double max)
+   {
+      MySetColor(builder, palette.GetColorCoord(val, min, max));
+   }
+
+   void MySetColor (gl3::GlBuilder& builder, double val)
+   {
+      if (val < 0.0) { val = 0.0; }
+      if (val > 1.0) { val = 1.0; }
+
+      builder.glTexCoord2f(val, 1.0);
+   }
+
+   // We only need 3 points, but the array is 4x3
+   void DrawTriangle(gl3::GlDrawable& buff,
+                     const double (&pts)[4][3], const double (&cv)[4],
+                     const double minv, const double maxv);
+
+   void DrawQuad(gl3::GlDrawable& buff,
+                 const double (&pts)[4][3], const double (&cv)[4],
+                 const double minv, const double maxv);
+
+   void DrawPatch(gl3::GlDrawable& buff, const mfem::DenseMatrix &pts,
+                  mfem::Vector &vals, mfem::DenseMatrix &normals,
+                  const int n, const mfem::Array<int> &ind, const double minv,
+                  const double maxv, const int normals_opt = 0);
 
 public:
    VisualizationScene();

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -7756,6 +7756,30 @@ void PaletteState::Init()
    }
 }
 
+
+
+double PaletteState::GetColorCoord(double val, double min, double max)
+{
+   // static double eps = 1e-24;
+   static const double eps = 0.0;
+   if (use_logscale)
+   {
+      if (val < min)
+      {
+         val = min;
+      }
+      if (val > max)
+      {
+         val = max;
+      }
+      return log(fabs(val/(min+eps))) / (log(fabs(max/(min+eps)))+eps);
+   }
+   else
+   {
+      return ((val-min)/(max-min));
+   }
+}
+
 const double * PaletteState::GetData() const
 {
    return RGB_Palettes[curr_palette];

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -7780,6 +7780,31 @@ double PaletteState::GetColorCoord(double val, double min, double max)
    }
 }
 
+void PaletteState::GetColorFromVal(double val, float * rgba)
+{
+   int palSize = RGB_Palettes_Sizes[curr_palette];
+   const double* palData = RGB_Palettes[curr_palette];
+   val *= 0.999999999 * ( palSize - 1 ) * abs(RepeatPaletteTimes);
+   int i = (int) floor( val );
+   double t = val - i;
+
+   const double* pal;
+   if (((i / (palSize-1)) % 2 == 0 && RepeatPaletteTimes > 0) ||
+       ((i / (palSize-1)) % 2 == 1 && RepeatPaletteTimes < 0))
+   {
+      pal = palData + 3 * ( i % (palSize-1) );
+   }
+   else
+   {
+      pal = palData + 3 * ( (palSize-2) - i % (palSize-1) );
+      t = 1.0 - t;
+   }
+   rgba[0] = (1.0 - t) * pal[0] + t * pal[3];
+   rgba[1] = (1.0 - t) * pal[1] + t * pal[4];
+   rgba[2] = (1.0 - t) * pal[2] + t * pal[5];
+   rgba[3] = 1.f;
+}
+
 const double * PaletteState::GetData() const
 {
    return RGB_Palettes[curr_palette];

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -7853,14 +7853,14 @@ void PaletteState::GenerateAlphaTexture(float matAlpha, float matAlphaCenter)
    glActiveTexture(GL_TEXTURE0);
 }
 
-void PaletteState::NextPalette()
+void PaletteState::NextIndex()
 {
-   SetPalette((curr_palette + 1) % Num_RGB_Palettes);
+   SetIndex((curr_palette + 1) % Num_RGB_Palettes);
 }
 
-void PaletteState::PrevPalette()
+void PaletteState::PrevIndex()
 {
-   SetPalette((curr_palette == 0) ? Num_RGB_Palettes - 1 :
+   SetIndex((curr_palette == 0) ? Num_RGB_Palettes - 1 :
               curr_palette - 1);
 }
 
@@ -7868,7 +7868,7 @@ int PaletteState::SelectNewRGBPalette()
 {
    int pal = ChoosePalette();
 
-   SetPalette(pal);
+   SetIndex(pal);
 
    return pal;
 }

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -7397,110 +7397,109 @@ void Init_Visit_Calewhite_Palette()
 
 void Init_Palettes()
 {
-   // init rainbow palette
-   for (int i = 0; i < RGB_Palette_23_Size; i++)
+   static bool first_init = true;
+   if (first_init)
    {
-      double t = double(i) / (RGB_Palette_23_Size-1), s, r, g, b;
-      // t *= 3.0; // red to red
-      t *= 2.5; // red to purple
-      if (t < 1.0)
+      // init rainbow palette
+      for (int i = 0; i < RGB_Palette_23_Size; i++)
       {
-         s = sin(t * M_PI);
-         if (t < 0.5)
+         double t = double(i) / (RGB_Palette_23_Size-1), s, r, g, b;
+         // t *= 3.0; // red to red
+         t *= 2.5; // red to purple
+         if (t < 1.0)
          {
-            r = 1.0;
-            g = s;
+            s = sin(t * M_PI);
+            if (t < 0.5)
+            {
+               r = 1.0;
+               g = s;
+            }
+            else
+            {
+               r = s;
+               g = 1.0;
+            }
+            b = 0.0;
+         }
+         else if (t < 2.0)
+         {
+            s = sin((t - 1.0) * M_PI);
+            if (t < 1.5)
+            {
+               g = 1.0;
+               b = s;
+            }
+            else
+            {
+               g = s;
+               b = 1.0;
+            }
+            r = 0.0;
          }
          else
          {
-            r = s;
-            g = 1.0;
+            s = sin((t - 2.0) * M_PI);
+            if (t < 2.5)
+            {
+               r = s;
+               b = 1.0;
+            }
+            else
+            {
+               r = 1.0;
+               b = s;
+            }
+            g = 0.0;
          }
-         b = 0.0;
+         RGB_Palette_23[i][0] = r;
+         RGB_Palette_23[i][1] = g;
+         RGB_Palette_23[i][2] = b;
       }
-      else if (t < 2.0)
+
+      // init vivid palette
+      const int ns = 7;
+      const double ts[ns] = { 0., 3./16., 4./16., 1./2., 12./16., 13./16., 1. };
+
+      const double rs[ns] = { 0.0, 0.0, 0.0, 1.0, 0.9, 1.0, 0.5 };
+      const double gs[ns] = { 0.0, 1.0, 0.9, 1.0, 0.0, 0.0, 0.0 };
+      const double bs[ns] = { 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
+      const double rc[ns-1] = { 1.0, 1.0, 1.3, 1.0, 1.0, 1.2 };
+      const double gc[ns-1] = { 1.2, 1.0, 1.0, 1.4, 1.0, 1.0 };
+      const double bc[ns-1] = { 1.0, 1.0, 1.0, 1.0, 1.6, 1.0 };
+
+      for (int i = 0; i < RGB_Palette_13_Size; i++)
       {
-         s = sin((t - 1.0) * M_PI);
-         if (t < 1.5)
-         {
-            g = 1.0;
-            b = s;
-         }
-         else
-         {
-            g = s;
-            b = 1.0;
-         }
-         r = 0.0;
+         double t = double(i) / (RGB_Palette_13_Size-1), r, g, b;
+         int k;
+         for (k = 1; k < ns; k++)
+            if (t >= ts[k-1] && t <= ts[k])
+            {
+               break;
+            }
+         t = (t - ts[k-1]) / (ts[k] - ts[k-1]);
+         r = (1.0 - t) * corr(rc[k-1], rs[k-1]) + t * corr(rc[k-1], rs[k]);
+         g = (1.0 - t) * corr(gc[k-1], gs[k-1]) + t * corr(gc[k-1], gs[k]);
+         b = (1.0 - t) * corr(bc[k-1], bs[k-1]) + t * corr(bc[k-1], bs[k]);
+         RGB_Palette_13[i][0] = corr(1./rc[k-1], r);
+         RGB_Palette_13[i][1] = corr(1./gc[k-1], g);
+         RGB_Palette_13[i][2] = corr(1./bc[k-1], b);
       }
-      else
+
+      Init_Visit_Calewhite_Palette();
+
+      // init gray palette
+      for (int i = 0; i < RGB_Palette_36_Size; i++)
       {
-         s = sin((t - 2.0) * M_PI);
-         if (t < 2.5)
-         {
-            r = s;
-            b = 1.0;
-         }
-         else
-         {
-            r = 1.0;
-            b = s;
-         }
-         g = 0.0;
+         double t = double(i) / (RGB_Palette_36_Size-1);
+         RGB_Palette_36[i][0] = t;
+         RGB_Palette_36[i][1] = t;
+         RGB_Palette_36[i][2] = t;
       }
-      RGB_Palette_23[i][0] = r;
-      RGB_Palette_23[i][1] = g;
-      RGB_Palette_23[i][2] = b;
-   }
-
-   // init vivid palette
-   const int ns = 7;
-   const double ts[ns] = { 0., 3./16., 4./16., 1./2., 12./16., 13./16., 1. };
-
-   const double rs[ns] = { 0.0, 0.0, 0.0, 1.0, 0.9, 1.0, 0.5 };
-   const double gs[ns] = { 0.0, 1.0, 0.9, 1.0, 0.0, 0.0, 0.0 };
-   const double bs[ns] = { 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0 };
-   const double rc[ns-1] = { 1.0, 1.0, 1.3, 1.0, 1.0, 1.2 };
-   const double gc[ns-1] = { 1.2, 1.0, 1.0, 1.4, 1.0, 1.0 };
-   const double bc[ns-1] = { 1.0, 1.0, 1.0, 1.0, 1.6, 1.0 };
-
-   for (int i = 0; i < RGB_Palette_13_Size; i++)
-   {
-      double t = double(i) / (RGB_Palette_13_Size-1), r, g, b;
-      int k;
-      for (k = 1; k < ns; k++)
-         if (t >= ts[k-1] && t <= ts[k])
-         {
-            break;
-         }
-      t = (t - ts[k-1]) / (ts[k] - ts[k-1]);
-      r = (1.0 - t) * corr(rc[k-1], rs[k-1]) + t * corr(rc[k-1], rs[k]);
-      g = (1.0 - t) * corr(gc[k-1], gs[k-1]) + t * corr(gc[k-1], gs[k]);
-      b = (1.0 - t) * corr(bc[k-1], bs[k-1]) + t * corr(bc[k-1], bs[k]);
-      RGB_Palette_13[i][0] = corr(1./rc[k-1], r);
-      RGB_Palette_13[i][1] = corr(1./gc[k-1], g);
-      RGB_Palette_13[i][2] = corr(1./bc[k-1], b);
-   }
-
-   Init_Visit_Calewhite_Palette();
-
-   // init gray palette
-   for (int i = 0; i < RGB_Palette_36_Size; i++)
-   {
-      double t = double(i) / (RGB_Palette_36_Size-1);
-      RGB_Palette_36[i][0] = t;
-      RGB_Palette_36[i][1] = t;
-      RGB_Palette_36[i][2] = t;
+      first_init = false;
    }
 }
 
-bool first_init = true;
-GLuint palette_tex[Num_RGB_Palettes][2];
-GLuint alpha_tex;
-int curr_palette = 2;
-int use_smooth = 0;
-
-int Choose_Palette()
+int PaletteState::ChoosePalette()
 {
    const int buflen = 256;
    char buffer[buflen];
@@ -7541,14 +7540,11 @@ int Choose_Palette()
 }
 
 
-int RepeatPaletteTimes = 1;
-int MaxTextureSize;
-GLenum rgba_internal;
-
 /* *
  * Generates a discrete texture from the given palette.
  */
-void PaletteToTextureDiscrete(double * palette, size_t plt_size, GLuint tex)
+void PaletteState::ToTextureDiscrete(double * palette, size_t plt_size,
+                                     GLuint tex)
 {
    vector<array<float,4>> texture_buf(plt_size);
 
@@ -7622,7 +7618,8 @@ void PaletteToTextureDiscrete(double * palette, size_t plt_size, GLuint tex)
 /* *
  * Generates a smooth texture from the given palette.
  */
-void PaletteToTextureSmooth(double * palette, size_t plt_size, GLuint tex)
+void PaletteState::ToTextureSmooth(double * palette, size_t plt_size,
+                                   GLuint tex)
 {
    vector<array<float,4>> texture_buf(MaxTextureSize);
    glBindTexture(GL_TEXTURE_2D, tex);
@@ -7689,18 +7686,15 @@ void PaletteToTextureSmooth(double * palette, size_t plt_size, GLuint tex)
    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 }
 
-void paletteRebind()
+PaletteState::PaletteState()
+   : palette_tex(Num_RGB_Palettes)
+   , first_init(false)
 {
-   GetAppWindow()->getRenderer()
-   .setColorTexture(palette_tex[curr_palette][use_smooth]);
-   GetAppWindow()->getRenderer().setAlphaTexture(alpha_tex);
 }
 
-GLenum alpha_channel;
-
-void paletteInit()
+void PaletteState::Init()
 {
-   if (first_init)
+   if (!first_init)
    {
       glGetIntegerv(GL_MAX_TEXTURE_SIZE, &MaxTextureSize);
       if (MaxTextureSize < 4096)
@@ -7710,81 +7704,73 @@ void paletteInit()
       MaxTextureSize = std::min(MaxTextureSize, 4096);
       Init_Palettes();
 
-      glGenTextures(Num_RGB_Palettes * 2, &(palette_tex[0][0]));
-      glGenTextures(1, &alpha_tex);
-      first_init = false;
-   }
-   GLenum alpha_internal;
-   if (gl3::GLDevice::useLegacyTextureFmts())
-   {
-      alpha_internal = GL_ALPHA;
-      alpha_channel = GL_ALPHA;
-      rgba_internal = GL_RGBA;
-   }
-   else
-   {
-      // WebGL 2 requires sized internal format for float texture
-      alpha_internal = GL_R32F;
-      alpha_channel = GL_RED;
-      rgba_internal = GL_RGBA32F;
+      GLuint paletteTexIds[Num_RGB_Palettes][2];
+      GLuint alphaTexId;
+
+      glGenTextures(Num_RGB_Palettes * 2, &(paletteTexIds[0][0]));
+      glGenTextures(1, &alphaTexId);
+
+      for (int ipal = 0; ipal < Num_RGB_Palettes; ipal++)
+      {
+         palette_tex[ipal][0] = paletteTexIds[ipal][0];
+         palette_tex[ipal][1] = paletteTexIds[ipal][1];
+      }
+      alpha_tex = alphaTexId;
+
+      GLenum alpha_internal;
+      if (gl3::GLDevice::useLegacyTextureFmts())
+      {
+         alpha_internal = GL_ALPHA;
+         alpha_channel = GL_ALPHA;
+         rgba_internal = GL_RGBA;
+      }
+      else
+      {
+         // WebGL 2 requires sized internal format for float texture
+         alpha_internal = GL_R32F;
+         alpha_channel = GL_RED;
+         rgba_internal = GL_RGBA32F;
+      }
+      // set alpha texture to 1.0
+      std::vector<float> alphaTexData(MaxTextureSize * 2);
+      std::fill(alphaTexData.begin(), alphaTexData.end(), 1.0f);
+      glActiveTexture(GL_TEXTURE1);
+      glBindTexture(GL_TEXTURE_2D, alpha_tex);
+      glTexImage2D(GL_TEXTURE_2D, 0, alpha_internal, MaxTextureSize, 2, 0,
+                   alpha_channel, GL_FLOAT, alphaTexData.data());
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+      glActiveTexture(GL_TEXTURE0);
+      first_init = true;
    }
 
    for (int i = 0; i < Num_RGB_Palettes; i++)
    {
-      PaletteToTextureDiscrete(RGB_Palettes[i], RGB_Palettes_Sizes[i],
-                               palette_tex[i][0]);
-      PaletteToTextureSmooth(RGB_Palettes[i], RGB_Palettes_Sizes[i],
-                             palette_tex[i][1]);
+      ToTextureDiscrete(RGB_Palettes[i], RGB_Palettes_Sizes[i],
+                        palette_tex[i][0]);
+      ToTextureSmooth(RGB_Palettes[i], RGB_Palettes_Sizes[i],
+                      palette_tex[i][1]);
    }
-   // set alpha texture to 1.0
-   std::vector<float> alphaTexData(MaxTextureSize * 2);
-   std::fill(alphaTexData.begin(), alphaTexData.end(), 1.0f);
-   glActiveTexture(GL_TEXTURE1);
-   glBindTexture(GL_TEXTURE_2D, alpha_tex);
-   glTexImage2D(GL_TEXTURE_2D, 0, alpha_internal, MaxTextureSize, 2, 0,
-                alpha_channel, GL_FLOAT, alphaTexData.data());
-   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-   glActiveTexture(GL_TEXTURE0);
-   paletteRebind();
 }
 
-void paletteUseDiscrete()
-{
-   use_smooth = 0;
-   paletteRebind();
-}
-
-void paletteUseSmooth()
-{
-   use_smooth = 1;
-   paletteRebind();
-}
-
-void paletteSet(int num)
-{
-   curr_palette = num;
-   paletteRebind();
-}
-
-double * paletteGet()
+const double * PaletteState::GetData() const
 {
    return RGB_Palettes[curr_palette];
 }
 
-int paletteGetSize(int pal)
+int PaletteState::GetSize(int pal) const
 {
    if (pal == -1)
    {
       return RGB_Palettes_Sizes[curr_palette];
    }
-   return RGB_Palettes_Sizes[curr_palette];
+   return RGB_Palettes_Sizes[pal];
 }
 
-void GenerateAlphaTexture(float matAlpha, float matAlphaCenter)
+void PaletteState::GenerateAlphaTexture(float matAlpha, float matAlphaCenter)
 {
    std::vector<float> alphaTexData(MaxTextureSize);
    if (matAlpha >= 1.0)
@@ -7818,22 +7804,22 @@ void GenerateAlphaTexture(float matAlpha, float matAlphaCenter)
    glActiveTexture(GL_TEXTURE0);
 }
 
-void Next_RGB_Palette()
+void PaletteState::NextPalette()
 {
-   paletteSet((curr_palette + 1) % Num_RGB_Palettes);
+   SetPalette((curr_palette + 1) % Num_RGB_Palettes);
 }
 
-void Prev_RGB_Palette()
+void PaletteState::PrevPalette()
 {
-   paletteSet((curr_palette == 0) ? Num_RGB_Palettes - 1 :
+   SetPalette((curr_palette == 0) ? Num_RGB_Palettes - 1 :
               curr_palette - 1);
 }
 
-int Select_New_RGB_Palette()
+int PaletteState::SelectNewRGBPalette()
 {
-   int pal = Choose_Palette();
+   int pal = ChoosePalette();
 
-   paletteSet(pal);
+   SetPalette(pal);
 
    return pal;
 }

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -7861,7 +7861,7 @@ void PaletteState::NextIndex()
 void PaletteState::PrevIndex()
 {
    SetIndex((curr_palette == 0) ? Num_RGB_Palettes - 1 :
-              curr_palette - 1);
+            curr_palette - 1);
 }
 
 int PaletteState::SelectNewRGBPalette()

--- a/lib/palettes.hpp
+++ b/lib/palettes.hpp
@@ -49,6 +49,7 @@ public:
    void SetUseLogscale(bool logscale) { use_logscale = logscale; }
    bool GetUseLogscale() { return use_logscale; }
    double GetColorCoord(double val, double min, double max);
+   void GetColorFromVal(double val, float* rgba);
 
    GLuint GetColorTexture() const
    { return palette_tex[curr_palette][use_smooth]; }

--- a/lib/palettes.hpp
+++ b/lib/palettes.hpp
@@ -11,7 +11,7 @@
 
 #ifndef GLVIS_PALETTES_HPP
 #define GLVIS_PALETTES_HPP
-#include "gl/renderer.hpp"
+#include "gl/types.hpp"
 #include <vector>
 #include <array>
 
@@ -57,7 +57,7 @@ public:
 private:
    void ToTextureDiscrete(double * palette, size_t plt_size, GLuint tex);
    void ToTextureSmooth(double * palette, size_t plt_size, GLuint tex);
-   using TexHandle = gl3::GLDevice::TextureHandle;
+   using TexHandle = gl3::resource::TextureHandle;
 
    std::vector<std::array<TexHandle,2>> palette_tex;
    TexHandle alpha_tex;

--- a/lib/palettes.hpp
+++ b/lib/palettes.hpp
@@ -11,27 +11,62 @@
 
 #ifndef GLVIS_PALETTES_HPP
 #define GLVIS_PALETTES_HPP
+#include "gl/renderer.hpp"
+#include <vector>
+#include <array>
 
-/// Initializes the palette textures.
-void paletteInit();
-/// Binds the discrete version of the current palette texture.
-void paletteUseDiscrete();
-/// Binds the smooth version of the current palette texture.
-void paletteUseSmooth();
-/// Sets the palette texture to bind.
-void paletteSet(int num);
-/// Gets the palette color array.
-double * paletteGet();
-/// Rebind the color and alpha textures to their texture units.
-void paletteRebind();
+class PaletteState
+{
+public:
+   PaletteState();
+   /// Initializes the palette textures.
+   void Init();
+   /// Binds the discrete version of the current palette texture.
+   void UseDiscrete() { use_smooth = 0; }
+   /// Binds the smooth version of the current palette texture.
+   void UseSmooth() { use_smooth = 1; }
+   /// Gets whether the smooth texture is being used (1 = true)
+   int GetSmoothSetting() { return use_smooth; }
+   /// Sets the palette texture to bind.
+   void SetPalette(int num) { curr_palette = num; }
+   int GetPalette() const { return curr_palette; }
+   void NextPalette();
+   void PrevPalette();
+   int ChoosePalette();
+   int SelectNewRGBPalette();
+   /// Gets the data in the palette color array.
+   const double* GetData() const;
+   /// Gets the total number of colors in the current palette color array.
+   int GetSize(int pal = -1) const;
+   /// Gets the number of colors used in the current palette color array.
+   int GetNumColors(int pal = -1) const
+   { return PaletteNumColors ? PaletteNumColors : GetSize(pal); }
+   /// Sets the number of colors to use in the current palette color array.
+   void SetNumColors(int numColors) { PaletteNumColors = numColors; }
+   int GetRepeatTimes() const { return RepeatPaletteTimes; }
+   void SetRepeatTimes(int rpt) { RepeatPaletteTimes = rpt; }
 
-int paletteGetSize(int pal = -1);
+   GLuint GetColorTexture() const
+   { return palette_tex[curr_palette][use_smooth]; }
+   GLuint GetAlphaTexture() const { return alpha_tex; }
+   void GenerateAlphaTexture(float matAlpha, float matAlphaCenter);
+private:
+   void ToTextureDiscrete(double * palette, size_t plt_size, GLuint tex);
+   void ToTextureSmooth(double * palette, size_t plt_size, GLuint tex);
+   using TexHandle = gl3::GLDevice::TextureHandle;
 
-void GenerateAlphaTexture(float matAlpha, float matAlphaCenter);
+   std::vector<std::array<TexHandle,2>> palette_tex;
+   TexHandle alpha_tex;
 
-void Next_RGB_Palette();
-void Prev_RGB_Palette();
-int Choose_Palette();
-int Select_New_RGB_Palette();
+   int curr_palette = 2;
+   int use_smooth = 0;
+   int RepeatPaletteTimes = 1;
+   int PaletteNumColors = 0;
+
+   bool first_init;
+   int MaxTextureSize;
+   GLenum alpha_channel;
+   GLenum rgba_internal;
+};
 
 #endif

--- a/lib/palettes.hpp
+++ b/lib/palettes.hpp
@@ -46,6 +46,10 @@ public:
    int GetRepeatTimes() const { return RepeatPaletteTimes; }
    void SetRepeatTimes(int rpt) { RepeatPaletteTimes = rpt; }
 
+   void SetUseLogscale(bool logscale) { use_logscale = logscale; }
+   bool GetUseLogscale() { return use_logscale; }
+   double GetColorCoord(double val, double min, double max);
+
    GLuint GetColorTexture() const
    { return palette_tex[curr_palette][use_smooth]; }
    GLuint GetAlphaTexture() const { return alpha_tex; }
@@ -62,6 +66,8 @@ private:
    int use_smooth = 0;
    int RepeatPaletteTimes = 1;
    int PaletteNumColors = 0;
+
+   bool use_logscale = false;
 
    bool first_init;
    int MaxTextureSize;

--- a/lib/palettes.hpp
+++ b/lib/palettes.hpp
@@ -28,10 +28,10 @@ public:
    /// Gets whether the smooth texture is being used (1 = true)
    int GetSmoothSetting() { return use_smooth; }
    /// Sets the palette texture to bind.
-   void SetPalette(int num) { curr_palette = num; }
-   int GetPalette() const { return curr_palette; }
-   void NextPalette();
-   void PrevPalette();
+   void SetIndex(int num) { curr_palette = num; }
+   int GetCurrIndex() const { return curr_palette; }
+   void NextIndex();
+   void PrevIndex();
    int ChoosePalette();
    int SelectNewRGBPalette();
    /// Gets the data in the palette color array.

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -674,7 +674,6 @@ void SdlWindow::mainIter()
       {
          if (glvis_command->Execute() < 0)
          {
-            cout << "GlvisCommand signalled exit" << endl;
             running = false;
          }
       }
@@ -686,11 +685,7 @@ void SdlWindow::mainIter()
       if (glvis_command && visualize == 1 &&
           (status = glvis_command->Execute()) != 1)
       {
-         if (status < 0)
-         {
-            cout << "GlvisCommand signalled exit" << endl;
-            running = false;
-         }
+         if (status < 0) { running = false; }
       }
       else
       {

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -652,6 +652,7 @@ void SdlWindow::mainIter()
       {
          if (glvis_command->Execute() < 0)
          {
+            cout << "GlvisCommand signalled exit" << endl;
             running = false;
          }
       }
@@ -663,7 +664,11 @@ void SdlWindow::mainIter()
       if (glvis_command && visualize == 1 &&
           (status = glvis_command->Execute()) != 1)
       {
-         if (status < 0) { running = false; }
+         if (status < 0)
+         {
+            cout << "GlvisCommand signalled exit" << endl;
+             running = false;
+         }
       }
       else
       {

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -667,7 +667,7 @@ void SdlWindow::mainIter()
          if (status < 0)
          {
             cout << "GlvisCommand signalled exit" << endl;
-             running = false;
+            running = false;
          }
       }
       else

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -684,7 +684,7 @@ int GLVisCommand::Execute()
       case PALETTE:
       {
          cout << "Command: palette: " << palette << endl;
-         paletteSet(palette-1);
+         (*vs)->GetPalette().SetPalette(palette-1);
          if (!GetUseTexture())
          {
             (*vs)->EventUpdateColors();
@@ -696,8 +696,8 @@ int GLVisCommand::Execute()
       case PALETTE_REPEAT:
       {
          cout << "Command: palette_repeat: " << palette_repeat << endl;
-         RepeatPaletteTimes = palette_repeat;
-         paletteInit();
+         (*vs)->GetPalette().SetRepeatTimes(palette_repeat);
+         (*vs)->GetPalette().Init();
 
          if (!GetUseTexture())
          {

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -684,7 +684,7 @@ int GLVisCommand::Execute()
       case PALETTE:
       {
          cout << "Command: palette: " << palette << endl;
-         (*vs)->GetPalette().SetPalette(palette-1);
+         (*vs)->palette.SetIndex(palette-1);
          if (!GetUseTexture())
          {
             (*vs)->EventUpdateColors();
@@ -696,8 +696,8 @@ int GLVisCommand::Execute()
       case PALETTE_REPEAT:
       {
          cout << "Command: palette_repeat: " << palette_repeat << endl;
-         (*vs)->GetPalette().SetRepeatTimes(palette_repeat);
-         (*vs)->GetPalette().Init();
+         (*vs)->palette.SetRepeatTimes(palette_repeat);
+         (*vs)->palette.Init();
 
          if (!GetUseTexture())
          {

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -559,14 +559,14 @@ void KeypPressed(GLenum state)
    }
    else
    {
-      Next_RGB_Palette();
+      locscene->GetPalette().NextPalette();
       SendExposeEvent();
    }
 }
 
 void KeyPPressed()
 {
-   Prev_RGB_Palette();
+   locscene->GetPalette().PrevPalette();
    SendExposeEvent();
 }
 
@@ -590,6 +590,7 @@ static void KeyF5Pressed()
 
 void KeyF6Pressed()
 {
+   int RepeatPaletteTimes = vsdata->GetPalette().GetRepeatTimes();
    cout << "Palette is repeated " << RepeatPaletteTimes << " times.\n"
         << "(Negative value means the palette is flipped.)\n"
         << "Enter new value: " << flush;
@@ -600,23 +601,24 @@ void KeyF6Pressed()
    }
    cout << "Palette will be repeated " << RepeatPaletteTimes
         << " times now.\n\n";
+   vsdata->GetPalette().SetRepeatTimes(RepeatPaletteTimes);
 
-   int pal = Choose_Palette();
+   int pal = vsdata->GetPalette().ChoosePalette();
 
-   int colors_used = PaletteNumColors ?  PaletteNumColors : paletteGetSize(pal);
+   int colors_used = vsdata->GetPalette().GetNumColors(pal);
+   int palette_size = vsdata->GetPalette().GetSize(pal);
    cout << "\nPalette is using " << colors_used << " colors.\n"
-        << "Enter new value (0 = use original " << paletteGetSize(pal)
+        << "Enter new value (0 = use original " << palette_size
         << " colors): " << flush;
-   cin >> PaletteNumColors;
-   if (PaletteNumColors == 1)
-   {
-      PaletteNumColors = 0;
-   }
-   colors_used = PaletteNumColors ?  PaletteNumColors : paletteGetSize();
-   cout << "Palette will be using " << colors_used << " colors now.\n";
+   cin >> colors_used;
+   if (colors_used == 1) { colors_used = 0; }
+   vsdata->GetPalette().SetNumColors(colors_used);
 
-   paletteInit();
-   paletteSet(pal);
+   vsdata->GetPalette().Init();
+   vsdata->GetPalette().SetPalette(pal);
+
+   colors_used = vsdata->GetPalette().GetNumColors();
+   cout << "Palette will be using " << colors_used << " colors now.\n";
 
    vsdata->EventUpdateColors();
    SendExposeEvent();
@@ -718,23 +720,23 @@ void KeyF2Pressed()
 
 void KeykPressed()
 {
-   MatAlpha -= 0.05;
-   if (MatAlpha < 0.0)
+   locscene->matAlpha -= 0.05;
+   if (locscene->matAlpha < 0.0)
    {
-      MatAlpha = 0.0;
+      locscene->matAlpha = 0.0;
    }
-   GenerateAlphaTexture(MatAlpha, MatAlphaCenter);
+   locscene->GenerateAlphaTexture();
    SendExposeEvent();
 }
 
 void KeyKPressed()
 {
-   MatAlpha += 0.05;
-   if (MatAlpha > 1.0)
+   locscene->matAlpha += 0.05;
+   if (locscene->matAlpha > 1.0)
    {
-      MatAlpha = 1.0;
+      locscene->matAlpha = 1.0;
    }
-   GenerateAlphaTexture(MatAlpha, MatAlphaCenter);
+   locscene->GenerateAlphaTexture();
    SendExposeEvent();
 }
 
@@ -752,23 +754,23 @@ void KeyAPressed()
 
 void KeyCommaPressed()
 {
-   MatAlphaCenter -= 0.25;
+   locscene->matAlphaCenter -= 0.25;
    //vsdata -> EventUpdateColors();
-   GenerateAlphaTexture(MatAlpha, MatAlphaCenter);
+   locscene->GenerateAlphaTexture();
    SendExposeEvent();
 #ifdef GLVIS_DEBUG
-   cout << "MatAlphaCenter = " << MatAlphaCenter << endl;
+   cout << "MatAlphaCenter = " << locscene->matAlphaCenter << endl;
 #endif
 }
 
 void KeyLessPressed()
 {
-   MatAlphaCenter += 0.25;
+   locscene->matAlphaCenter += 0.25;
    //vsdata -> EventUpdateColors();
-   GenerateAlphaTexture(MatAlpha, MatAlphaCenter);
+   locscene->GenerateAlphaTexture();
    SendExposeEvent();
 #ifdef GLVIS_DEBUG
-   cout << "MatAlphaCenter = " << MatAlphaCenter << endl;
+   cout << "MatAlphaCenter = " << locscene->matAlphaCenter << endl;
 #endif
 }
 
@@ -1045,10 +1047,17 @@ gl3::SceneInfo VisualizationSceneScalarData::GetSceneObjs()
 
 void VisualizationSceneScalarData::ToggleTexture()
 {
-   SetUseTexture((GetUseTexture()+1)%2);
-
-   static const char *texture_type[2] = {"discrete", "smooth"};
-   cout << "Texture type : " << texture_type[GetUseTexture()] << endl;
+   int isSmooth = palette.GetSmoothSetting();
+   if (isSmooth)
+   {
+      palette.UseDiscrete();
+      cout << "Texture type : discrete" << endl;
+   }
+   else
+   {
+      palette.UseSmooth();
+      cout << "Texture type : smooth" << endl;
+   }
 }
 
 void VisualizationSceneScalarData::SetAutoscale(int _autoscale)

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -559,14 +559,14 @@ void KeypPressed(GLenum state)
    }
    else
    {
-      locscene->GetPalette().NextPalette();
+      locscene->palette.NextIndex();
       SendExposeEvent();
    }
 }
 
 void KeyPPressed()
 {
-   locscene->GetPalette().PrevPalette();
+   locscene->palette.PrevIndex();
    SendExposeEvent();
 }
 
@@ -590,7 +590,7 @@ static void KeyF5Pressed()
 
 void KeyF6Pressed()
 {
-   int RepeatPaletteTimes = vsdata->GetPalette().GetRepeatTimes();
+   int RepeatPaletteTimes = vsdata->palette.GetRepeatTimes();
    cout << "Palette is repeated " << RepeatPaletteTimes << " times.\n"
         << "(Negative value means the palette is flipped.)\n"
         << "Enter new value: " << flush;
@@ -601,23 +601,23 @@ void KeyF6Pressed()
    }
    cout << "Palette will be repeated " << RepeatPaletteTimes
         << " times now.\n\n";
-   vsdata->GetPalette().SetRepeatTimes(RepeatPaletteTimes);
+   vsdata->palette.SetRepeatTimes(RepeatPaletteTimes);
 
-   int pal = vsdata->GetPalette().ChoosePalette();
+   int pal = vsdata->palette.ChoosePalette();
 
-   int colors_used = vsdata->GetPalette().GetNumColors(pal);
-   int palette_size = vsdata->GetPalette().GetSize(pal);
+   int colors_used = vsdata->palette.GetNumColors(pal);
+   int palette_size = vsdata->palette.GetSize(pal);
    cout << "\nPalette is using " << colors_used << " colors.\n"
         << "Enter new value (0 = use original " << palette_size
         << " colors): " << flush;
    cin >> colors_used;
    if (colors_used == 1) { colors_used = 0; }
-   vsdata->GetPalette().SetNumColors(colors_used);
+   vsdata->palette.SetNumColors(colors_used);
 
-   vsdata->GetPalette().Init();
-   vsdata->GetPalette().SetPalette(pal);
+   vsdata->palette.Init();
+   vsdata->palette.SetIndex(pal);
 
-   colors_used = vsdata->GetPalette().GetNumColors();
+   colors_used = vsdata->palette.GetNumColors();
    cout << "Palette will be using " << colors_used << " colors now.\n";
 
    vsdata->EventUpdateColors();

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -808,7 +808,7 @@ void VisualizationSceneScalarData::ToggleLogscale(bool print)
    if (logscale || LogscaleRange())
    {
       logscale = !logscale;
-      MySetColorLogscale = logscale;
+      palette.SetUseLogscale(logscale);
       SetLogA();
       SetLevelLines(minv, maxv, nl);
       UpdateLevelLines();
@@ -1092,7 +1092,6 @@ void VisualizationSceneScalarData::Init()
    minv = 0.0;
    maxv = 1.0;
    logscale = false;
-   MySetColorLogscale = 0;
    SetLogA();
    PrepareCaption(); // turn on or off the caption
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -476,8 +476,7 @@ void VisualizationSceneSolution::Init()
 
    VisualizationSceneScalarData::Init();  // Calls FindNewBox() !!!
 
-   paletteSet(2); // use the 'jet-like' palette in 2D
-   SetUseTexture(0);
+   palette.SetPalette(2); // use the 'jet-like' palette in 2D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
    CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*x[0]+(0.5+eps)*x[1]);
@@ -2318,7 +2317,7 @@ gl3::SceneInfo VisualizationSceneSolution::GetSceneObjs()
    params.use_clip_plane = draw_cp;
    double* cp_eqn = CuttingPlane->Equation();
    params.clip_plane_eqn = {cp_eqn[0], cp_eqn[1], cp_eqn[2], cp_eqn[3]};
-   params.contains_translucent = MatAlpha < 1.0;
+   params.contains_translucent = matAlpha < 1.0;
    if (drawelems)
    {
       // draw elements
@@ -2334,7 +2333,7 @@ gl3::SceneInfo VisualizationSceneSolution::GetSceneObjs()
    {
       scene.queue.emplace_back(params, &order_buf);
    }
-   params.contains_translucent = MatAlpha < 1.0;
+   params.contains_translucent = matAlpha < 1.0;
    params.mesh_material = VisualizationScene::BLK_MAT;
    // everything below will be drawn in "black"
    params.static_color = GetLineColor();

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -990,9 +990,9 @@ void VisualizationSceneSolution::ToggleLogscale(bool print)
 {
    if (logscale || LogscaleRange())
    {
-      // we do not change 'MySetColorLogscale' here. It is set to 0 in
+      // we do not change the palette logscale setting here. It is set to 0 in
       // Prepare() since we apply logarithmic scaling to the values.
-      // In PrepareVectorField() we set 'MySetColorLogscale' to 'logscale'.
+      // In PrepareVectorField() we call 'palette.SetUseLogscale(logscale)'.
       logscale = !logscale;
       SetLogA();
       SetLevelLines(minv, maxv, nl);
@@ -1038,58 +1038,6 @@ void DrawNumberedMarker(gl3::GlDrawable& buff, const double x[3], double dx,
    buff.addText(x[0], x[1], x[2], std::to_string(n));
 }
 
-void DrawTriangle(gl3::GlDrawable& buff,
-                  const double (&pts)[4][3], const double (&cv)[4],
-                  const double minv, const double maxv)
-{
-   double nor[3];
-   if (Compute3DUnitNormal(pts[0], pts[1], pts[2], nor))
-   {
-      return;
-   }
-
-   std::array<float, 2> texcoord[3];
-   std::array<float, 3> fpts[3];
-   std::array<float, 3> fnorm = {(float) nor[0], (float) nor[1], (float) nor[2]};
-
-   for (int i = 0; i < 3; i++)
-   {
-
-      texcoord[i] = { static_cast<float>(GetColorCoord(cv[i], minv, maxv)), 1.0 };
-      fpts[i] = {(float) pts[i][0], (float) pts[i][1], (float) pts[i][2]};
-   }
-   buff.addTriangle<gl3::VertexNormTex>(
-   {fpts[0], fnorm, texcoord[0]},
-   {fpts[1], fnorm, texcoord[1]},
-   {fpts[2], fnorm, texcoord[2]});
-}
-
-void DrawQuad(gl3::GlDrawable& buff,
-              const double (&pts)[4][3], const double (&cv)[4],
-              const double minv, const double maxv)
-{
-   double nor[3];
-   if (Compute3DUnitNormal(pts[0], pts[1], pts[2], nor))
-   {
-      return;
-   }
-
-   std::array<float, 2> texcoord[4];
-   std::array<float, 3> fpts[4];
-   std::array<float, 3> fnorm = {(float) nor[0], (float) nor[1], (float) nor[2]};
-
-   for (int i = 0; i < 4; i++)
-   {
-      texcoord[i] = { static_cast<float>(GetColorCoord(cv[i], minv, maxv)), 1.0 };
-      fpts[i] = {(float) pts[i][0], (float) pts[i][1], (float) pts[i][2]};
-   }
-   buff.addQuad<gl3::VertexNormTex>(
-   {fpts[0], fnorm, texcoord[0]},
-   {fpts[1], fnorm, texcoord[1]},
-   {fpts[2], fnorm, texcoord[2]},
-   {fpts[3], fnorm, texcoord[3]});
-}
-
 void RemoveFPErrors(const DenseMatrix &pts, Vector &vals, DenseMatrix &normals,
                     const int n, const Array<int> &ind, Array<int> &f_ind)
 {
@@ -1118,122 +1066,6 @@ void RemoveFPErrors(const DenseMatrix &pts, Vector &vals, DenseMatrix &normals,
    }
    f_ind.SetSize(o);
 }
-
-void DrawPatch(gl3::GlDrawable& drawable, const DenseMatrix &pts, Vector &vals,
-               DenseMatrix &normals,
-               const int n, const Array<int> &ind, const double minv,
-               const double maxv, const int normals_opt)
-{
-   gl3::GlBuilder poly = drawable.createBuilder();
-   double na[3];
-
-   if (normals_opt == 1 || normals_opt == -2)
-   {
-      normals.SetSize(3, pts.Width());
-      normals = 0.;
-      for (int i = 0; i < ind.Size(); i += n)
-      {
-         int j;
-         if (n == 3)
-            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
-                                    &pts(0, ind[i+2]), na);
-         else
-            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
-                                    &pts(0, ind[i+2]), &pts(0, ind[i+3]), na);
-         if (j == 0)
-            for ( ; j < n; j++)
-               for (int k = 0; k < 3; k++)
-               {
-                  normals(k, ind[i+j]) += na[k];
-               }
-      }
-   }
-
-   if (normals_opt != 0 && normals_opt != -1)
-   {
-      std::vector<gl3::VertexNormTex> vertices;
-      std::vector<int> indices;
-      vertices.reserve(pts.Size());
-      indices.reserve(ind.Size());
-      for (int i = 0; i < pts.Width(); i++)
-      {
-         vertices.emplace_back(
-            gl3::VertexNormTex
-         {
-            {(float) pts(0, i), (float) pts(1, i), (float) pts(2, i)},
-            {(float) normals(0, i), (float) normals(1, i), (float) normals(2, i)},
-            {(float) GetColorCoord(vals(i), minv, maxv), 1.0 }
-         });
-      }
-      if (normals_opt > 0)
-      {
-         for (int i = 0; i < ind.Size(); i++)
-         {
-            indices.emplace_back(ind[i]);
-         }
-      }
-      else
-      {
-         for (int i = ind.Size()-1; i >= 0; i--)
-         {
-            indices.emplace_back(ind[i]);
-         }
-      }
-      if (n == 3)
-      {
-         drawable.addTriangleIndexed(vertices, indices);
-      }
-      else
-      {
-         drawable.addQuadIndexed(vertices, indices);
-      }
-   }
-   else
-   {
-      if (n == 3)
-      {
-         poly.glBegin(GL_TRIANGLES);
-      }
-      else
-      {
-         poly.glBegin(GL_QUADS);
-      }
-      for (int i = 0; i < ind.Size(); i += n)
-      {
-         int j;
-         if (n == 3)
-            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
-                                    &pts(0, ind[i+2]), na);
-         else
-            j = Compute3DUnitNormal(&pts(0, ind[i]), &pts(0, ind[i+1]),
-                                    &pts(0, ind[i+2]), &pts(0, ind[i+3]), na);
-         if (j == 0)
-         {
-            if (normals_opt == 0)
-            {
-               poly.glNormal3dv(na);
-               for ( ; j < n; j++)
-               {
-                  MySetColor(poly, vals(ind[i+j]), minv, maxv);
-                  poly.glVertex3dv(&pts(0, ind[i+j]));
-               }
-            }
-            else
-            {
-               poly.glNormal3d(-na[0], -na[1], -na[2]);
-               for (j = n-1; j >= 0; j--)
-               {
-                  MySetColor(poly, vals(ind[i+j]), minv, maxv);
-                  poly.glVertex3dv(&pts(0, ind[i+j]));
-               }
-            }
-         }
-      }
-      poly.glEnd();
-   }
-}
-
-
 
 void VisualizationSceneSolution::PrepareWithNormals()
 {
@@ -1425,7 +1257,7 @@ void VisualizationSceneSolution::PrepareFlat2()
 
 void VisualizationSceneSolution::Prepare()
 {
-   MySetColorLogscale = 0;
+   palette.SetUseLogscale(0);
 
    switch (shading)
    {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -476,7 +476,7 @@ void VisualizationSceneSolution::Init()
 
    VisualizationSceneScalarData::Init();  // Calls FindNewBox() !!!
 
-   palette.SetPalette(2); // use the 'jet-like' palette in 2D
+   palette.SetIndex(2); // use the 'jet-like' palette in 2D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
    CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*x[0]+(0.5+eps)*x[1]);

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -165,18 +165,4 @@ public:
 void DrawNumberedMarker(gl3::GlDrawable& buff, const double x[3], double dx,
                         int n);
 
-// We only need 3 points, but the array is 4x3
-void DrawTriangle(gl3::GlDrawable& buff,
-                  const double (&pts)[4][3], const double (&cv)[4],
-                  const double minv, const double maxv);
-
-void DrawQuad(gl3::GlDrawable& buff,
-              const double (&pts)[4][3], const double (&cv)[4],
-              const double minv, const double maxv);
-
-void DrawPatch(gl3::GlDrawable& buff, const DenseMatrix &pts, Vector &vals,
-               DenseMatrix &normals,
-               const int n, const Array<int> &ind, const double minv,
-               const double maxv, const int normals_opt = 0);
-
 #endif

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -693,7 +693,7 @@ void VisualizationSceneSolution3d::Init()
 
    node_pos = new double[mesh->GetNV()];
 
-   palette.SetPalette(12); // use the 'vivid' palette in 3D
+   palette.SetIndex(12); // use the 'vivid' palette in 3D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
    CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*x[0]+(0.5+eps)*x[1]);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -632,82 +632,6 @@ static void KeyF10Pressed()
    SendExposeEvent();
 }
 
-// 'v' must define three vectors that add up to the zero vector
-// that is v[0], v[1], and v[2] are the sides of a triangle
-int UnitCrossProd(double v[][3], double nor[])
-{
-   // normalize the three vectors
-   for (int i = 0; i < 3; i++)
-      if (Normalize(v[i]))
-      {
-         return 1;
-      }
-
-   // find the pair that forms an angle closest to pi/2, i.e. having
-   // the longest cross product:
-   double cp[3][3], max_a = 0.;
-   int k = 0;
-   for (int i = 0; i < 3; i++)
-   {
-      CrossProd(v[(i+1)%3], v[(i+2)%3], cp[i]);
-      double a = sqrt(InnerProd(cp[i], cp[i]));
-      if (max_a < a)
-      {
-         max_a = a, k = i;
-      }
-   }
-   if (max_a == 0.)
-   {
-      return 1;
-   }
-   for (int i = 0; i < 3; i++)
-   {
-      nor[i] = cp[k][i] / max_a;
-   }
-
-   return 0;
-}
-
-int Compute3DUnitNormal(const double p1[], const double p2[],
-                        const double p3[], double nor[])
-{
-   double v[3][3];
-
-   for (int i = 0; i < 3; i++)
-   {
-      v[0][i] = p2[i] - p1[i];
-      v[1][i] = p3[i] - p2[i];
-      v[2][i] = p1[i] - p3[i];
-   }
-
-   return UnitCrossProd(v, nor);
-}
-
-int Compute3DUnitNormal (const double p1[], const double p2[],
-                         const double p3[], const double p4[], double nor[])
-{
-   double v[3][3];
-
-   for (int i = 0; i < 3; i++)
-   {
-      // cross product of the two diagonals:
-      /*
-        v[0][i] = p3[i] - p1[i];
-        v[1][i] = p4[i] - p2[i];
-        v[2][i] = (p1[i] + p2[i]) - (p3[i] + p4[i]);
-      */
-
-      // cross product of the two vectors connecting the midpoints of the
-      // two pairs of opposing sides; this gives the normal vector in the
-      // midpoint of the quad:
-      v[0][i] = 0.5 * ((p2[i] + p3[i]) - (p1[i] + p4[i]));
-      v[1][i] = 0.5 * ((p4[i] + p3[i]) - (p1[i] + p2[i]));
-      v[2][i] = p1[i] - p3[i];
-   }
-
-   return UnitCrossProd(v, nor);
-}
-
 VisualizationSceneSolution3d::VisualizationSceneSolution3d()
 {}
 
@@ -1182,16 +1106,6 @@ void VisualizationSceneSolution3d::NumberOfLevelSurf(int c)
       nlevels = 1;
    }
    PrepareLevelSurf();
-}
-
-int Normalize(DenseMatrix &normals)
-{
-   int err = 0;
-   for (int i = 0; i < normals.Width(); i++)
-   {
-      err += Normalize(&normals(0, i));
-   }
-   return err;
 }
 
 void VisualizationSceneSolution3d::GetFaceNormals(

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1010,7 +1010,7 @@ void VisualizationSceneSolution3d::EventUpdateColors()
 void VisualizationSceneSolution3d::UpdateValueRange(bool prepare)
 {
    logscale = logscale && LogscaleRange();
-   MySetColorLogscale = logscale;
+   palette.SetUseLogscale(logscale);
    SetLogA();
    SetLevelLines(minv, maxv, nl);
    if (prepare)

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -769,8 +769,7 @@ void VisualizationSceneSolution3d::Init()
 
    node_pos = new double[mesh->GetNV()];
 
-   paletteSet(12); // use the 'vivid' palette in 3D
-   SetUseTexture(0);
+   palette.SetPalette(12); // use the 'vivid' palette in 3D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
    CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*x[0]+(0.5+eps)*x[1]);
@@ -3596,7 +3595,7 @@ gl3::SceneInfo VisualizationSceneSolution3d::GetSceneObjs()
    params.use_clip_plane = cplane;
    double* cp_eqn = CuttingPlane->Equation();
    params.clip_plane_eqn = {cp_eqn[0], cp_eqn[1], cp_eqn[2], cp_eqn[3]};
-   params.contains_translucent = MatAlpha < 1.0;
+   params.contains_translucent = matAlpha < 1.0;
 
    if (drawlsurf)
    {

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -183,12 +183,4 @@ public:
    virtual int GetDrawMesh() { return drawmesh; }
 };
 
-int Normalize(DenseMatrix &normals);
-
-int Compute3DUnitNormal(const double p1[], const double p2[],
-                        const double p3[], double nor[]);
-
-int Compute3DUnitNormal (const double p1[], const double p2[],
-                         const double p3[], const double p4[], double nor[]);
-
 #endif

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -974,7 +974,7 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
    {
       scene.queue.emplace_back(params, &vector_buf);
    }
-   params.contains_translucent = MatAlpha < 1.0;
+   params.contains_translucent = matAlpha < 1.0;
    if (drawelems)
    {
       scene.queue.emplace_back(params, &disp_buf);

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -895,7 +895,7 @@ void VisualizationSceneVector::PrepareVectorField()
       {
          int i;
 
-         MySetColorLogscale = logscale;
+         palette.SetUseLogscale(logscale);
          if (drawvector == 3)
          {
             new_maxlen = 0.0;

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -1524,7 +1524,7 @@ gl3::SceneInfo VisualizationSceneVector3d::GetSceneObjs()
    params.use_clip_plane = cplane;
    double* cp_eqn = CuttingPlane->Equation();
    params.clip_plane_eqn = {cp_eqn[0], cp_eqn[1], cp_eqn[2], cp_eqn[3]};
-   params.contains_translucent = MatAlpha < 1.0;
+   params.contains_translucent = matAlpha < 1.0;
    // draw vector field
    if (drawvector == 2 || drawvector == 3)
    {

--- a/makefile
+++ b/makefile
@@ -229,7 +229,7 @@ COMMON_SOURCE_FILES = $(filter-out \
 HEADER_FILES = \
  lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp \
  lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp lib/gl/types.hpp \
- lib/aux_vis.hpp lib/font.hpp lib/gl2ps.h lib/logo.hpp lib/material.hpp \
+ lib/aux_vis.hpp lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h lib/logo.hpp lib/material.hpp \
  lib/openglvis.hpp lib/palettes.hpp lib/sdl.hpp lib/sdl_helper.hpp \
  lib/sdl_mac.hpp lib/sdl_x11.hpp lib/stream_reader.hpp lib/threads.hpp lib/visual.hpp \
  lib/vsdata.hpp lib/vssolution.hpp lib/vssolution3d.hpp lib/vsvector.hpp \


### PR DESCRIPTION
- Create a new `PaletteState` class to encapsulate global palette state
- Modify `VisualizationScene` and gl3 classes to use a local instance of `PaletteState`
- Move handle types into `gl/types.hpp` header
- Move common geometry functions into a single header