### PR TITLE
Pinch to zoom

### DIFF
--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -339,7 +339,7 @@ void processKeys(const std::string & keys)
    CallKeySequence(keys.c_str());
 }
 
-void processKey(char sym, bool ctrl=false, bool shift=false, bool alt=false)
+void processKey(int sym, bool ctrl=false, bool shift=false, bool alt=false)
 {
    Uint16 mod = 0;
    mod |= ctrl ? KMOD_CTRL : 0;

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -738,7 +738,8 @@ void RightButtonLoc (EventInfo *event)
 void RightButtonUp (EventInfo*)
 {}
 
-void TouchPinch(SDL_MultiGestureEvent & e) {
+void TouchPinch(SDL_MultiGestureEvent & e)
+{
    // Scale or Zoom?
    locscene->Zoom(exp(e.dDist*10));
    SendExposeEvent();

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -115,6 +115,8 @@ int InitVisualization (const char name[], int x, int y, int w, int h)
    wnd->setOnMouseUp(SDL_BUTTON_RIGHT, RightButtonUp);
    wnd->setOnMouseMove(SDL_BUTTON_RIGHT, RightButtonLoc);
 
+   wnd->setTouchPinchCallback(TouchPinch);
+
    // auxKeyFunc (AUX_p, KeyCtrlP); // handled in vsdata.cpp
    wnd->setOnKeyDown (SDLK_s, KeyS);
    wnd->setOnKeyDown ('S', KeyS);
@@ -734,6 +736,12 @@ void RightButtonLoc (EventInfo *event)
 
 void RightButtonUp (EventInfo*)
 {}
+
+void TouchPinch(SDL_MultiGestureEvent & e) {
+   // Scale or Zoom?
+   locscene->Zoom(exp(e.dDist*10));
+   SendExposeEvent();
+}
 
 #if defined(GLVIS_USE_LIBTIFF)
 const char *glvis_screenshot_ext = ".tif";

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -59,6 +59,8 @@ void RightButtonDown (EventInfo *event);
 void RightButtonLoc  (EventInfo *event);
 void RightButtonUp   (EventInfo *event);
 
+void TouchPinch(SDL_MultiGestureEvent & e);
+
 void KeyCtrlP();
 void KeyS();
 void KeyQPressed();

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -586,22 +586,27 @@ void SdlWindow::keyEvent(char c)
    }
 }
 
-void SdlWindow::multiGestureEvent(SDL_MultiGestureEvent & e) {
-  if (e.numFingers == 2) {
-    if (onTouchPinch && fabs(e.dDist) > 0.00002) {
-      onTouchPinch(e);
-    }
+void SdlWindow::multiGestureEvent(SDL_MultiGestureEvent & e)
+{
+   if (e.numFingers == 2)
+   {
+      if (onTouchPinch && fabs(e.dDist) > 0.00002)
+      {
+         onTouchPinch(e);
+      }
 
-    if (onTouchRotate) {
-      onTouchRotate(e);
-    }
-  }
+      if (onTouchRotate)
+      {
+         onTouchRotate(e);
+      }
+   }
 }
 
 void SdlWindow::mainIter()
 {
    SDL_Event e;
    static bool useIdle = false;
+   static bool disable_mouse = false;
    if (SDL_PollEvent(&e))
    {
       bool keep_going;
@@ -615,6 +620,16 @@ void SdlWindow::mainIter()
                break;
             case SDL_WINDOWEVENT:
                windowEvent(e.window);
+               break;
+            case SDL_FINGERDOWN:
+               fingers.insert(e.tfinger.fingerId);
+               if (fingers.size() >= 2) { disable_mouse = true; }
+               keep_going = true;
+               break;
+            case SDL_FINGERUP:
+               fingers.erase(e.tfinger.fingerId);
+               if (fingers.size() < 2) { disable_mouse = false; }
+               keep_going = true;
                break;
             case SDL_MULTIGESTURE:
                multiGestureEvent(e.mgesture);
@@ -634,15 +649,15 @@ void SdlWindow::mainIter()
                keyEvent(e.text.text[0]);
                break;
             case SDL_MOUSEMOTION:
-               motionEvent(e.motion);
+               if (!disable_mouse) { motionEvent(e.motion); }
                // continue processing events
                keep_going = true;
                break;
             case SDL_MOUSEBUTTONDOWN:
-               mouseEventDown(e.button);
+               if (!disable_mouse) { mouseEventDown(e.button); }
                break;
             case SDL_MOUSEBUTTONUP:
-               mouseEventUp(e.button);
+               if (!disable_mouse) { mouseEventUp(e.button); }
                break;
          }
       }

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -98,16 +98,7 @@ bool SdlWindow::isGlInitialized()
 // Initialize static member
 Uint32 SdlWindow::glvis_event_type = (Uint32)(-1);
 
-SdlWindow::SdlWindow()
-   : onIdle(nullptr)
-   , onExpose(nullptr)
-   , onReshape(nullptr)
-   , ctrlDown(false)
-   , wnd_state(RenderState::Updated)
-   , takeScreenshot(false)
-   , saved_keys("")
-{
-}
+SdlWindow::SdlWindow() {}
 
 int SdlWindow::probeGLContextSupport()
 {
@@ -555,6 +546,18 @@ void SdlWindow::keyEvent(char c)
    }
 }
 
+void SdlWindow::multiGestureEvent(SDL_MultiGestureEvent & e) {
+  if (e.numFingers == 2) {
+    if (onTouchPinch && fabs(e.dDist) > 0.00002) {
+      onTouchPinch(e);
+    }
+
+    if (onTouchRotate) {
+      onTouchRotate(e);
+    }
+  }
+}
+
 void SdlWindow::mainIter()
 {
    SDL_Event e;
@@ -572,6 +575,10 @@ void SdlWindow::mainIter()
                break;
             case SDL_WINDOWEVENT:
                windowEvent(e.window);
+               break;
+            case SDL_MULTIGESTURE:
+               multiGestureEvent(e.mgesture);
+               keep_going = true;
                break;
             case SDL_KEYDOWN:
                keyEvent(e.key.keysym);

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -26,6 +26,7 @@ struct EventInfo
    SDL_Keymod keymod;
 };
 
+typedef void (*TouchDelegate)(SDL_MultiGestureEvent&);
 typedef void (*MouseDelegate)(EventInfo*);
 typedef std::function<void(GLenum)> KeyDelegate;
 typedef void (*WindowDelegate)(int, int);
@@ -57,15 +58,17 @@ private:
 
    bool running;
 
-   Delegate onIdle;
-   Delegate onExpose;
-   WindowDelegate onReshape;
+   Delegate onIdle{nullptr};
+   Delegate onExpose{nullptr};
+   WindowDelegate onReshape{nullptr};
    std::map<int, KeyDelegate> onKeyDown;
    std::map<int, MouseDelegate> onMouseDown;
    std::map<int, MouseDelegate> onMouseUp;
    std::map<int, MouseDelegate> onMouseMove;
+   TouchDelegate onTouchPinch{nullptr};
+   TouchDelegate onTouchRotate{nullptr};
 
-   bool ctrlDown;
+   bool ctrlDown{false};
 
 #ifdef __EMSCRIPTEN__
    std::string canvas_id_;
@@ -81,10 +84,10 @@ private:
       SwapPending
    };
 
-   RenderState wnd_state;
+   RenderState wnd_state{RenderState::Updated};
 
    //bool requiresExpose;
-   bool takeScreenshot;
+   bool takeScreenshot{false};
    std::string screenshot_file;
 
    int probeGLContextSupport();
@@ -95,6 +98,7 @@ private:
    void mouseEventUp(SDL_MouseButtonEvent& eb);
    void keyEvent(SDL_Keysym& ks);
    void keyEvent(char c);
+   void multiGestureEvent(SDL_MultiGestureEvent & e);
 
    std::string saved_keys;
 public:
@@ -125,6 +129,9 @@ public:
    void setOnMouseDown(int btn, MouseDelegate func) { onMouseDown[btn] = func; }
    void setOnMouseUp(int btn, MouseDelegate func) { onMouseUp[btn] = func; }
    void setOnMouseMove(int btn, MouseDelegate func) { onMouseMove[btn] = func; }
+
+   void setTouchPinchCallback(TouchDelegate cb) { onTouchPinch = cb; }
+   void setTouchRotateCallback(TouchDelegate cb) { onTouchRotate = cb; }
 
    void clearEvents()
    {

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <functional>
 #include <map>
+#include <set>
 #include "gl/renderer.hpp"
 #include "sdl_helper.hpp"
 
@@ -67,6 +68,7 @@ private:
    std::map<int, MouseDelegate> onMouseMove;
    TouchDelegate onTouchPinch{nullptr};
    TouchDelegate onTouchRotate{nullptr};
+   std::set<SDL_FingerID> fingers;
 
    bool ctrlDown{false};
 


### PR DESCRIPTION
- Adds event hander for `SDL_MULTIGESTURE`; pinch and rotate
   - Adds pinch handler that zooms
   - No rotate handler currently
   - Mouse Events (single finger touch events) are disabled when the number of detected fingers is > 1
- `void processKey(char sym, ...` -> void processKey(int sym, ...` for JS interface so that high-valued functions keys work