### PR TITLE
Replace pthreads with C++11 threads library

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@ Version 4.0.1 (development)
 
 - Refactoring of palette handling code.
 
+- Replace pthreads with C++11 standard thread library.
+
 
 Version 4.0, released on Dec 11, 2020
 =====================================

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -857,7 +857,7 @@ void communication_thread::execute()
             tmp.mesh.reset(new Mesh(mesh_array, nproc));
             tmp.grid_f.reset(new GridFunction(tmp.mesh.get(), gf_array, nproc));
 
-        for (int p = 0; p < nproc; p++)
+            for (int p = 0; p < nproc; p++)
             {
                delete gf_array[nproc-1-p];
                delete mesh_array[nproc-1-p];

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -16,6 +16,7 @@
 #include "stream_reader.hpp"
 #include <mfem.hpp>
 #include <thread>
+#include <atomic>
 #include <condition_variable>
 
 class GLVisCommand

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -155,7 +155,7 @@ private:
    // signal for thread cancellation
    std::atomic<bool> terminate_thread {false};
 
-   static void *execute(void *);
+   void execute();
 
 public:
    communication_thread(Array<std::istream *> &_is);

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -15,7 +15,8 @@
 #include "vsdata.hpp"
 #include "stream_reader.hpp"
 #include <mfem.hpp>
-#include <pthread.h>
+#include <thread>
+#include <condition_variable>
 
 class GLVisCommand
 {
@@ -25,8 +26,9 @@ private:
    StreamState&         curr_state;
    bool                 *keep_attr;
 
-   pthread_mutex_t glvis_mutex;
-   pthread_cond_t  glvis_cond;
+   std::mutex glvis_mutex;
+   std::condition_variable glvis_cond;
+
    int num_waiting;
    bool terminating;
    int pfd[2];  // pfd[0] -- reading, pfd[1] -- writing
@@ -148,18 +150,10 @@ private:
    std::unique_ptr<GridFunction> new_g;
    std::string ident;
 
-   // thread id
-   pthread_t tid;
-
-   static void cancel_off()
-   {
-      pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-   }
-
-   static void cancel_on()
-   {
-      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-   }
+   // thread object
+   std::thread tid;
+   // signal for thread cancellation
+   std::atomic<bool> terminate_thread {false};
 
    static void *execute(void *);
 


### PR DESCRIPTION
Replaces pthreads functions with C++11 standard library equivalents. This should help with portability to non-POSIX platforms, and enables us to clean up some code in `communication_thread::execute()` as well.