### PR TITLE
Modularize shader handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,7 @@ Version 4.0.1 (development)
 
 - Various bugfixes and improvements related to the JavaScript version.
 
-- Refactoring of palette handling code.
+- Refactoring of rendering components, including palette and shader handling.
 
 
 Version 4.0, released on Dec 11, 2020

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,7 @@
 list(APPEND SOURCES
   gl/renderer.cpp
   gl/renderer_core.cpp
+  gl/shader.cpp
   gl/types.cpp
   aux_vis.cpp
   font.cpp
@@ -31,6 +32,7 @@ list(APPEND HEADERS
   gl/platform_gl.hpp
   gl/renderer.hpp
   gl/renderer_core.hpp
+  gl/shader.hpp
   gl/types.hpp
   aux_vis.hpp
   font.hpp

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -121,7 +121,7 @@ protected:
          }
          return *this;
       }
-      operator GLuint() { return hnd; }
+      operator GLuint() const { return hnd; }
    };
 
    static void boCleanup(GLuint vbo_hnd)
@@ -137,6 +137,11 @@ protected:
    static void prgmCleanup(GLuint prgm)
    {
       glDeleteProgram(prgm);
+   }
+
+   static void shdrCleanup(GLuint shdr)
+   {
+       glDeleteShader(shdr);
    }
 
    static void vaoCleanup(GLuint vao)
@@ -164,6 +169,7 @@ public:
    using DispListHandle = Handle<dspListCleanup>;
    using VtxArrayHandle = Handle<vaoCleanup>;
    using ShaderPrgmHandle = Handle<prgmCleanup>;
+   using ShaderHandle = Handle<shdrCleanup>;
    using TextureHandle = Handle<texCleanup>;
    using FBOHandle = Handle<fboCleanup>;
    using RenderBufHandle = Handle<rboCleanup>;
@@ -266,6 +272,8 @@ class MeshRenderer
 
    bool feat_use_fbo_antialias;
    void init();
+
+   void renderImpl(GlDrawable* drawable);
 public:
    MeshRenderer()
       : msaa_enable(false)

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -204,8 +204,6 @@ class MeshRenderer
 
    bool feat_use_fbo_antialias;
    void init();
-
-   void renderImpl(GlDrawable* drawable);
 public:
    MeshRenderer()
       : msaa_enable(false)

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -92,11 +92,11 @@ bool CoreGLDevice::compileShaders()
 {
    std::unordered_map<int, std::string> attribMap =
    {
-       { CoreGLDevice::ATTR_VERTEX, "vertex"},
-       { CoreGLDevice::ATTR_TEXT_VERTEX, "textVertex"},
-       { CoreGLDevice::ATTR_NORMAL, "normal"},
-       { CoreGLDevice::ATTR_COLOR, "color"},
-       { CoreGLDevice::ATTR_TEXCOORD0, "texCoord0"}
+      { CoreGLDevice::ATTR_VERTEX, "vertex"},
+      { CoreGLDevice::ATTR_TEXT_VERTEX, "textVertex"},
+      { CoreGLDevice::ATTR_NORMAL, "normal"},
+      { CoreGLDevice::ATTR_COLOR, "color"},
+      { CoreGLDevice::ATTR_TEXCOORD0, "texCoord0"}
    };
 
    if (!default_prgm.create(DEFAULT_VS, DEFAULT_FS, attribMap, 1))
@@ -135,26 +135,26 @@ void CoreGLDevice::initializeShaderState(const ShaderProgram& prog)
    uniforms = prog.getUniformMap();
    for (const auto& uf : unif_list)
    {
-       if (uniforms.find(uf) == uniforms.end())
-       {
+      if (uniforms.find(uf) == uniforms.end())
+      {
 #ifdef GLVIS_DEBUG
          std::cerr << "Uniform \"" << uf
                    << "\" missing in shader, ignoring." << std::endl;
 #endif
          // set uniform index to -1 so glUniform ignores data
          uniforms.emplace(uf, -1);
-       }
+      }
    }
 #ifdef GLVIS_DEBUG
    unordered_set<string> expectedUnifs(unif_list.begin(), unif_list.end());
    for (const auto& pairunif : uniforms)
    {
-       if (expectedUnifs.find(pairunif.first) == expectedUnifs.end())
-       {
+      if (expectedUnifs.find(pairunif.first) == expectedUnifs.end())
+      {
          std::cerr << "Warning: unexpected uniform \""
                    << pairunif.first
                    << "\" found in shader." << std::endl;
-       }
+      }
    }
 #endif
    glUniform1i(uniforms["colorTex"], 0);

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -170,7 +170,7 @@ void CoreGLDevice::init()
       std::cerr << "Unable to initialize CoreGLDevice." << std::endl;
       return;
    }
-   this->initializeShaderState(RenderMode::Default);
+   this->initializeShaderState(default_prgm);
    if (GLEW_VERSION_3_0 || GLEW_ARB_vertex_array_object)
    {
       GLuint hnd_vao;

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -17,12 +17,6 @@
 #include <type_traits>
 #include <unordered_set>
 
-#ifdef __EMSCRIPTEN__
-// TODO: for webgl glsl the version ends in "es": #version GLSL_VER es
-const std::string GLSL_HEADER = "precision mediump float;\n";
-#else
-const std::string GLSL_HEADER = "#version GLSL_VER\n";
-#endif
 // weird but loads them inline
 
 const std::string BLINN_PHONG_FS =
@@ -135,18 +129,10 @@ bool CoreGLDevice::compileShaders()
    return true;
 }
 
-void CoreGLDevice::initializeShaderState(CoreGLDevice::RenderMode mode)
+void CoreGLDevice::initializeShaderState(const ShaderProgram& prog)
 {
-   if (mode == RenderMode::Default)
-   {
-      default_prgm.bind();
-      uniforms = default_prgm.getUniformMap();
-   }
-   else if (mode == RenderMode::Feedback)
-   {
-      feedback_prgm.bind();
-      uniforms = feedback_prgm.getUniformMap();
-   }
+   prog.bind();
+   uniforms = prog.getUniformMap();
    for (const auto& uf : unif_list)
    {
        if (uniforms.find(uf) == uniforms.end())

--- a/lib/gl/renderer_core.hpp
+++ b/lib/gl/renderer_core.hpp
@@ -44,12 +44,6 @@ private:
 
    BufObjHandle feedback_vbo;
 
-   enum class RenderMode
-   {
-      Default,
-      Feedback
-   };
-
    const static std::vector<std::string> unif_list;
 
    std::unordered_map<std::string, GLuint> uniforms;
@@ -68,7 +62,7 @@ private:
    std::vector<VBOData> vbos;
 
    bool compileShaders();
-   void initializeShaderState(RenderMode mode);
+   void initializeShaderState(const ShaderProgram& prog);
 
    template<typename T>
    void drawDeviceBufferImpl(GLenum shape, int count, bool indexed);
@@ -105,13 +99,19 @@ public:
    void initXfbMode() override
    {
       glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, feedback_vbo);
-      initializeShaderState(RenderMode::Feedback);
+      initializeShaderState(feedback_prgm);
       glEnable(GL_RASTERIZER_DISCARD);
    }
    void exitXfbMode() override
    {
       glDisable(GL_RASTERIZER_DISCARD);
-      initializeShaderState(RenderMode::Default);
+      initializeShaderState(default_prgm);
+      glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, 0);
+   }
+   void bindExternalProgram(const ShaderProgram& prog)
+   {
+      glDisable(GL_RASTERIZER_DISCARD);
+      initializeShaderState(prog);
       glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, 0);
    }
    void captureXfbBuffer(CaptureBuffer& cbuf, int hnd) override;

--- a/lib/gl/renderer_core.hpp
+++ b/lib/gl/renderer_core.hpp
@@ -12,6 +12,7 @@
 #ifndef GLVIS_RENDERER_CORE_HPP
 #define GLVIS_RENDERER_CORE_HPP
 #include "renderer.hpp"
+#include "shader.hpp"
 
 namespace gl3
 {
@@ -37,8 +38,8 @@ public:
    };
 
 private:
-   ShaderPrgmHandle default_prgm;
-   ShaderPrgmHandle feedback_prgm;
+   ShaderProgram default_prgm;
+   ShaderProgram feedback_prgm;
    VtxArrayHandle global_vao;
 
    BufObjHandle feedback_vbo;
@@ -79,7 +80,7 @@ private:
 
 public:
    CoreGLDevice()
-      : default_prgm(0), feedback_prgm(0), global_vao(0)
+      : global_vao(0)
    {
       vbos.emplace_back(VBOData{}); // dummy for index 0
    }

--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -231,12 +231,14 @@ bool ShaderProgram::linkShaders(const std::vector<GLuint>& shaders)
                            attrib_pair.second.c_str());
    }
 
+#ifndef __EMSCRIPTEN__
    // Bind fragment output variables to MRT indices.
    for (int i = 0; i < num_outputs; i++)
    {
       std::string fragOutVar = "fragColor_" + std::to_string(i);
       glBindFragDataLocation(program_id, i, fragOutVar.c_str());
    }
+#endif
 
    for (GLuint i : shaders)
    {

--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -1,3 +1,14 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
 #include "shader.hpp"
 #include <regex>
 

--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -16,35 +16,35 @@ bool ShaderProgram::create(std::string vertexShader,
                            std::unordered_map<int, std::string> inAttributes,
                            int numOutputs)
 {
-    attrib_idx = inAttributes;
-    num_outputs = numOutputs;
-    is_compiled = false;
-    GetGLSLVersion();
+   attrib_idx = inAttributes;
+   num_outputs = numOutputs;
+   is_compiled = false;
+   GetGLSLVersion();
 
-    std::string fmtVS = formatShader(vertexShader, GL_VERTEX_SHADER);
-    vertex_shader = compileShader(fmtVS, GL_VERTEX_SHADER);
-    if (vertex_shader == 0)
-    {
-        return false;
-    }
+   std::string fmtVS = formatShader(vertexShader, GL_VERTEX_SHADER);
+   vertex_shader = compileShader(fmtVS, GL_VERTEX_SHADER);
+   if (vertex_shader == 0)
+   {
+      return false;
+   }
 
-    std::string fmtFS = formatShader(fragmentShader, GL_FRAGMENT_SHADER);
-    fragment_shader = compileShader(fmtFS, GL_FRAGMENT_SHADER);
-    if (fragment_shader == 0)
-    {
-        return false;
-    }
+   std::string fmtFS = formatShader(fragmentShader, GL_FRAGMENT_SHADER);
+   fragment_shader = compileShader(fmtFS, GL_FRAGMENT_SHADER);
+   if (fragment_shader == 0)
+   {
+      return false;
+   }
 
-    if (!linkShaders({vertex_shader, fragment_shader}))
-    {
-        std::cerr << "Failed to link shaders for program." << std::endl;
-        return false;
-    }
+   if (!linkShaders({vertex_shader, fragment_shader}))
+   {
+      std::cerr << "Failed to link shaders for program." << std::endl;
+      return false;
+   }
 
-    mapShaderUniforms();
+   mapShaderUniforms();
 
-    is_compiled = true;
-    return is_compiled;
+   is_compiled = true;
+   return is_compiled;
 }
 
 int ShaderProgram::glsl_version = -1;
@@ -53,60 +53,60 @@ void ShaderProgram::GetGLSLVersion()
 {
    if (glsl_version == -1)
    {
-   std::string verStr = (char*)glGetString(GL_VERSION);
-   int ver_major, ver_minor;
-   int vs_idx = verStr.find_first_of(".");
-   ver_major = std::stoi(verStr.substr(vs_idx - 1, vs_idx));
-   ver_minor = std::stoi(verStr.substr(vs_idx + 1, 1));
-   int opengl_ver = ver_major * 100 + ver_minor * 10;
+      std::string verStr = (char*)glGetString(GL_VERSION);
+      int ver_major, ver_minor;
+      int vs_idx = verStr.find_first_of(".");
+      ver_major = std::stoi(verStr.substr(vs_idx - 1, vs_idx));
+      ver_minor = std::stoi(verStr.substr(vs_idx + 1, 1));
+      int opengl_ver = ver_major * 100 + ver_minor * 10;
 
 #ifndef __EMSCRIPTEN__
-   // The GLSL version is the same as the OpenGL version when the OpenGL
-   // version is >= 3.30, otherwise it is:
-   //
-   // GL Version | GLSL Version
-   // -------------------------
-   //    2.0     |   1.10
-   //    2.1     |   1.20
-   //    3.0     |   1.30
-   //    3.1     |   1.40
-   //    3.2     |   1.50
+      // The GLSL version is the same as the OpenGL version when the OpenGL
+      // version is >= 3.30, otherwise it is:
+      //
+      // GL Version | GLSL Version
+      // -------------------------
+      //    2.0     |   1.10
+      //    2.1     |   1.20
+      //    3.0     |   1.30
+      //    3.1     |   1.40
+      //    3.2     |   1.50
 
-   if (opengl_ver < 330)
-   {
-      if (ver_major == 2)
+      if (opengl_ver < 330)
       {
-         glsl_version = opengl_ver - 90;
-      }
-      else if (ver_major == 3)
-      {
-         glsl_version = opengl_ver - 170;
+         if (ver_major == 2)
+         {
+            glsl_version = opengl_ver - 90;
+         }
+         else if (ver_major == 3)
+         {
+            glsl_version = opengl_ver - 170;
+         }
+         else
+         {
+            std::cerr << "fatal: unsupported OpenGL version " << opengl_ver << std::endl;
+            glsl_version = 100;
+         }
       }
       else
       {
-         std::cerr << "fatal: unsupported OpenGL version " << opengl_ver << std::endl;
+         glsl_version = opengl_ver;
+      }
+#else
+      // GL Version | WebGL Version | GLSL Version
+      //    2.0     |      1.0      |   1.00 ES
+      //    3.0     |      2.0      |   3.00 ES
+      //    3.1     |               |   3.10 ES
+      if (opengl_ver < 300)
+      {
          glsl_version = 100;
       }
-   }
-   else
-   {
-      glsl_version = opengl_ver;
-   }
-#else
-   // GL Version | WebGL Version | GLSL Version
-   //    2.0     |      1.0      |   1.00 ES
-   //    3.0     |      2.0      |   3.00 ES
-   //    3.1     |               |   3.10 ES
-   if (opengl_ver < 300)
-   {
-      glsl_version = 100;
-   }
-   else
-   {
-      glsl_version = 300;
-   }
+      else
+      {
+         glsl_version = 300;
+      }
 #endif
-   std::cerr << "Using GLSL " << glsl_version << std::endl;
+      std::cerr << "Using GLSL " << glsl_version << std::endl;
    }
 }
 
@@ -132,28 +132,28 @@ std::string ShaderProgram::formatShader(const std::string& inShader,
          // although gl_FragColor was deprecated in GLSL 1.3
          for (int i = 0; i < num_outputs; i++)
          {
-             std::string indexString = "gl_FragData[";
-             indexString += std::to_string(i) + "]";
-             std::string outputString = "out vec4 fragColor_";
-             outputString += std::to_string(i) + ";\n";
-             if (glsl_version > 130 && glsl_version < 330)
-             {
+            std::string indexString = "gl_FragData[";
+            indexString += std::to_string(i) + "]";
+            std::string outputString = "out vec4 fragColor_";
+            outputString += std::to_string(i) + ";\n";
+            if (glsl_version > 130 && glsl_version < 330)
+            {
 
-                 formatted = outputString + formatted;
-                 formatted = std::regex_replace(formatted, std::regex(indexString),
-                                                "fragColor");
-             }
-             else if (glsl_version >= 330)
-             {
-                 std::string layoutString = "layout(location = ";
-                 layoutString += std::to_string(i) + ") ";
-                 formatted = layoutString + outputString + formatted;
-             }
-             if (i == 0)
-             {
-                 formatted = std::regex_replace(formatted, std::regex("gl_FragColor"),
-                                                "fragColor_0");
-             }
+               formatted = outputString + formatted;
+               formatted = std::regex_replace(formatted, std::regex(indexString),
+                                              "fragColor");
+            }
+            else if (glsl_version >= 330)
+            {
+               std::string layoutString = "layout(location = ";
+               layoutString += std::to_string(i) + ") ";
+               formatted = layoutString + outputString + formatted;
+            }
+            if (i == 0)
+            {
+               formatted = std::regex_replace(formatted, std::regex("gl_FragColor"),
+                                              "fragColor_0");
+            }
          }
       }
 
@@ -216,15 +216,15 @@ bool ShaderProgram::linkShaders(const std::vector<GLuint>& shaders)
    // Bind all incoming attributes to their VAO indices.
    for (auto attrib_pair : attrib_idx)
    {
-       glBindAttribLocation(program_id, attrib_pair.first,
-                            attrib_pair.second.c_str());
+      glBindAttribLocation(program_id, attrib_pair.first,
+                           attrib_pair.second.c_str());
    }
 
    // Bind fragment output variables to MRT indices.
    for (int i = 0; i < num_outputs; i++)
    {
-       std::string fragOutVar = "fragColor_" + std::to_string(i);
-       glBindFragDataLocation(program_id, i, fragOutVar.c_str());
+      std::string fragOutVar = "fragColor_" + std::to_string(i);
+      glBindFragDataLocation(program_id, i, fragOutVar.c_str());
    }
 
    for (GLuint i : shaders)
@@ -255,7 +255,8 @@ void ShaderProgram::mapShaderUniforms()
       GLsizei name_length;
       GLint gl_size;
       GLenum gl_type;
-      glGetActiveUniform(program_id, i, max_unif_len, &name_length, &gl_size, &gl_type,
+      glGetActiveUniform(program_id, i, max_unif_len, &name_length, &gl_size,
+                         &gl_type,
                          unif_buf.data());
       std::string unif_name(unif_buf.data(), name_length);
       GLuint location = glGetUniformLocation(program_id, unif_name.c_str());

--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -1,0 +1,266 @@
+#include "shader.hpp"
+#include <regex>
+
+#ifdef __EMSCRIPTEN__
+// TODO: for webgl glsl the version ends in "es": #version GLSL_VER es
+const std::string GLSL_HEADER = "precision mediump float;\n";
+#else
+const std::string GLSL_HEADER = "#version GLSL_VER\n";
+#endif
+
+namespace gl3
+{
+
+bool ShaderProgram::create(std::string vertexShader,
+                           std::string fragmentShader,
+                           std::unordered_map<int, std::string> inAttributes,
+                           int numOutputs)
+{
+    attrib_idx = inAttributes;
+    num_outputs = numOutputs;
+    is_compiled = false;
+    GetGLSLVersion();
+
+    std::string fmtVS = formatShader(vertexShader, GL_VERTEX_SHADER);
+    vertex_shader = compileShader(fmtVS, GL_VERTEX_SHADER);
+    if (vertex_shader == 0)
+    {
+        return false;
+    }
+
+    std::string fmtFS = formatShader(fragmentShader, GL_FRAGMENT_SHADER);
+    fragment_shader = compileShader(fmtFS, GL_FRAGMENT_SHADER);
+    if (fragment_shader == 0)
+    {
+        return false;
+    }
+
+    if (!linkShaders({vertex_shader, fragment_shader}))
+    {
+        std::cerr << "Failed to link shaders for program." << std::endl;
+        return false;
+    }
+
+    mapShaderUniforms();
+
+    is_compiled = true;
+    return is_compiled;
+}
+
+int ShaderProgram::glsl_version = -1;
+
+void ShaderProgram::GetGLSLVersion()
+{
+   if (glsl_version == -1)
+   {
+   std::string verStr = (char*)glGetString(GL_VERSION);
+   int ver_major, ver_minor;
+   int vs_idx = verStr.find_first_of(".");
+   ver_major = std::stoi(verStr.substr(vs_idx - 1, vs_idx));
+   ver_minor = std::stoi(verStr.substr(vs_idx + 1, 1));
+   int opengl_ver = ver_major * 100 + ver_minor * 10;
+
+#ifndef __EMSCRIPTEN__
+   // The GLSL version is the same as the OpenGL version when the OpenGL
+   // version is >= 3.30, otherwise it is:
+   //
+   // GL Version | GLSL Version
+   // -------------------------
+   //    2.0     |   1.10
+   //    2.1     |   1.20
+   //    3.0     |   1.30
+   //    3.1     |   1.40
+   //    3.2     |   1.50
+
+   if (opengl_ver < 330)
+   {
+      if (ver_major == 2)
+      {
+         glsl_version = opengl_ver - 90;
+      }
+      else if (ver_major == 3)
+      {
+         glsl_version = opengl_ver - 170;
+      }
+      else
+      {
+         std::cerr << "fatal: unsupported OpenGL version " << opengl_ver << std::endl;
+         glsl_version = 100;
+      }
+   }
+   else
+   {
+      glsl_version = opengl_ver;
+   }
+#else
+   // GL Version | WebGL Version | GLSL Version
+   //    2.0     |      1.0      |   1.00 ES
+   //    3.0     |      2.0      |   3.00 ES
+   //    3.1     |               |   3.10 ES
+   if (opengl_ver < 300)
+   {
+      glsl_version = 100;
+   }
+   else
+   {
+      glsl_version = 300;
+   }
+#endif
+   std::cerr << "Using GLSL " << glsl_version << std::endl;
+   }
+}
+
+std::string ShaderProgram::formatShader(const std::string& inShader,
+                                        GLenum shaderType)
+{
+   std::string formatted = inShader;
+
+   // replace some identifiers depending on the version of glsl we're using
+   if (glsl_version >= 130)
+   {
+      if (shaderType == GL_VERTEX_SHADER)
+      {
+         formatted = std::regex_replace(formatted, std::regex("attribute"), "in");
+         formatted = std::regex_replace(formatted, std::regex("varying"), "out");
+      }
+
+      else if (shaderType == GL_FRAGMENT_SHADER)
+      {
+         formatted = std::regex_replace(formatted, std::regex("varying"), "in");
+
+         // requires GL_ARB_explicit_attrib_location extension or GLSL 3.30
+         // although gl_FragColor was deprecated in GLSL 1.3
+         for (int i = 0; i < num_outputs; i++)
+         {
+             std::string indexString = "gl_FragData[";
+             indexString += std::to_string(i) + "]";
+             std::string outputString = "out vec4 fragColor_";
+             outputString += std::to_string(i) + ";\n";
+             if (glsl_version > 130 && glsl_version < 330)
+             {
+
+                 formatted = outputString + formatted;
+                 formatted = std::regex_replace(formatted, std::regex(indexString),
+                                                "fragColor");
+             }
+             else if (glsl_version >= 330)
+             {
+                 std::string layoutString = "layout(location = ";
+                 layoutString += std::to_string(i) + ") ";
+                 formatted = layoutString + outputString + formatted;
+             }
+             if (i == 0)
+             {
+                 formatted = std::regex_replace(formatted, std::regex("gl_FragColor"),
+                                                "fragColor_0");
+             }
+         }
+      }
+
+      else
+      {
+         std::cerr << "buildShaderString: unknown shader type" << std::endl;
+         return {};
+      }
+
+      formatted = std::regex_replace(formatted, std::regex("texture2D"), "texture");
+   }
+
+   if (GLDevice::useLegacyTextureFmts())
+   {
+      formatted = "#define USE_ALPHA\n" + formatted;
+   }
+   // add the header
+   formatted = std::regex_replace(GLSL_HEADER, std::regex("GLSL_VER"),
+                                  std::to_string(glsl_version)) + formatted;
+#ifdef __EMSCRIPTEN__
+   // special prepend for WebGL 2 shaders
+   if (glsl_version == 300)
+   {
+      formatted = "#version 300 es\n" + formatted;
+   }
+#endif
+
+   return formatted;
+}
+
+GLuint ShaderProgram::compileShader(const std::string& inShader,
+                                    GLenum shaderType)
+{
+   int shader_len = inShader.length();
+   const char *shader_cstr = inShader.c_str();
+
+   GLuint shader = glCreateShader(shaderType);
+   glShaderSource(shader, 1, &shader_cstr, &shader_len);
+   glCompileShader(shader);
+
+   GLint stat;
+   glGetShaderiv(shader, GL_COMPILE_STATUS, &stat);
+   // glGetObjectParameteriv
+   if (stat == GL_FALSE)
+   {
+      std::cerr << "failed to compile shader" << std::endl;
+      int err_len;
+      glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &err_len);
+      char *error_text = new char[err_len];
+      glGetShaderInfoLog(shader, err_len, &err_len, error_text);
+      std::cerr << error_text << std::endl;
+      delete[] error_text;
+      return 0;
+   }
+   return shader;
+}
+
+bool ShaderProgram::linkShaders(const std::vector<GLuint>& shaders)
+{
+   // Bind all incoming attributes to their VAO indices.
+   for (auto attrib_pair : attrib_idx)
+   {
+       glBindAttribLocation(program_id, attrib_pair.first,
+                            attrib_pair.second.c_str());
+   }
+
+   // Bind fragment output variables to MRT indices.
+   for (int i = 0; i < num_outputs; i++)
+   {
+       std::string fragOutVar = "fragColor_" + std::to_string(i);
+       glBindFragDataLocation(program_id, i, fragOutVar.c_str());
+   }
+
+   for (GLuint i : shaders)
+   {
+      glAttachShader(program_id, i);
+   }
+   glLinkProgram(program_id);
+
+   GLint stat;
+   glGetProgramiv(program_id, GL_LINK_STATUS, &stat);
+   if (stat == GL_FALSE)
+   {
+      cerr << "fatal: Shader linking failed" << endl;
+   }
+   return (stat == GL_TRUE);
+}
+
+void ShaderProgram::mapShaderUniforms()
+{
+   int num_unifs;
+   glGetProgramiv(program_id, GL_ACTIVE_UNIFORMS, &num_unifs);
+   int max_unif_len;
+   glGetProgramiv(program_id, GL_ACTIVE_UNIFORM_MAX_LENGTH, &max_unif_len);
+
+   for (int i = 0; i < num_unifs; i++)
+   {
+      vector<char> unif_buf(max_unif_len+1);
+      GLsizei name_length;
+      GLint gl_size;
+      GLenum gl_type;
+      glGetActiveUniform(program_id, i, max_unif_len, &name_length, &gl_size, &gl_type,
+                         unif_buf.data());
+      std::string unif_name(unif_buf.data(), name_length);
+      GLuint location = glGetUniformLocation(program_id, unif_name.c_str());
+      uniform_idx[unif_name] = location;
+   }
+}
+
+}

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -10,59 +10,59 @@ namespace gl3
 class ShaderProgram
 {
 public:
-    ShaderProgram()
-    {
-        program_id = glCreateProgram();
-        if (program_id == 0)
-        {
-            std::cerr << "Failed to create an OpenGL program object." << std::endl;
-        }
-    }
+   ShaderProgram()
+   {
+      program_id = glCreateProgram();
+      if (program_id == 0)
+      {
+         std::cerr << "Failed to create an OpenGL program object." << std::endl;
+      }
+   }
 
-    bool create(std::string vertexShader,
-                std::string fragmentShader,
-                std::unordered_map<int, std::string> inAttributes,
-                int numOutputs);
+   bool create(std::string vertexShader,
+               std::string fragmentShader,
+               std::unordered_map<int, std::string> inAttributes,
+               int numOutputs);
 
-    bool isCompiled() const { return is_compiled; }
+   bool isCompiled() const { return is_compiled; }
 
-    int uniform(std::string uniformName) const
-    {
-        auto unifId = uniform_idx.find(uniformName);
-        if (unifId != uniform_idx.end())
-        {
-            return unifId->second;
-        }
-        return -1;
-    }
+   int uniform(std::string uniformName) const
+   {
+      auto unifId = uniform_idx.find(uniformName);
+      if (unifId != uniform_idx.end())
+      {
+         return unifId->second;
+      }
+      return -1;
+   }
 
-    std::unordered_map<std::string, GLuint> getUniformMap() const
-    {
-        return uniform_idx;
-    }
+   std::unordered_map<std::string, GLuint> getUniformMap() const
+   {
+      return uniform_idx;
+   }
 
-    GLuint getProgramId() const { return program_id; }
+   GLuint getProgramId() const { return program_id; }
 
-    void bind() const { glUseProgram(program_id); }
+   void bind() const { glUseProgram(program_id); }
 
 private:
 
-    static void GetGLSLVersion();
+   static void GetGLSLVersion();
 
-    std::string formatShader(const std::string& inShader, GLenum shaderType);
-    GLuint compileShader(const std::string& inShader, GLenum shaderType);
-    bool linkShaders(const std::vector<GLuint>& shaders);
-    void mapShaderUniforms();
+   std::string formatShader(const std::string& inShader, GLenum shaderType);
+   GLuint compileShader(const std::string& inShader, GLenum shaderType);
+   bool linkShaders(const std::vector<GLuint>& shaders);
+   void mapShaderUniforms();
 
-    static int glsl_version;
-    std::unordered_map<int, std::string> attrib_idx;
-    int num_outputs = 0;
+   static int glsl_version;
+   std::unordered_map<int, std::string> attrib_idx;
+   int num_outputs = 0;
 
-    ShaderPrgmHandle program_id = 0;
-    ShaderHandle vertex_shader = 0;
-    ShaderHandle fragment_shader = 0;
-    bool is_compiled = false;
-    std::unordered_map<std::string, GLuint> uniform_idx;
+   ShaderPrgmHandle program_id = 0;
+   ShaderHandle vertex_shader = 0;
+   ShaderHandle fragment_shader = 0;
+   bool is_compiled = false;
+   std::unordered_map<std::string, GLuint> uniform_idx;
 };
 
 }

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -1,3 +1,14 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
 #ifndef GLVIS_SHADER_HPP
 #define GLVIS_SHADER_HPP
 
@@ -46,7 +57,6 @@ public:
    void bind() const { glUseProgram(program_id); }
 
 private:
-
    static void GetGLSLVersion();
 
    std::string formatShader(const std::string& inShader, GLenum shaderType);

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -43,10 +43,7 @@ public:
 
     GLuint getProgramId() const { return program_id; }
 
-    void bind()
-    {
-        glUseProgram(program_id);
-    }
+    void bind() const { glUseProgram(program_id); }
 
 private:
 

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -1,0 +1,73 @@
+#ifndef GLVIS_SHADER_HPP
+#define GLVIS_SHADER_HPP
+
+#include "renderer.hpp"
+
+#include <unordered_map>
+
+namespace gl3
+{
+class ShaderProgram
+{
+public:
+    ShaderProgram()
+    {
+        program_id = glCreateProgram();
+        if (program_id == 0)
+        {
+            std::cerr << "Failed to create an OpenGL program object." << std::endl;
+        }
+    }
+
+    bool create(std::string vertexShader,
+                std::string fragmentShader,
+                std::unordered_map<int, std::string> inAttributes,
+                int numOutputs);
+
+    bool isCompiled() const { return is_compiled; }
+
+    int uniform(std::string uniformName) const
+    {
+        auto unifId = uniform_idx.find(uniformName);
+        if (unifId != uniform_idx.end())
+        {
+            return unifId->second;
+        }
+        return -1;
+    }
+
+    std::unordered_map<std::string, GLuint> getUniformMap() const
+    {
+        return uniform_idx;
+    }
+
+    GLuint getProgramId() const { return program_id; }
+
+    void bind()
+    {
+        glUseProgram(program_id);
+    }
+
+private:
+
+    static void GetGLSLVersion();
+
+    std::string formatShader(const std::string& inShader, GLenum shaderType);
+    GLuint compileShader(const std::string& inShader, GLenum shaderType);
+    bool linkShaders(const std::vector<GLuint>& shaders);
+    void mapShaderUniforms();
+
+    static int glsl_version;
+    std::unordered_map<int, std::string> attrib_idx;
+    int num_outputs = 0;
+
+    GLDevice::ShaderPrgmHandle program_id = 0;
+    GLDevice::ShaderHandle vertex_shader = 0;
+    GLDevice::ShaderHandle fragment_shader = 0;
+    bool is_compiled = false;
+    std::unordered_map<std::string, GLuint> uniform_idx;
+};
+
+}
+
+#endif // GLVIS_SHADER_HPP

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -58,9 +58,9 @@ private:
     std::unordered_map<int, std::string> attrib_idx;
     int num_outputs = 0;
 
-    GLDevice::ShaderPrgmHandle program_id = 0;
-    GLDevice::ShaderHandle vertex_shader = 0;
-    GLDevice::ShaderHandle fragment_shader = 0;
+    ShaderPrgmHandle program_id = 0;
+    ShaderHandle vertex_shader = 0;
+    ShaderHandle fragment_shader = 0;
     bool is_compiled = false;
     std::unordered_map<std::string, GLuint> uniform_idx;
 };

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -78,6 +78,11 @@ inline void prgmCleanup(GLuint prgm)
    glDeleteProgram(prgm);
 }
 
+inline void shdrCleanup(GLuint shdr)
+{
+   glDeleteShader(shdr);
+}
+
 inline void vaoCleanup(GLuint vao)
 {
    glDeleteVertexArrays(1, &vao);
@@ -102,6 +107,7 @@ using BufObjHandle = Handle<boCleanup>;
 using DispListHandle = Handle<dspListCleanup>;
 using VtxArrayHandle = Handle<vaoCleanup>;
 using ShaderPrgmHandle = Handle<prgmCleanup>;
+using ShaderHandle = Handle<shdrCleanup>;
 using TextureHandle = Handle<texCleanup>;
 using FBOHandle = Handle<fboCleanup>;
 using RenderBufHandle = Handle<rboCleanup>;

--- a/makefile
+++ b/makefile
@@ -212,11 +212,11 @@ Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 
 # generated with 'echo lib/gl/*.c* lib/*.c*', does not include lib/*.m (Obj-C)
 ALL_SOURCE_FILES = \
- lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp lib/gl/shader.cpp \
- lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp lib/font.cpp lib/gl2ps.c \
- lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/sdl.cpp lib/stream_reader.cpp \
- lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp lib/vssolution3d.cpp \
- lib/vsvector.cpp lib/vsvector3d.cpp
+ lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp \
+ lib/gl/shader.cpp lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp lib/font.cpp \
+ lib/gl2ps.c lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/sdl.cpp \
+ lib/stream_reader.cpp lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp \
+ lib/vssolution3d.cpp lib/vsvector.cpp lib/vsvector3d.cpp
 OBJC_SOURCE_FILES = $(if $(NOTMAC),,lib/sdl_mac.mm)
 DESKTOP_ONLY_SOURCE_FILES = lib/gl/renderer_ff.cpp lib/threads.cpp lib/gl2ps.c
 WEB_ONLY_SOURCE_FILES = lib/aux_js.cpp
@@ -227,13 +227,13 @@ COMMON_SOURCE_FILES = $(filter-out \
 
 # generated with 'echo lib/gl/*.h* lib/*.h*'
 HEADER_FILES = \
- lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp lib/gl/shader.hpp \
- lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp lib/gl/types.hpp \
- lib/aux_vis.hpp lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h lib/logo.hpp lib/material.hpp \
- lib/openglvis.hpp lib/palettes.hpp lib/sdl.hpp lib/sdl_helper.hpp \
- lib/sdl_mac.hpp lib/sdl_x11.hpp lib/stream_reader.hpp lib/threads.hpp lib/visual.hpp \
- lib/vsdata.hpp lib/vssolution.hpp lib/vssolution3d.hpp lib/vsvector.hpp \
- lib/vsvector3d.hpp
+ lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp \
+ lib/gl/shader.hpp lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp \
+ lib/gl/types.hpp lib/aux_vis.hpp lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h \
+ lib/logo.hpp lib/material.hpp lib/openglvis.hpp lib/palettes.hpp lib/sdl.hpp \
+ lib/sdl_helper.hpp lib/sdl_mac.hpp lib/sdl_x11.hpp lib/stream_reader.hpp \
+ lib/threads.hpp lib/visual.hpp lib/vsdata.hpp lib/vssolution.hpp \
+ lib/vssolution3d.hpp lib/vsvector.hpp lib/vsvector3d.hpp
 
 DESKTOP_SOURCE_FILES = $(COMMON_SOURCE_FILES) $(DESKTOP_ONLY_SOURCE_FILES) $(LOGO_FILE_CPP)
 WEB_SOURCE_FILES     = $(COMMON_SOURCE_FILES) $(WEB_ONLY_SOURCE_FILES)

--- a/makefile
+++ b/makefile
@@ -212,7 +212,7 @@ Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 
 # generated with 'echo lib/gl/*.c* lib/*.c*', does not include lib/*.m (Obj-C)
 ALL_SOURCE_FILES = \
- lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp \
+ lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp lib/gl/shader.cpp \
  lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp lib/font.cpp lib/gl2ps.c \
  lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/sdl.cpp lib/stream_reader.cpp \
  lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp lib/vssolution3d.cpp \
@@ -227,7 +227,7 @@ COMMON_SOURCE_FILES = $(filter-out \
 
 # generated with 'echo lib/gl/*.h* lib/*.h*'
 HEADER_FILES = \
- lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp \
+ lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp lib/gl/shader.hpp \
  lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp lib/gl/types.hpp \
  lib/aux_vis.hpp lib/font.hpp lib/gl2ps.h lib/logo.hpp lib/material.hpp \
  lib/openglvis.hpp lib/palettes.hpp lib/sdl.hpp lib/sdl_helper.hpp \


### PR DESCRIPTION
Create a `gl3::ShaderProgram` class to handle creation and binding of shaders, replacing the code in `CoreGLDevice`.

This enables other components in GLVis to use shaders in the future (e.g. order-independent transparency).