### PR TITLE
ProjectVectorFEGridFunction ownership fix

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -93,8 +93,6 @@ int ReadInputStreams(StreamState& state);
 
 void CloseInputStreams(bool);
 
-GridFunction *ProjectVectorFEGridFunction(GridFunction*);
-
 // Visualize the data in the global variables mesh, sol/grid_f, etc
 // 0 - scalar data, 1 - vector data, 2 - mesh only, (-1) - unknown
 bool GLVisInitVis(int field_type)
@@ -210,9 +208,8 @@ bool GLVisInitVis(int field_type)
       {
          if (stream_state.grid_f)
          {
-            GridFunction* proj_grid_f = ProjectVectorFEGridFunction(
-                                           stream_state.grid_f.get());
-            stream_state.grid_f.reset(proj_grid_f);
+            stream_state.grid_f
+               = ProjectVectorFEGridFunction(std::move(stream_state.grid_f));
             vs = new VisualizationSceneVector3d(*stream_state.grid_f);
          }
          else

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -46,5 +46,11 @@ struct StreamState
                               VisualizationScene* vs);
 };
 
+// Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec
+// or Raviart-Thomas space) with a discontinuous piece-wise polynomial Cartesian
+// product vector grid function of the same order.
+std::unique_ptr<mfem::GridFunction>
+ProjectVectorFEGridFunction(std::unique_ptr<mfem::GridFunction> gf);
+
 
 #endif // GLVIS_STREAM_READER_HPP

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -408,8 +408,6 @@ int GLVisCommand::Autopause(const char *mode)
    return 0;
 }
 
-extern GridFunction *ProjectVectorFEGridFunction(GridFunction*);
-
 int GLVisCommand::Execute()
 {
    char c;


### PR DESCRIPTION
`ProjectVectorFEGridFunction` originally handled the deletion of the incoming GridFunction before #153 was merged. Afterwards, however, if the incoming GridFunction was not replaced and the original grid function is returned instead, the subsequent call to `stream_state.grid_f.reset(proj_grid_f)` deletes the original grid function.

In this PR:
- `ProjectVectorFEGridFunction` now explicitly takes ownership of the GridFunction by accepting an `std::unique_ptr<GridFunction>` by-value. It handles freeing the original grid function if a new one was generated.
- Extra declarations/definitions of `ProjectVectorFEGridFunction` were deleted.

Fixes #162.