### PR TITLE
[WIP] Improved transparency with dual depth peeling

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND SOURCES
   gl/renderer_core.cpp
   gl/renderer_msaa.cpp
   gl/renderer_print.cpp
+  gl/depth_peel_oit.cpp
   gl/shader.cpp
   gl/types.cpp
   aux_vis.cpp
@@ -36,6 +37,7 @@ list(APPEND HEADERS
   gl/renderer_core.hpp
   gl/renderer_msaa.hpp
   gl/renderer_print.hpp
+  gl/depth_peel_oit.hpp
   gl/shader.hpp
   gl/types.hpp
   aux_vis.hpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,8 @@
 list(APPEND SOURCES
   gl/renderer.cpp
   gl/renderer_core.cpp
+  gl/renderer_msaa.cpp
+  gl/renderer_print.cpp
   gl/shader.cpp
   gl/types.cpp
   aux_vis.cpp
@@ -32,6 +34,8 @@ list(APPEND HEADERS
   gl/platform_gl.hpp
   gl/renderer.hpp
   gl/renderer_core.hpp
+  gl/renderer_msaa.hpp
+  gl/renderer_print.hpp
   gl/shader.hpp
   gl/types.hpp
   aux_vis.hpp

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -380,7 +380,7 @@ void MyReshape(GLsizei w, GLsizei h)
 void MyExpose(GLsizei w, GLsizei h)
 {
    MyReshape (w, h);
-   bool use_depth_peel = true;
+   bool use_depth_peel = !(locscene->matAlpha == 1.0);
    gl3::DefaultPass rndr_main_pass;
    gl3::DepthPeeler rndr_depth_peeled;
    if (!use_depth_peel)

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -55,6 +55,7 @@ void RightButtonUp   (EventInfo *event);
 
 void TouchPinch(SDL_MultiGestureEvent & e);
 
+void KeyAPressed();
 void KeyCtrlP();
 void KeyS();
 void KeyQPressed();

--- a/lib/gl/attr_traits.hpp
+++ b/lib/gl/attr_traits.hpp
@@ -125,9 +125,9 @@ AttrNormal<TV, decltype((void)TV::norm, 0)>>
    const static GLenum FFArrayIdx = GL_NORMAL_ARRAY;
    static void FFSetupFunc(GLint /*size*/, GLenum type, GLsizei stride,
                            const GLvoid* ptr)
-{
-   glNormalPointer(type, stride, ptr);
-}
+   {
+      glNormalPointer(type, stride, ptr);
+   }
 };
 
 template<typename TV>

--- a/lib/gl/depth_peel_oit.cpp
+++ b/lib/gl/depth_peel_oit.cpp
@@ -289,7 +289,8 @@ void DepthPeeler::PostRender()
 
    finalize_prgm.bind();
    finalize_prgm.setOutputFramebuffer(*target);
-   glClearColor(0, 0, 0, 1);
+   auto clear_color = device->getClearColor();
+   glClearColor(clear_color[0], clear_color[1], clear_color[2], clear_color[3]);
    glClear(GL_COLOR_BUFFER_BIT);
    glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 

--- a/lib/gl/depth_peel_oit.cpp
+++ b/lib/gl/depth_peel_oit.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "depth_peel_oit.hpp"
+#include "renderer_core.hpp"
+#include "shader.hpp"
+
+const std::string DepthPeelVS[2] =
+{
+#include "shaders/default.vert"
+   ,
+#include "shaders/depth_peel_passthrough.vert"
+};
+
+const std::string DepthPeelFS[] =
+{
+#include "shaders/lighting.glsl"
+#include "shaders/depth_peel.frag"
+   ,
+#include "shaders/depth_peel_blend_back.frag"
+   ,
+#include "shaders/depth_peel_finalize.frag"
+};
+
+
+namespace gl3
+{
+
+void DepthPeeler::SetGLDevice(GLDevice* dev)
+{
+   IMainRenderPass::SetGLDevice(dev);
+   {
+      GLuint vbo;
+      glGenBuffers(1, &vbo);
+      rect_buf = BufObjHandle{vbo};
+      float quad_verts[] =
+      {
+         -1.f, 1.f, -1.f, -1.f, 1.f, -1.f,
+            -1.f, 1.f, 1.f, -1.f, 1.f, 1.f,
+         };
+      glBindBuffer(GL_ARRAY_BUFFER, vbo);
+      glBufferData(GL_ARRAY_BUFFER, 12, quad_verts, GL_STATIC_DRAW);
+      glBindBuffer(GL_ARRAY_BUFFER, 0);
+   }
+
+   std::unordered_map<int, std::string> attribMap =
+   {
+      { CoreGLDevice::ATTR_VERTEX, "vertex"},
+      { CoreGLDevice::ATTR_TEXT_VERTEX, "textVertex"},
+      { CoreGLDevice::ATTR_NORMAL, "normal"},
+      { CoreGLDevice::ATTR_COLOR, "color"},
+      { CoreGLDevice::ATTR_TEXCOORD0, "texCoord0"}
+   };
+   if (!main_prgm.create(DepthPeelVS[0], DepthPeelFS[0], attribMap, 3))
+   {
+      std::cerr << "Unable to create depth peeling main program." << std::endl;
+   }
+   if (!blend_prgm.create(DepthPeelVS[1], DepthPeelFS[1], attribMap, 1))
+   {
+      std::cerr << "Unable to create depth peeling blending program." << std::endl;
+   }
+   if (!finalize_prgm.create(DepthPeelVS[1], DepthPeelFS[2], attribMap, 1))
+   {
+      std::cerr << "Unable to create depth peeling blending program." << std::endl;
+   }
+
+   GLint vp[4];
+   device->getViewport(vp);
+   int tex_w = vp[2];
+   int tex_h = vp[3];
+
+   for (int i = 0; i < 2; i++)
+   {
+      glBindFramebuffer(GL_FRAMEBUFFER, main_peel_fbs[i]);
+
+      glBindTexture(GL_TEXTURE_2D, depthTex[i]);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, tex_w, tex_h, 0, GL_RG, GL_FLOAT,
+                   nullptr);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                             depthTex[i], 0);
+
+      glBindTexture(GL_TEXTURE_2D, frontColorTex[i]);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, tex_w, tex_h, 0, GL_RGBA,
+                   GL_HALF_FLOAT, nullptr);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D,
+                             frontColorTex[i], 0);
+
+      glBindTexture(GL_TEXTURE_2D, backColorTex[i]);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, tex_w, tex_h, 0, GL_RGBA,
+                   GL_HALF_FLOAT, nullptr);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT2, GL_TEXTURE_2D,
+                             backColorTex[i], 0);
+
+      glBindFramebuffer(GL_FRAMEBUFFER, color_fbs[i]);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                             frontColorTex[i], 0);
+      glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D,
+                             backColorTex[i], 0);
+   }
+
+   glBindFramebuffer(GL_FRAMEBUFFER, blend_back_fb);
+   glBindTexture(GL_TEXTURE_2D, backBlendTex);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, tex_w, tex_h, 0, GL_RGBA,
+                GL_HALF_FLOAT, nullptr);
+   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                          backBlendTex, 0);
+
+   glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+
+void DepthPeeler::PreRender()
+{
+   // Clear back blend buffer
+   {
+      GLenum blendBufs = GL_COLOR_ATTACHMENT0;
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, blend_back_fb);
+      glDrawBuffers(1, &blendBufs);
+      glClearColor(0, 0, 0, 0);
+      glClear(GL_COLOR_BUFFER_BIT);
+   }
+   for (int i = 0; i < 2; i++)
+   {
+      // Initial depth texture should be set to [-MAX_DEPTH, MAX_DEPTH]
+      GLenum depthBufs = GL_COLOR_ATTACHMENT0;
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, main_peel_fbs[i]);
+      glDrawBuffers(1, &depthBufs);
+      glClearColor(MAX_DEPTH, MAX_DEPTH, 0, 0);
+      glClear(GL_COLOR_BUFFER_BIT);
+
+      GLenum colorBufs[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, color_fbs[i]);
+      glDrawBuffers(2, colorBufs);
+      glClearColor(0, 0, 0, 0);
+      glClear(GL_COLOR_BUFFER_BIT);
+   }
+   device->enableBlend();
+   device->enableDepthWrite();
+}
+
+void DepthPeeler::DoRenderPass(int i, const RenderQueue& queue)
+{
+   int src_i = i % 2;
+   int dst_i = 1 - src_i;
+   // Clear our target buffers for this pass
+   {
+      GLenum depthBufs = GL_COLOR_ATTACHMENT0;
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, main_peel_fbs[dst_i]);
+      glDrawBuffers(1, &depthBufs);
+      glClearColor(MAX_DEPTH, MAX_DEPTH, 0, 0);
+      glClear(GL_COLOR_BUFFER_BIT);
+
+      GLenum colorBufs[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, color_fbs[dst_i]);
+      glDrawBuffers(2, colorBufs);
+      glClearColor(0, 0, 0, 0);
+      glClear(GL_COLOR_BUFFER_BIT);
+   }
+
+   // Setup main peel program and framebuffer
+   dynamic_cast<CoreGLDevice*>(device)->bindExternalProgram(main_prgm);
+   main_prgm.setOutputFramebuffer(main_peel_fbs[dst_i]);
+   glBlendEquation(GL_MAX);
+
+   // Bind source depth and front color texture
+   glActiveTexture(GL_TEXTURE0 + 2);
+   glBindTexture(GL_TEXTURE_2D, depthTex[src_i]);
+
+   glActiveTexture(GL_TEXTURE0 + 3);
+   glBindTexture(GL_TEXTURE_2D, frontColorTex[src_i]);
+
+   glUniform1i(main_prgm.uniform("lastDepthTex"), 2);
+   glUniform1i(main_prgm.uniform("lastFrontColorTex"), 3);
+
+   int color_tex = palette->GetColorTexture();
+   int alpha_tex = palette->GetAlphaTexture();
+   device->enableDepthWrite();
+   // Render the geometry to peel
+   for (auto& geom : queue)
+   {
+      const RenderParams& params = geom.first;
+      device->setTransformMatrices(params.model_view.mtx, params.projection.mtx);
+      device->setMaterial(params.mesh_material);
+      device->setNumLights(params.num_pt_lights);
+      for (int i = 0; i < params.num_pt_lights; i++)
+      {
+         device->setPointLight(i, params.lights[i]);
+      }
+      device->setAmbientLight(params.light_amb_scene);
+      device->setStaticColor(params.static_color);
+      device->setClipPlaneUse(params.use_clip_plane);
+      device->setClipPlaneEqn(params.clip_plane_eqn);
+      // aggregate buffers with common parameters
+      std::vector<int> tex_bufs, no_tex_bufs;
+      GlDrawable* curr_drawable = geom.second;
+      auto buffers = curr_drawable->getArrayBuffers();
+      for (const IVertexBuffer* buf : buffers)
+      {
+         if (buf->getVertexLayout() == LAYOUT_VTX_TEXTURE0
+             || buf->getVertexLayout() == LAYOUT_VTX_NORMAL_TEXTURE0)
+         {
+            tex_bufs.emplace_back(buf->getHandle());
+         }
+         else
+         {
+            no_tex_bufs.emplace_back(buf->getHandle());
+         }
+      }
+      device->attachTexture(GLDevice::SAMPLER_COLOR, color_tex);
+      device->attachTexture(GLDevice::SAMPLER_ALPHA, alpha_tex);
+      for (auto buf : tex_bufs)
+      {
+         device->drawDeviceBuffer(buf);
+      }
+      device->detachTexture(GLDevice::SAMPLER_COLOR);
+      device->detachTexture(GLDevice::SAMPLER_ALPHA);
+      for (auto buf : no_tex_bufs)
+      {
+         device->drawDeviceBuffer(buf);
+      }
+      device->attachTexture(1, font_tex);
+      device->setNumLights(0);
+      device->drawDeviceBuffer(curr_drawable->getTextBuffer());
+   }
+
+   // Blend just-written back layer separately
+   blend_prgm.setOutputFramebuffer(blend_back_fb);
+   blend_prgm.bind();
+   glBlendEquation(GL_FUNC_ADD);
+   glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE,
+                       GL_ONE_MINUS_SRC_ALPHA);
+
+   glActiveTexture(GL_TEXTURE0 + 2);
+   glBindTexture(GL_TEXTURE_2D, backColorTex[dst_i]);
+   glUniform1i(blend_prgm.uniform("lastBackColor"), 2);
+
+   glBindBuffer(GL_ARRAY_BUFFER, rect_buf);
+   glEnableVertexAttribArray(CoreGLDevice::ATTR_VERTEX);
+   glVertexAttribPointer(CoreGLDevice::ATTR_VERTEX,
+                         2, GL_FLOAT, false, 0, 0);
+   glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+void DepthPeeler::PostRender()
+{
+   int src_i = (NUM_PASSES+1) % 2;
+
+   finalize_prgm.setOutputFramebuffer(*target);
+   finalize_prgm.bind();
+   glClearColor(0, 0, 0, 1);
+   glClear(GL_COLOR_BUFFER_BIT);
+   glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+   glActiveTexture(GL_TEXTURE0);
+   glBindTexture(GL_TEXTURE_2D, frontColorTex[src_i]);
+
+   glActiveTexture(GL_TEXTURE0 + 1);
+   glBindTexture(GL_TEXTURE_2D, backBlendTex);
+
+   glUniform1i(finalize_prgm.uniform("lastFrontColor"), 0);
+   glUniform1i(finalize_prgm.uniform("lastBackColor"), 1);
+
+   glBindBuffer(GL_ARRAY_BUFFER, rect_buf);
+   glEnableVertexAttribArray(CoreGLDevice::ATTR_VERTEX);
+   glVertexAttribPointer(CoreGLDevice::ATTR_VERTEX,
+                         2, GL_FLOAT, false, 0, 0);
+   glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+void DepthPeeler::Render(const RenderQueue& queue)
+{
+   for (int i = 0; i < NUM_PASSES; i++)
+   {
+      DoRenderPass(i, queue);
+   }
+}
+
+}
+
+

--- a/lib/gl/depth_peel_oit.cpp
+++ b/lib/gl/depth_peel_oit.cpp
@@ -176,7 +176,6 @@ void DepthPeeler::PreRender()
       glClear(GL_COLOR_BUFFER_BIT);
    }
    device->enableBlend();
-   device->enableDepthWrite();
 }
 
 void DepthPeeler::DoRenderPass(int i, const RenderQueue& queue)
@@ -214,8 +213,6 @@ void DepthPeeler::DoRenderPass(int i, const RenderQueue& queue)
 
    int color_tex = palette->GetColorTexture();
    int alpha_tex = palette->GetAlphaTexture();
-   glDisable(GL_DEPTH_TEST);
-   device->enableBlend();
    glBlendEquation(GL_MAX);
    // Render the geometry to peel
    for (auto& geom : queue)
@@ -308,6 +305,11 @@ void DepthPeeler::PostRender()
    glVertexAttribPointer(CoreGLDevice::ATTR_VERTEX,
                          2, GL_FLOAT, false, 0, 0);
    glDrawArrays(GL_TRIANGLES, 0, 6);
+
+   // Reset to the default program state
+   device->initRenderMode();
+   glBlendEquation(GL_FUNC_ADD);
+   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
 void DepthPeeler::Render(const RenderQueue& queue)

--- a/lib/gl/depth_peel_oit.hpp
+++ b/lib/gl/depth_peel_oit.hpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_DEPTH_PEEL_OIT_HPP
+#define GLVIS_DEPTH_PEEL_OIT_HPP
+
+#include "renderer.hpp"
+#include "shader.hpp"
+
+namespace gl3
+{
+
+class DepthPeeler : public IMainRenderPass
+{
+   virtual void SetGLDevice(GLDevice* device);
+
+   virtual bool Filter(const RenderParams& param)
+   {
+      return true;
+   }
+
+   virtual void PreRender();
+   virtual void Render(const RenderQueue& queue);
+   virtual void PostRender();
+private:
+   const double MAX_DEPTH = 10.0;
+   const int NUM_PASSES = 4;
+
+   void DoRenderPass(int i, const RenderQueue& queue);
+
+   MeshRenderer* renderer;
+
+   ShaderProgram main_prgm;
+   ShaderProgram blend_prgm;
+   ShaderProgram finalize_prgm;
+
+   TextureHandle depthTex[2];
+   TextureHandle frontColorTex[2];
+   TextureHandle backColorTex[2];
+
+   TextureHandle backBlendTex;
+
+   FBOHandle main_peel_fbs[2];
+   FBOHandle color_fbs[2];
+   FBOHandle blend_back_fb;
+
+   // Drawing full-screen rectangles
+   BufObjHandle rect_buf;
+};
+
+}
+
+#endif

--- a/lib/gl/depth_peel_oit.hpp
+++ b/lib/gl/depth_peel_oit.hpp
@@ -34,6 +34,8 @@ private:
    const double MAX_DEPTH = 10.0;
    const int NUM_PASSES = 4;
 
+   void RenderOpaque(const RenderQueue& queue);
+
    void DoRenderPass(int i, const RenderQueue& queue);
 
    MeshRenderer* renderer;
@@ -45,12 +47,14 @@ private:
    TextureHandle depthTex[2];
    TextureHandle frontColorTex[2];
    TextureHandle backColorTex[2];
+   TextureHandle opaqueColorTex, opaqueDepthTex;
 
    TextureHandle backBlendTex;
 
    FBOHandle main_peel_fbs[2];
    FBOHandle color_fbs[2];
    FBOHandle blend_back_fb;
+   FBOHandle opaque_fb;
 
    // Drawing full-screen rectangles
    BufObjHandle rect_buf;

--- a/lib/gl/renderer.cpp
+++ b/lib/gl/renderer.cpp
@@ -55,6 +55,8 @@ void GLDevice::attachFramebuffer(const FBOHandle& fbo)
 
 void DefaultPass::Render(const RenderQueue& queue)
 {
+   auto clear_color = device->getClearColor();
+   glClearColor(clear_color[0], clear_color[1], clear_color[2], clear_color[3]);
    // elements containing opaque objects should be rendered first
    RenderQueue sorted_queue = queue;
    std::stable_partition(sorted_queue.begin(), sorted_queue.end(),

--- a/lib/gl/renderer.cpp
+++ b/lib/gl/renderer.cpp
@@ -42,71 +42,7 @@ bool GLDevice::useLegacyTextureFmts()
 #endif
 }
 
-void MeshRenderer::setAntialiasing(bool aa_status)
-{
-   if (msaa_enable != aa_status)
-   {
-      msaa_enable = aa_status;
-      if (msaa_enable)
-      {
-         if (!feat_use_fbo_antialias)
-         {
-            glEnable(GL_MULTISAMPLE);
-            glEnable(GL_LINE_SMOOTH);
-            device->enableBlend();
-         }
-         device->setLineWidth(line_w_aa);
-      }
-      else
-      {
-         if (!feat_use_fbo_antialias)
-         {
-            glDisable(GL_MULTISAMPLE);
-            glDisable(GL_LINE_SMOOTH);
-            device->disableBlend();
-         }
-         device->setLineWidth(line_w);
-      }
-   }
-}
-
-void MeshRenderer::setLineWidth(float w)
-{
-   line_w = w;
-   if (device && !msaa_enable)
-   {
-      device->setLineWidth(line_w);
-   }
-}
-
-void MeshRenderer::setLineWidthMS(float w)
-{
-   line_w_aa = w;
-   if (device && msaa_enable)
-   {
-      device->setLineWidth(line_w_aa);
-   }
-}
-
-void MeshRenderer::init()
-{
-#ifdef __EMSCRIPTEN__
-   const std::string versionString
-      = reinterpret_cast<const char*>(glGetString(GL_VERSION));
-   bool is_webgl2 = (versionString.find("OpenGL ES 3.0") != std::string::npos);
-   feat_use_fbo_antialias = is_webgl2;
-   if (feat_use_fbo_antialias)
-   {
-      glGetIntegerv(GL_MAX_SAMPLES, &msaa_samples);
-   }
-#else
-   // TODO: we could also support ARB_framebuffer_object
-   feat_use_fbo_antialias = GLEW_VERSION_3_0;
-   glGetIntegerv(GL_MAX_SAMPLES, &msaa_samples);
-#endif
-}
-
-void MeshRenderer::render(const RenderQueue& queue)
+void DefaultPass::Render(const RenderQueue& queue)
 {
    // elements containing opaque objects should be rendered first
    RenderQueue sorted_queue = queue;
@@ -115,52 +51,10 @@ void MeshRenderer::render(const RenderQueue& queue)
    {
       return !renderPair.first.contains_translucent;
    });
-   RenderBufHandle renderBufs[2];
-   FBOHandle msaaFb;
-   if (feat_use_fbo_antialias && msaa_enable)
-   {
-      GLuint colorBuf, depthBuf;
-      glGenRenderbuffers(1, &colorBuf);
-      glGenRenderbuffers(1, &depthBuf);
-      renderBufs[0] = RenderBufHandle(colorBuf);
-      renderBufs[1] = RenderBufHandle(depthBuf);
-
-      GLuint fbo;
-      glGenFramebuffers(1, &fbo);
-
-      int vp[4];
-      device->getViewport(vp);
-      int width = vp[2];
-      int height = vp[3];
-      glBindRenderbuffer(GL_RENDERBUFFER, colorBuf);
-      glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_samples,
-                                       GL_RGBA8, width, height);
-      glBindRenderbuffer(GL_RENDERBUFFER, depthBuf);
-      glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_samples,
-                                       GL_DEPTH_COMPONENT24, width, height);
-      glBindRenderbuffer(GL_RENDERBUFFER, 0);
-
-      glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                GL_RENDERBUFFER, colorBuf);
-      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
-                                GL_RENDERBUFFER, depthBuf);
-
-      if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-      {
-         cerr << "Unable to create multisampled renderbuffer." << flush;
-         glDeleteFramebuffers(1, &fbo);
-         glBindFramebuffer(GL_FRAMEBUFFER, 0);
-      }
-      else
-      {
-         msaaFb = FBOHandle(fbo);
-      }
-#ifndef __EMSCRIPTEN__
-      glEnable(GL_MULTISAMPLE);
-#endif
-   }
    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+   int color_tex = palette->GetColorTexture();
+   int alpha_tex = palette->GetAlphaTexture();
+   bool always_blend = device->isBlendEnabled();
    for (auto& q_elem : sorted_queue)
    {
       const RenderParams& params = q_elem.first;
@@ -177,38 +71,20 @@ void MeshRenderer::render(const RenderQueue& queue)
       device->setClipPlaneEqn(params.clip_plane_eqn);
       // aggregate buffers with common parameters
       std::vector<int> tex_bufs, no_tex_bufs;
-      std::vector<TextBuffer*> text_bufs;
       GlDrawable* curr_drawable = q_elem.second;
-      for (int i = 0; i < NUM_LAYOUTS; i++)
+      auto buffers = curr_drawable->getArrayBuffers();
+      for (const IVertexBuffer* buf : buffers)
       {
-         for (size_t j = 0; j < GlDrawable::NUM_SHAPES; j++)
+         if (buf->getVertexLayout() == LAYOUT_VTX_TEXTURE0
+             || buf->getVertexLayout() == LAYOUT_VTX_NORMAL_TEXTURE0)
          {
-            if (curr_drawable->buffers[i][j])
-            {
-               if (i == LAYOUT_VTX_TEXTURE0 || i == LAYOUT_VTX_NORMAL_TEXTURE0)
-               {
-                  tex_bufs.emplace_back(curr_drawable->buffers[i][j].get()->getHandle());
-               }
-               else
-               {
-                  no_tex_bufs.emplace_back(curr_drawable->buffers[i][j].get()->getHandle());
-               }
-            }
-            if (curr_drawable->indexed_buffers[i][j])
-            {
-               if (i == LAYOUT_VTX_TEXTURE0 || i == LAYOUT_VTX_NORMAL_TEXTURE0)
-               {
-                  tex_bufs.emplace_back(curr_drawable->indexed_buffers[i][j].get()->getHandle());
-               }
-               else
-               {
-                  no_tex_bufs.emplace_back(
-                     curr_drawable->indexed_buffers[i][j].get()->getHandle());
-               }
-            }
+            tex_bufs.emplace_back(buf->getHandle());
+         }
+         else
+         {
+            no_tex_bufs.emplace_back(buf->getHandle());
          }
       }
-      text_bufs.emplace_back(&curr_drawable->text_buffer);
       if (params.contains_translucent)
       {
          device->enableBlend();
@@ -236,162 +112,79 @@ void MeshRenderer::render(const RenderQueue& queue)
       }
       device->attachTexture(1, font_tex);
       device->setNumLights(0);
-      for (TextBuffer* buf : text_bufs)
-      {
-         device->drawDeviceBuffer(*buf);
-      }
+      device->drawDeviceBuffer(curr_drawable->getTextBuffer());
       device->enableDepthWrite();
-      if (feat_use_fbo_antialias || !msaa_enable) { device->disableBlend(); }
-   }
-   if (feat_use_fbo_antialias && msaa_enable && msaaFb)
-   {
-      device->enableBlend();
-      int vp[4];
-      device->getViewport(vp);
-      int width = vp[2];
-      int height = vp[3];
-      GLuint colorBufId;
-      glGenRenderbuffers(1, &colorBufId);
-      RenderBufHandle colorBuf(colorBufId);
-
-      GLuint fboId;
-      glGenFramebuffers(1, &fboId);
-      FBOHandle resolveFb(fboId);
-
-      glBindRenderbuffer(GL_RENDERBUFFER, colorBuf);
-      glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
-      glBindRenderbuffer(GL_RENDERBUFFER, 0);
-
-      glBindFramebuffer(GL_FRAMEBUFFER, resolveFb);
-      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                                GL_RENDERBUFFER, colorBuf);
-
-      if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-      {
-         cerr << "Unable to create resolve renderbuffer." << endl;
-         glBindFramebuffer(GL_FRAMEBUFFER, 0);
-      }
-
-      // bind our draw framebuffer and blit the multisampled image
-      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolveFb);
-      glBindFramebuffer(GL_READ_FRAMEBUFFER, msaaFb);
-      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-      glBlitFramebuffer(0, 0, width, height,
-                        0, 0, width, height,
-                        GL_COLOR_BUFFER_BIT,
-                        GL_NEAREST);
-#ifndef __EMSCRIPTEN__
-      glDisable(GL_MULTISAMPLE);
-#endif
-      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-      glBindFramebuffer(GL_READ_FRAMEBUFFER, resolveFb);
-      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-      glBlitFramebuffer(0, 0, width, height,
-                        0, 0, width, height,
-                        GL_COLOR_BUFFER_BIT,
-                        GL_LINEAR);
-      device->disableBlend();
+      if (!always_blend) { device->disableBlend(); }
    }
 }
 
-CaptureBuffer MeshRenderer::capture(const RenderQueue& queue)
+void MeshRenderer::render(const vector<IMainRenderPass*>& main_passes,
+                          const vector<IRenderPass*>& extra_passes,
+                          const RenderQueue& queued)
 {
-   CaptureBuffer cbuf;
-   device->initXfbMode();
-   for (auto& q_elem : queue)
+   for (IMainRenderPass* pass : main_passes)
    {
-      const RenderParams& params = q_elem.first;
-      device->setTransformMatrices(params.model_view.mtx, params.projection.mtx);
-      device->setMaterial(params.mesh_material);
-      device->setNumLights(params.num_pt_lights);
-      for (int i = 0; i < params.num_pt_lights; i++)
+      pass->SetGLDevice(device.get());
+   }
+   for (IRenderPass* pass : extra_passes)
+   {
+      pass->SetGLDevice(device.get());
+   }
+   // Step 1: Match renderables in the queue with the *first* render pass that
+   //         can handle them.
+   std::vector<RenderQueue> matched_queues(main_passes.size());
+   for (auto drawable : queued)
+   {
+      for (int ipass = 0; ipass < main_passes.size(); ipass++)
       {
-         device->setPointLight(i, params.lights[i]);
-      }
-      device->setAmbientLight(params.light_amb_scene);
-      device->setStaticColor(params.static_color);
-      device->setClipPlaneUse(params.use_clip_plane);
-      device->setClipPlaneEqn(params.clip_plane_eqn);
-      // aggregate buffers with common parameters
-      std::vector<int> tex_bufs, no_tex_bufs;
-      std::vector<TextBuffer*> text_bufs;
-      GlDrawable* curr_drawable = q_elem.second;
-      for (int i = 0; i < NUM_LAYOUTS; i++)
-      {
-         for (size_t j = 0; j < GlDrawable::NUM_SHAPES; j++)
+         if (main_passes[ipass]->Filter(drawable.first))
          {
-            if (curr_drawable->buffers[i][j])
-            {
-               if (i == LAYOUT_VTX_TEXTURE0 || i == LAYOUT_VTX_NORMAL_TEXTURE0)
-               {
-                  tex_bufs.emplace_back(curr_drawable->buffers[i][j].get()->getHandle());
-               }
-               else
-               {
-                  no_tex_bufs.emplace_back(curr_drawable->buffers[i][j].get()->getHandle());
-               }
-            }
-            if (curr_drawable->indexed_buffers[i][j])
-            {
-               if (i == LAYOUT_VTX_TEXTURE0 || i == LAYOUT_VTX_NORMAL_TEXTURE0)
-               {
-                  tex_bufs.emplace_back(curr_drawable->indexed_buffers[i][j].get()->getHandle());
-               }
-               else
-               {
-                  no_tex_bufs.emplace_back(
-                     curr_drawable->indexed_buffers[i][j].get()->getHandle());
-               }
-            }
+            matched_queues[ipass].emplace_back(drawable);
+            break;
          }
       }
-      text_bufs.emplace_back(&curr_drawable->text_buffer);
-
-      device->attachTexture(GLDevice::SAMPLER_COLOR, color_tex);
-      device->attachTexture(GLDevice::SAMPLER_ALPHA, alpha_tex);
-      for (auto buf : tex_bufs)
-      {
-         device->captureXfbBuffer(*pal, cbuf, buf);
-      }
-      device->detachTexture(GLDevice::SAMPLER_COLOR);
-      device->detachTexture(GLDevice::SAMPLER_ALPHA);
-      for (auto buf : no_tex_bufs)
-      {
-         device->captureXfbBuffer(*pal, cbuf, buf);
-      }
-      if (!params.contains_translucent)
-      {
-         device->enableBlend();
-         device->disableDepthWrite();
-      }
-      device->attachTexture(1, font_tex);
-      device->setNumLights(0);
-      for (TextBuffer* buf : text_bufs)
-      {
-         device->captureXfbBuffer(cbuf, *buf);
-      }
    }
-   device->exitXfbMode();
-   return cbuf;
+   // Step 2: Setup the framebuffer with the first extra pass, and render the
+   //         queue with the main passes.
+   if (extra_passes.size() > 0)
+   {
+      extra_passes[0]->PreRender();
+   }
+   for (int ipass = 0; ipass < main_passes.size(); ipass++)
+   {
+      main_passes[ipass]->PreRender();
+      main_passes[ipass]->Render(matched_queues[ipass]);
+      main_passes[ipass]->PostRender();
+   }
+
+   if (extra_passes.size() > 0)
+   {
+      for (int ipass = 1; ipass < extra_passes.size(); ipass++)
+      {
+         // Finalize last stage's results onto next stage
+         extra_passes[ipass]->PreRender();
+         extra_passes[ipass-1]->PostRender();
+      }
+      extra_passes[extra_passes.size() - 1]->PostRender();
+   }
 }
 
 void MeshRenderer::buffer(GlDrawable* buf)
 {
-   for (int i = 0; i < NUM_LAYOUTS; i++)
+   auto buffers = buf->getArrayBuffers();
+   for (IVertexBuffer* buf : buffers)
    {
-      for (size_t j = 0; j < GlDrawable::NUM_SHAPES; j++)
+      IIndexedBuffer* ibuf = dynamic_cast<IIndexedBuffer*>(buf);
+      if (ibuf)
       {
-         if (buf->buffers[i][j])
-         {
-            device->bufferToDevice((array_layout) i, *(buf->buffers[i][j].get()));
-         }
-         if (buf->indexed_buffers[i][j])
-         {
-            device->bufferToDevice((array_layout) i, *(buf->indexed_buffers[i][j].get()));
-         }
+         device->bufferToDevice(buf->getVertexLayout(), *ibuf);
+      }
+      else
+      {
+         device->bufferToDevice(buf->getVertexLayout(), *buf);
       }
    }
-   device->bufferToDevice(buf->text_buffer);
+   device->bufferToDevice(buf->getTextBuffer());
 }
 
 void GLDevice::init()
@@ -439,20 +232,6 @@ void GLDevice::setTransformMatrices(glm::mat4 model_view, glm::mat4 projection)
 {
    model_view_mtx = model_view;
    proj_mtx = projection;
-}
-
-void GLDevice::captureXfbBuffer(CaptureBuffer& capture, const TextBuffer& t_buf)
-{
-   for (const auto& entry : t_buf)
-   {
-      glm::vec3 raster = glm::project(
-                            glm::vec3(entry.rx, entry.ry, entry.rz),
-                            model_view_mtx,
-                            proj_mtx,
-                            glm::vec4(0, 0, vp_width, vp_height));
-      capture.text.emplace_back(raster, glm::make_vec4(static_color.data()),
-                                entry.text);
-   }
 }
 
 }

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -105,6 +105,8 @@ public:
       glBindTexture(GL_TEXTURE_2D, tex_id);
    };
 
+   void attachFramebuffer(const FBOHandle& fbo);
+
    // If true, use unsized internal formats and GL_ALPHA for single-channel
    // data. Otherwise, use the newer sized internal formats and GL_RED.
    static bool useLegacyTextureFmts();
@@ -175,8 +177,15 @@ public:
    virtual void SetGLDevice(GLDevice* dev) { device = dev; }
    virtual void PreRender() = 0;
    virtual void PostRender() = 0;
+
+   virtual const FBOHandle& GetSourceFramebuffer() const
+   { return default_target; }
+
+   virtual void SetTargetFramebuffer(const FBOHandle& fbo) { target = &fbo; }
 protected:
    GLDevice* device;
+   const FBOHandle* target = nullptr;
+   const FBOHandle default_target{0};
 };
 
 // Generic interface for an action on a queue of renderable objects.

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -75,6 +75,7 @@ protected:
    glm::mat4 proj_mtx;
 
    std::array<float, 4> static_color;
+   std::array<float, 4> clear_color { 1.f, 1.f, 1.f, 1.f };
 
    bool blend_enabled = false;
 
@@ -126,6 +127,10 @@ public:
    void getViewport(GLint (&vp)[4]);
    // Set the color to use, if a color attribute is not provided.
    void setStaticColor(const std::array<float, 4>& rgba) { static_color = rgba; }
+   // Set the background clear color to use.
+   void setClearColor(const std::array<float, 4>& rgba) { clear_color = rgba; }
+   // Gets the current background color.
+   std::array<float, 4> getClearColor() const { return clear_color; }
 
    // === Render pipeline functions ===
 
@@ -249,7 +254,8 @@ public:
    }
    float GetLineWidth() { return line_w; }
 
-   void setClearColor(float r, float g, float b, float a) { glClearColor(r, g, b, a); }
+   void setClearColor(float r, float g, float b, float a)
+   { device->setClearColor({r,g,b,a}); }
    void setViewport(GLsizei w, GLsizei h) { device->setViewport(w, h); }
 
    void render(const std::vector<IMainRenderPass*>& main_passes,

--- a/lib/gl/renderer.hpp
+++ b/lib/gl/renderer.hpp
@@ -165,7 +165,7 @@ public:
    // Initializes state needed for transform feedback.
    virtual void initXfbMode() {}
    // Prepares state when exiting transform feedback.
-   virtual void exitXfbMode() {}
+   virtual void initRenderMode() {}
    // Capture the next drawn vertex buffer to a feedback buffer instead of
    // drawing to screen.
    virtual void captureXfbBuffer(PaletteState& pal, CaptureBuffer& capture,

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -147,14 +147,17 @@ void CoreGLDevice::initializeShaderState(const ShaderProgram& prog)
       }
    }
 #ifdef GLVIS_DEBUG
-   unordered_set<string> expectedUnifs(unif_list.begin(), unif_list.end());
-   for (const auto& pairunif : uniforms)
+   if (prog == default_prgm)
    {
-      if (expectedUnifs.find(pairunif.first) == expectedUnifs.end())
+      unordered_set<string> expectedUnifs(unif_list.begin(), unif_list.end());
+      for (const auto& pairunif : uniforms)
       {
-         std::cerr << "Warning: unexpected uniform \""
-                   << pairunif.first
-                   << "\" found in shader." << std::endl;
+         if (expectedUnifs.find(pairunif.first) == expectedUnifs.end())
+         {
+            std::cerr << "Warning: unexpected uniform \""
+                      << pairunif.first
+                      << "\" found in shader." << std::endl;
+         }
       }
    }
 #endif

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -11,6 +11,7 @@
 
 #include "attr_traits.hpp"
 #include "renderer_core.hpp"
+#include "renderer_print.hpp"
 #include "../aux_vis.hpp"
 
 #include <regex>
@@ -244,7 +245,7 @@ void CoreGLDevice::setClipPlaneEqn(const std::array<double, 4> &eqn)
    glUniform4fv(uniforms["clipPlane"], 1, glm::value_ptr(clip_plane));
 }
 
-void CoreGLDevice::bufferToDevice(array_layout layout, IVertexBuffer &buf)
+void CoreGLDevice::bufferToDevice(ArrayLayout layout, IVertexBuffer &buf)
 {
    if (buf.getHandle() == 0)
    {
@@ -264,7 +265,7 @@ void CoreGLDevice::bufferToDevice(array_layout layout, IVertexBuffer &buf)
                 buf.getData(), GL_STATIC_DRAW);
 }
 
-void CoreGLDevice::bufferToDevice(array_layout layout, IIndexedBuffer& buf)
+void CoreGLDevice::bufferToDevice(ArrayLayout layout, IIndexedBuffer& buf)
 {
    if (buf.getHandle() == 0)
    {

--- a/lib/gl/renderer_core.hpp
+++ b/lib/gl/renderer_core.hpp
@@ -56,7 +56,7 @@ private:
       BufObjHandle elem_buf;
       GLenum shape;
       size_t count;
-      array_layout layout;
+      ArrayLayout layout;
    };
 
    std::vector<VBOData> vbos;
@@ -90,8 +90,8 @@ public:
    void setClipPlaneUse(bool enable) override;
    void setClipPlaneEqn(const std::array<double, 4>& eqn) override;
 
-   void bufferToDevice(array_layout layout, IVertexBuffer& buf) override;
-   void bufferToDevice(array_layout layout, IIndexedBuffer& buf) override;
+   void bufferToDevice(ArrayLayout layout, IVertexBuffer& buf) override;
+   void bufferToDevice(ArrayLayout layout, IIndexedBuffer& buf) override;
    void bufferToDevice(TextBuffer& t_buf) override;
    void drawDeviceBuffer(int hnd) override;
    void drawDeviceBuffer(const TextBuffer& t_buf) override;

--- a/lib/gl/renderer_core.hpp
+++ b/lib/gl/renderer_core.hpp
@@ -102,7 +102,7 @@ public:
       initializeShaderState(feedback_prgm);
       glEnable(GL_RASTERIZER_DISCARD);
    }
-   void exitXfbMode() override
+   void initRenderMode() override
    {
       glDisable(GL_RASTERIZER_DISCARD);
       initializeShaderState(default_prgm);

--- a/lib/gl/renderer_ff.cpp
+++ b/lib/gl/renderer_ff.cpp
@@ -157,7 +157,7 @@ void FFGLDevice::setClipPlaneEqn(const std::array<double, 4>& eqn)
    glClipPlane(GL_CLIP_PLANE0, eqn.data());
 }
 
-void FFGLDevice::bufferToDevice(array_layout layout, IVertexBuffer& buf)
+void FFGLDevice::bufferToDevice(ArrayLayout layout, IVertexBuffer& buf)
 {
    if (buf.getHandle() == 0)
    {
@@ -196,7 +196,7 @@ void FFGLDevice::bufferToDevice(array_layout layout, IVertexBuffer& buf)
    }
 }
 
-void FFGLDevice::bufferToDevice(array_layout layout, IIndexedBuffer& buf)
+void FFGLDevice::bufferToDevice(ArrayLayout layout, IIndexedBuffer& buf)
 {
    if (buf.getHandle() == 0)
    {
@@ -324,138 +324,6 @@ void FFGLDevice::drawDeviceBuffer(const TextBuffer& buf)
    }
    glMatrixMode(GL_MODELVIEW);
    glPopMatrix();
-}
-
-void FFGLDevice::captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf,
-                                  int hnd)
-{
-   if (hnd == 0) { return; }
-   if (disp_lists[hnd].count == 0) { return; }
-   GLenum fbType;
-   int fbStride;
-   if (disp_lists[hnd].layout == VertexTex::layout
-       || disp_lists[hnd].layout == VertexNormTex::layout)
-   {
-      //capture texture values too
-      // [ X Y Z ] [ R G B A ] [ U V - - ]
-      fbType = GL_3D_COLOR_TEXTURE;
-      fbStride = 11;
-   }
-   else
-   {
-      // only capture pos and color
-      // [ X Y Z ] [ R G B A ]
-      fbType = GL_3D_COLOR;
-      fbStride = 7;
-   }
-   // compute feedback buffer size
-   int sizebuf = 0;
-   if (disp_lists[hnd].shape == GL_LINES)
-   {
-      // for each line: LINE_TOKEN [Vtx] [Vtx]
-      sizebuf = (disp_lists[hnd].count / 2) + disp_lists[hnd].count * fbStride;
-   }
-   else if (disp_lists[hnd].shape == GL_TRIANGLES)
-   {
-      // for each tri: POLY_TOKEN 3 [Vtx] [Vtx] [Vtx]
-      // NOTE: when clip plane is enabled, we might get two triangles
-      // or a quad for an input triangle. However, the other clipped
-      // triangles get discarded, so this *should* be enough space.
-      sizebuf = (disp_lists[hnd].count / 3) * (2 + fbStride * 4);
-   }
-   else
-   {
-      std::cerr << "Warning: unhandled primitive type in FFPrinter::preDraw()" <<
-                std::endl;
-      return;
-   }
-   // allocate feedback buffer
-   vector<float> xfb_buf;
-   xfb_buf.resize(sizebuf);
-   glFeedbackBuffer(sizebuf, fbType, xfb_buf.data());
-   // draw with feedback capture
-   glRenderMode(GL_FEEDBACK);
-   drawDeviceBuffer(hnd);
-#ifndef GLVIS_DEBUG
-   glRenderMode(GL_RENDER);
-#else
-   if (glRenderMode(GL_RENDER) < 0)
-   {
-      std::cerr << "Warning: feedback data exceeded available buffer size" <<
-                std::endl;
-   }
-#endif
-   size_t tok_idx = 0;
-   // process feedback buffer
-   while (tok_idx < xfb_buf.size())
-   {
-      switch ((GLuint)xfb_buf[tok_idx])
-      {
-         case GL_LINE_TOKEN:
-         case GL_LINE_RESET_TOKEN:
-         {
-            tok_idx++;
-            glm::vec3 coord0 = glm::make_vec3(&xfb_buf[tok_idx]),
-                      coord1 = glm::make_vec3(&xfb_buf[tok_idx + fbStride]);
-            glm::vec4 color0 = glm::make_vec4(&xfb_buf[tok_idx + 3]),
-                      color1 = glm::make_vec4(&xfb_buf[tok_idx + 3 + fbStride]);
-            if (fbStride == 11)
-            {
-               // get texture
-               pal.GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
-               pal.GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
-            }
-            cbuf.lines.emplace_back(coord0, color0);
-            cbuf.lines.emplace_back(coord1, color1);
-            tok_idx += fbStride * 2;
-         }
-         break;
-         case GL_POLYGON_TOKEN:
-         {
-            int n = xfb_buf[tok_idx + 1];
-            tok_idx += 2;
-            // get vertex 0, 1
-            glm::vec3 coord0 = glm::make_vec3(&xfb_buf[tok_idx]),
-                      coord1 = glm::make_vec3(&xfb_buf[tok_idx + fbStride]);
-            glm::vec4 color0 = glm::make_vec4(&xfb_buf[tok_idx + 3]),
-                      color1 = glm::make_vec4(&xfb_buf[tok_idx + 3 + fbStride]);
-            if (fbStride == 11)
-            {
-               // get texture
-               pal.GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
-               pal.GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
-            }
-            // decompose polygon into n-2 triangles [0 1 2] [0 2 3] ...
-            for (int i = 0; i < n-2; i++)
-            {
-               // get last vertex of current triangle
-               int vtxStart = fbStride * (2 + 3*i);
-               glm::vec3 coord2 = glm::make_vec3(&xfb_buf[tok_idx + vtxStart]);
-               glm::vec4 color2 = glm::make_vec4(&xfb_buf[tok_idx + 3 + vtxStart]);
-               if (fbStride == 11)
-               {
-                  pal.GetColorFromVal(xfb_buf[tok_idx + 7 + vtxStart], glm::value_ptr(color2));
-               }
-               cbuf.triangles.emplace_back(coord0, color0);
-               cbuf.triangles.emplace_back(coord1, color1);
-               cbuf.triangles.emplace_back(coord2, color2);
-               // last vertex becomes second vertex of next triangle
-               coord1 = coord2;
-               color1 = color2;
-            }
-            tok_idx += n * fbStride;
-         }
-         break;
-         case GL_POINT_TOKEN:
-         case GL_BITMAP_TOKEN:
-         case GL_DRAW_PIXEL_TOKEN:
-         case GL_COPY_PIXEL_TOKEN:
-         default:
-            // commands containing the token + a single vertex ignore for now
-            tok_idx += 1 + fbStride;
-            break;
-      }
-   }
 }
 
 }

--- a/lib/gl/renderer_ff.hpp
+++ b/lib/gl/renderer_ff.hpp
@@ -26,7 +26,7 @@ class FFGLDevice : public GLDevice
       DispListHandle list;
       GLenum shape;
       size_t count;
-      array_layout layout;
+      ArrayLayout layout;
    };
    std::vector<DispListData_> disp_lists;
 
@@ -52,8 +52,8 @@ public:
    void setClipPlaneUse(bool enable) override;
    void setClipPlaneEqn(const std::array<double, 4>& eqn) override;
 
-   void bufferToDevice(array_layout layout, IVertexBuffer& buf) override;
-   void bufferToDevice(array_layout layout, IIndexedBuffer& buf) override;
+   void bufferToDevice(ArrayLayout layout, IVertexBuffer& buf) override;
+   void bufferToDevice(ArrayLayout layout, IIndexedBuffer& buf) override;
    void bufferToDevice(TextBuffer& t_buf) override;
    void drawDeviceBuffer(int hnd) override;
    void drawDeviceBuffer(const TextBuffer& t_buf) override;

--- a/lib/gl/renderer_msaa.cpp
+++ b/lib/gl/renderer_msaa.cpp
@@ -147,7 +147,7 @@ void MultisamplePass::PostRender()
 #ifndef __EMSCRIPTEN__
       glDisable(GL_MULTISAMPLE);
 #endif
-      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, *target);
       glBindFramebuffer(GL_READ_FRAMEBUFFER, resolveFb);
       glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
       glBlitFramebuffer(0, 0, width, height,

--- a/lib/gl/renderer_msaa.cpp
+++ b/lib/gl/renderer_msaa.cpp
@@ -1,0 +1,190 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "renderer_msaa.hpp"
+
+namespace gl3
+{
+
+void MultisamplePass::SetGLDevice(GLDevice* dev)
+{
+   IRenderPass::SetGLDevice(dev);
+   int max_msaa_samples;
+#ifdef __EMSCRIPTEN__
+   const std::string versionString
+      = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+   bool is_webgl2 = (versionString.find("OpenGL ES 3.0") != std::string::npos);
+   feat_use_fbo_antialias = is_webgl2;
+   if (feat_use_fbo_antialias)
+   {
+      glGetIntegerv(GL_MAX_SAMPLES, &max_msaa_samples);
+   }
+#else
+   // TODO: we could also support ARB_framebuffer_object
+   feat_use_fbo_antialias = GLEW_VERSION_3_0;
+   glGetIntegerv(GL_MAX_SAMPLES, &max_msaa_samples);
+#endif
+   if (msaa_samples > max_msaa_samples)
+   {
+      std::cerr << "GL_MAX_SAMPLES = " << max_msaa_samples
+                << " but requested " << msaa_samples << "x MSAA. ";
+      std::cerr << "Setting antialiasing mode to "
+                << max_msaa_samples << "x MSAA." << endl;
+      msaa_samples = max_msaa_samples;
+   }
+   if (feat_use_fbo_antialias)
+   {
+      GLuint colorBuf, depthBuf;
+      glGenRenderbuffers(1, &colorBuf);
+      glGenRenderbuffers(1, &depthBuf);
+      renderBufs[0] = RenderBufHandle(colorBuf);
+      renderBufs[1] = RenderBufHandle(depthBuf);
+
+      GLuint fbo;
+      glGenFramebuffers(1, &fbo);
+
+      int vp[4];
+      device->getViewport(vp);
+      int width = vp[2];
+      int height = vp[3];
+      glBindRenderbuffer(GL_RENDERBUFFER, colorBuf);
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_samples,
+                                       GL_RGBA8, width, height);
+      glBindRenderbuffer(GL_RENDERBUFFER, depthBuf);
+      glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa_samples,
+                                       GL_DEPTH_COMPONENT24, width, height);
+      glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+      glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                GL_RENDERBUFFER, colorBuf);
+      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+                                GL_RENDERBUFFER, depthBuf);
+
+      if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+      {
+         cerr << "Unable to create multisampled renderbuffer." << flush;
+         glDeleteFramebuffers(1, &fbo);
+      }
+      else
+      {
+         msaaFb = FBOHandle(fbo);
+      }
+      glBindFramebuffer(GL_FRAMEBUFFER, 0);
+   }
+}
+
+void MultisamplePass::PreRender()
+{
+   if (msaa_enable)
+   {
+      if (feat_use_fbo_antialias)
+      {
+         glBindFramebuffer(GL_FRAMEBUFFER, msaaFb);
+      }
+      else
+      {
+         glEnable(GL_LINE_SMOOTH);
+         device->enableBlend();
+      }
+#ifndef __EMSCRIPTEN__
+      glEnable(GL_MULTISAMPLE);
+#endif
+      device->setLineWidth(line_w_aa);
+   }
+   else
+   {
+      device->setLineWidth(line_w);
+   }
+}
+
+void MultisamplePass::PostRender()
+{
+   if (msaa_enable && feat_use_fbo_antialias && msaaFb)
+   {
+      int vp[4];
+      device->getViewport(vp);
+      int width = vp[2];
+      int height = vp[3];
+      GLuint colorBufId;
+      glGenRenderbuffers(1, &colorBufId);
+      RenderBufHandle colorBuf(colorBufId);
+
+      GLuint fboId;
+      glGenFramebuffers(1, &fboId);
+      FBOHandle resolveFb(fboId);
+
+      glBindRenderbuffer(GL_RENDERBUFFER, colorBuf);
+      glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, width, height);
+      glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+      glBindFramebuffer(GL_FRAMEBUFFER, resolveFb);
+      glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                GL_RENDERBUFFER, colorBuf);
+
+      if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+      {
+         cerr << "Unable to create resolve renderbuffer." << endl;
+         glBindFramebuffer(GL_FRAMEBUFFER, 0);
+      }
+
+      // bind our draw framebuffer and blit the multisampled image
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, resolveFb);
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, msaaFb);
+      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+      glBlitFramebuffer(0, 0, width, height,
+                        0, 0, width, height,
+                        GL_COLOR_BUFFER_BIT,
+                        GL_NEAREST);
+#ifndef __EMSCRIPTEN__
+      glDisable(GL_MULTISAMPLE);
+#endif
+      glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+      glBindFramebuffer(GL_READ_FRAMEBUFFER, resolveFb);
+      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+      glBlitFramebuffer(0, 0, width, height,
+                        0, 0, width, height,
+                        GL_COLOR_BUFFER_BIT,
+                        GL_LINEAR);
+   }
+   else if (msaa_enable && !feat_use_fbo_antialias)
+   {
+      glDisable(GL_MULTISAMPLE);
+      glDisable(GL_LINE_SMOOTH);
+      device->disableBlend();
+   }
+   device->setLineWidth(line_w);
+}
+
+void MultisamplePass::SetAntialiasing(bool aa_status)
+{
+   msaa_enable = aa_status;
+}
+
+void MultisamplePass::SetLineWidth(float w)
+{
+   line_w = w;
+   if (device && !msaa_enable)
+   {
+      device->setLineWidth(line_w);
+   }
+}
+
+void MultisamplePass::SetLineWidthMS(float w)
+{
+   line_w_aa = w;
+   if (device && msaa_enable)
+   {
+      device->setLineWidth(line_w_aa);
+   }
+}
+
+}

--- a/lib/gl/renderer_msaa.hpp
+++ b/lib/gl/renderer_msaa.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_RENDERER_MSAA_HPP
+#define GLVIS_RENDERER_MSAA_HPP
+
+#include "renderer.hpp"
+
+namespace gl3
+{
+
+class MultisamplePass : public IRenderPass
+{
+public:
+   MultisamplePass() { }
+   virtual void SetGLDevice(GLDevice* dev);
+   virtual void PreRender();
+   virtual void PostRender();
+
+   void SetAntialiasing(bool aa_status);
+   bool GetAntialiasing() { return msaa_enable; }
+   void SetNumSamples(int samples)
+   {
+      msaa_samples = samples;
+   }
+   int GetNumSamples() { return msaa_samples; }
+
+   void SetLineWidth(float w);
+   float GetLineWidth() { return line_w; }
+   void SetLineWidthMS(float w);
+   float GetLineWidthMS() { return line_w_aa; }
+private:
+   bool feat_use_fbo_antialias;
+   bool msaa_enable{false};
+   int msaa_samples;
+   float line_w, line_w_aa;
+
+   RenderBufHandle renderBufs[2];
+   FBOHandle msaaFb;
+};
+
+}
+
+#endif // GLVIS_RENDERER_MSAA_HPP

--- a/lib/gl/renderer_msaa.hpp
+++ b/lib/gl/renderer_msaa.hpp
@@ -25,6 +25,18 @@ public:
    virtual void PreRender();
    virtual void PostRender();
 
+   virtual const FBOHandle& GetSourceFramebuffer() const
+   {
+      if (msaa_enable && msaaFb)
+      {
+         return msaaFb;
+      }
+      else
+      {
+         return IRenderPass::default_target;
+      }
+   }
+
    void SetAntialiasing(bool aa_status);
    bool GetAntialiasing() { return msaa_enable; }
    void SetNumSamples(int samples)

--- a/lib/gl/renderer_print.cpp
+++ b/lib/gl/renderer_print.cpp
@@ -1,0 +1,226 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "renderer_print.hpp"
+#include "renderer_ff.hpp"
+
+namespace gl3
+{
+
+// Defined in renderer.hpp
+void GLDevice::captureXfbBuffer(CaptureBuffer& capture, const TextBuffer& t_buf)
+{
+   for (const auto& entry : t_buf)
+   {
+      glm::vec3 raster = glm::project(
+                            glm::vec3(entry.rx, entry.ry, entry.rz),
+                            model_view_mtx,
+                            proj_mtx,
+                            glm::vec4(0, 0, vp_width, vp_height));
+      capture.text.emplace_back(raster, glm::make_vec4(static_color.data()),
+                                entry.text);
+   }
+}
+
+// Defined in renderer_ff.hpp
+void FFGLDevice::captureXfbBuffer(PaletteState& pal, CaptureBuffer& cbuf,
+                                  int hnd)
+{
+   if (hnd == 0) { return; }
+   if (disp_lists[hnd].count == 0) { return; }
+   GLenum fbType;
+   int fbStride;
+   if (disp_lists[hnd].layout == VertexTex::layout
+       || disp_lists[hnd].layout == VertexNormTex::layout)
+   {
+      //capture texture values too
+      // [ X Y Z ] [ R G B A ] [ U V - - ]
+      fbType = GL_3D_COLOR_TEXTURE;
+      fbStride = 11;
+   }
+   else
+   {
+      // only capture pos and color
+      // [ X Y Z ] [ R G B A ]
+      fbType = GL_3D_COLOR;
+      fbStride = 7;
+   }
+   // compute feedback buffer size
+   int sizebuf = 0;
+   if (disp_lists[hnd].shape == GL_LINES)
+   {
+      // for each line: LINE_TOKEN [Vtx] [Vtx]
+      sizebuf = (disp_lists[hnd].count / 2) + disp_lists[hnd].count * fbStride;
+   }
+   else if (disp_lists[hnd].shape == GL_TRIANGLES)
+   {
+      // for each tri: POLY_TOKEN 3 [Vtx] [Vtx] [Vtx]
+      // NOTE: when clip plane is enabled, we might get two triangles
+      // or a quad for an input triangle. However, the other clipped
+      // triangles get discarded, so this *should* be enough space.
+      sizebuf = (disp_lists[hnd].count / 3) * (2 + fbStride * 4);
+   }
+   else
+   {
+      std::cerr << "Warning: unhandled primitive type in FFPrinter::preDraw()" <<
+                std::endl;
+      return;
+   }
+   // allocate feedback buffer
+   vector<float> xfb_buf;
+   xfb_buf.resize(sizebuf);
+   glFeedbackBuffer(sizebuf, fbType, xfb_buf.data());
+   // draw with feedback capture
+   glRenderMode(GL_FEEDBACK);
+   drawDeviceBuffer(hnd);
+#ifndef GLVIS_DEBUG
+   glRenderMode(GL_RENDER);
+#else
+   if (glRenderMode(GL_RENDER) < 0)
+   {
+      std::cerr << "Warning: feedback data exceeded available buffer size" <<
+                std::endl;
+   }
+#endif
+   size_t tok_idx = 0;
+   // process feedback buffer
+   while (tok_idx < xfb_buf.size())
+   {
+      switch ((GLuint)xfb_buf[tok_idx])
+      {
+         case GL_LINE_TOKEN:
+         case GL_LINE_RESET_TOKEN:
+         {
+            tok_idx++;
+            glm::vec3 coord0 = glm::make_vec3(&xfb_buf[tok_idx]),
+                      coord1 = glm::make_vec3(&xfb_buf[tok_idx + fbStride]);
+            glm::vec4 color0 = glm::make_vec4(&xfb_buf[tok_idx + 3]),
+                      color1 = glm::make_vec4(&xfb_buf[tok_idx + 3 + fbStride]);
+            if (fbStride == 11)
+            {
+               // get texture
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
+            }
+            cbuf.lines.emplace_back(coord0, color0);
+            cbuf.lines.emplace_back(coord1, color1);
+            tok_idx += fbStride * 2;
+         }
+         break;
+         case GL_POLYGON_TOKEN:
+         {
+            int n = xfb_buf[tok_idx + 1];
+            tok_idx += 2;
+            // get vertex 0, 1
+            glm::vec3 coord0 = glm::make_vec3(&xfb_buf[tok_idx]),
+                      coord1 = glm::make_vec3(&xfb_buf[tok_idx + fbStride]);
+            glm::vec4 color0 = glm::make_vec4(&xfb_buf[tok_idx + 3]),
+                      color1 = glm::make_vec4(&xfb_buf[tok_idx + 3 + fbStride]);
+            if (fbStride == 11)
+            {
+               // get texture
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7], glm::value_ptr(color0));
+               pal.GetColorFromVal(xfb_buf[tok_idx + 7 + fbStride], glm::value_ptr(color1));
+            }
+            // decompose polygon into n-2 triangles [0 1 2] [0 2 3] ...
+            for (int i = 0; i < n-2; i++)
+            {
+               // get last vertex of current triangle
+               int vtxStart = fbStride * (2 + 3*i);
+               glm::vec3 coord2 = glm::make_vec3(&xfb_buf[tok_idx + vtxStart]);
+               glm::vec4 color2 = glm::make_vec4(&xfb_buf[tok_idx + 3 + vtxStart]);
+               if (fbStride == 11)
+               {
+                  pal.GetColorFromVal(xfb_buf[tok_idx + 7 + vtxStart], glm::value_ptr(color2));
+               }
+               cbuf.triangles.emplace_back(coord0, color0);
+               cbuf.triangles.emplace_back(coord1, color1);
+               cbuf.triangles.emplace_back(coord2, color2);
+               // last vertex becomes second vertex of next triangle
+               coord1 = coord2;
+               color1 = color2;
+            }
+            tok_idx += n * fbStride;
+         }
+         break;
+         case GL_POINT_TOKEN:
+         case GL_BITMAP_TOKEN:
+         case GL_DRAW_PIXEL_TOKEN:
+         case GL_COPY_PIXEL_TOKEN:
+         default:
+            // commands containing the token + a single vertex ignore for now
+            tok_idx += 1 + fbStride;
+            break;
+      }
+   }
+}
+
+void CapturePass::Render(const RenderQueue& queue)
+{
+   int color_tex = palette->GetColorTexture();
+   int alpha_tex = palette->GetAlphaTexture();
+   bool always_blend = device->isBlendEnabled();
+   for (auto& q_elem : queue)
+   {
+      const RenderParams& params = q_elem.first;
+      device->setTransformMatrices(params.model_view.mtx, params.projection.mtx);
+      device->setMaterial(params.mesh_material);
+      device->setNumLights(params.num_pt_lights);
+      for (int i = 0; i < params.num_pt_lights; i++)
+      {
+         device->setPointLight(i, params.lights[i]);
+      }
+      device->setAmbientLight(params.light_amb_scene);
+      device->setStaticColor(params.static_color);
+      device->setClipPlaneUse(params.use_clip_plane);
+      device->setClipPlaneEqn(params.clip_plane_eqn);
+      // aggregate buffers with common parameters
+      std::vector<int> tex_bufs, no_tex_bufs;
+      GlDrawable* curr_drawable = q_elem.second;
+      auto buffers = curr_drawable->getArrayBuffers();
+      for (const IVertexBuffer* buf : buffers)
+      {
+         if (buf->getVertexLayout() == LAYOUT_VTX_TEXTURE0
+             || buf->getVertexLayout() == LAYOUT_VTX_NORMAL_TEXTURE0)
+         {
+            tex_bufs.emplace_back(buf->getHandle());
+         }
+         else
+         {
+            no_tex_bufs.emplace_back(buf->getHandle());
+         }
+      }
+
+      device->attachTexture(GLDevice::SAMPLER_COLOR, color_tex);
+      device->attachTexture(GLDevice::SAMPLER_ALPHA, alpha_tex);
+      for (auto buf : tex_bufs)
+      {
+         device->captureXfbBuffer(*palette, cbuf, buf);
+      }
+      device->detachTexture(GLDevice::SAMPLER_COLOR);
+      device->detachTexture(GLDevice::SAMPLER_ALPHA);
+      for (auto buf : no_tex_bufs)
+      {
+         device->captureXfbBuffer(*palette, cbuf, buf);
+      }
+      if (!params.contains_translucent)
+      {
+         device->enableBlend();
+         device->disableDepthWrite();
+      }
+      device->attachTexture(1, font_tex);
+      device->setNumLights(0);
+      device->captureXfbBuffer(cbuf, curr_drawable->getTextBuffer());
+      if (!always_blend) { device->disableBlend(); }
+   }
+}
+
+}

--- a/lib/gl/renderer_print.hpp
+++ b/lib/gl/renderer_print.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_RENDERER_PRINT_HPP
+#define GLVIS_RENDERER_PRINT_HPP
+
+#include "renderer.hpp"
+
+namespace gl3
+{
+
+struct FeedbackVertex
+{
+   glm::vec3 position;
+   glm::vec4 color;
+
+   FeedbackVertex() = default;
+   FeedbackVertex(glm::vec3 pos, glm::vec4 c)
+      : position(pos), color(c) { }
+   FeedbackVertex(glm::vec4 pos, glm::vec4 c)
+      : position(pos), color(c) { }
+};
+
+struct FeedbackText
+{
+   glm::vec3 offset;
+   glm::vec4 color;
+   std::string text;
+
+   FeedbackText() = default;
+   FeedbackText(glm::vec3 t_off, glm::vec4 t_color, std::string txt)
+      : offset(t_off), color(t_color), text(std::move(txt)) { }
+};
+
+struct CaptureBuffer
+{
+   vector<FeedbackVertex> lines;
+   vector<FeedbackVertex> triangles;
+   vector<FeedbackText> text;
+};
+
+class CapturePass : public IMainRenderPass
+{
+public:
+   CapturePass() { }
+   virtual bool Filter(const RenderParams& param) { return true; }
+
+   virtual void PreRender() { device->initXfbMode(); }
+   virtual void Render(const RenderQueue& queued);
+   virtual void PostRender() { device->exitXfbMode(); }
+
+   CaptureBuffer GetLastCaptureBuffer()
+   {
+      CaptureBuffer b_mov = std::move(cbuf);
+      cbuf = {};
+      return b_mov;
+   }
+
+private:
+   CaptureBuffer cbuf;
+};
+
+}
+
+#endif // GLVIS_RENDERER_PRINT_HPP

--- a/lib/gl/renderer_print.hpp
+++ b/lib/gl/renderer_print.hpp
@@ -55,7 +55,7 @@ public:
 
    virtual void PreRender() { device->initXfbMode(); }
    virtual void Render(const RenderQueue& queued);
-   virtual void PostRender() { device->exitXfbMode(); }
+   virtual void PostRender() { device->initRenderMode(); }
 
    CaptureBuffer GetLastCaptureBuffer()
    {

--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -177,15 +177,19 @@ std::string ShaderProgram::formatShader(const std::string& inShader,
          // although gl_FragColor was deprecated in GLSL 1.3
          for (int i = 0; i < num_outputs; i++)
          {
-            std::string indexString = "gl_FragData[";
-            indexString += std::to_string(i) + "]";
+            std::string indexString = "gl_FragData\\[";
+            indexString += std::to_string(i) + "\\]";
             std::string outputString = "out vec4 fragColor_";
             outputString += std::to_string(i) + ";\n";
+            if (glsl_version > 130)
+            {
+               formatted = std::regex_replace(formatted, std::regex(indexString),
+                                              "fragColor_" + std::to_string(i));
+            }
             if (glsl_version > 130 && glsl_version < 330)
             {
+               // append output variable specifications without layout specifiers
                formatted = outputString + formatted;
-               formatted = std::regex_replace(formatted, std::regex(indexString),
-                                              "fragColor");
             }
             else if (glsl_version >= 330 || (glsl_version == 300 && glsl_es))
             {
@@ -243,7 +247,7 @@ GLuint ShaderProgram::compileShader(const std::string& inShader,
    // glGetObjectParameteriv
    if (stat == GL_FALSE)
    {
-      std::cerr << "failed to compile shader" << std::endl;
+      std::cerr << "Failed to compile shader" << std::endl;
       int err_len;
       glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &err_len);
       char *error_text = new char[err_len];

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -56,6 +56,9 @@ public:
 
    void bind() const { glUseProgram(program_id); }
 
+   void setOutputFramebuffer(const FBOHandle& fbo);
+   void setDefaultDrawFramebuffer();
+
 private:
    static void GetGLSLVersion();
 
@@ -65,6 +68,7 @@ private:
    void mapShaderUniforms();
 
    static int glsl_version;
+   static bool glsl_es;
    std::unordered_map<int, std::string> attrib_idx;
    int num_outputs = 0;
 

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -59,6 +59,11 @@ public:
    void setOutputFramebuffer(const FBOHandle& fbo);
    void setDefaultDrawFramebuffer();
 
+   bool operator== (const ShaderProgram& other) const
+   {
+      return program_id == other.program_id;
+   }
+
 private:
    static void GetGLSLVersion();
 

--- a/lib/gl/shaders/depth_peel.frag
+++ b/lib/gl/shaders/depth_peel.frag
@@ -53,12 +53,12 @@ void main()
    float thisDepth = gl_FragCoord.z;
    float alphaMultiplier = 1.0 - lastFrontColor.a;
 
-   gl_FragData[0].xy = vec2(-MAX_DEPTH);
    gl_FragData[1] = lastFrontColor;
    gl_FragData[2] = vec4(0.0);
 
    if (thisDepth < nearestDepth || thisDepth > farthestDepth)
    {
+       gl_FragData[0].xy = vec2(-MAX_DEPTH);
        return;
    }
 
@@ -68,6 +68,7 @@ void main()
        return;
    }
 
+   gl_FragData[0].xy = vec2(-MAX_DEPTH);
    vec4 color = fColor * texture2D(colorTex, vec2(fTexCoord));
    color = blinnPhong(fPosition, fNormal, color);
 #ifdef USE_ALPHA
@@ -79,7 +80,7 @@ void main()
     if (thisDepth == nearestDepth)
     {
         gl_FragData[1].rgb += color.rgb * color.a * alphaMultiplier;
-        gl_FragData[2].a = 1.0 - alphaMultiplier * (1.0 - color.a);
+        gl_FragData[1].a = 1.0 - alphaMultiplier * (1.0 - color.a);
     }
     else
     {

--- a/lib/gl/shaders/depth_peel.frag
+++ b/lib/gl/shaders/depth_peel.frag
@@ -1,0 +1,89 @@
+R"(
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+uniform sampler2D alphaTex;
+uniform sampler2D colorTex;
+uniform sampler2D lastDepthTex;
+uniform sampler2D lastFrontColorTex;
+
+varying vec3 fNormal;
+varying vec3 fPosition;
+varying vec4 fColor;
+varying vec2 fTexCoord;
+
+uniform bool useClipPlane;
+varying float fClipVal;
+
+void fragmentClipPlane()
+{
+   if (useClipPlane && fClipVal < 0.0)
+   {
+      discard;
+   }
+}
+
+#define MAX_DEPTH 10.0
+
+// location 0: depth
+// location 1: front color
+// location 2: back color
+
+// adapted from "Order Independent Transparency with Dual Depth Peeling":
+// http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.193.3485&rep=rep1&type=pdf
+// and https://github.com/tsherif/webgl2examples/blob/master/oit-dual-depth-peeling.html
+
+void main()
+{
+   fragmentClipPlane();
+
+   ivec2 iFragCoord = ivec2(gl_FragCoord.xy);
+   vec2 lastDepths = texelFetch(lastDepthTex, iFragCoord, 0).xy;
+   vec4 lastFrontColor = texelFetch(lastFrontColorTex, iFragCoord, 0);
+   float nearestDepth = -lastDepths.x;
+   float farthestDepth = lastDepths.y;
+   float thisDepth = gl_FragCoord.z;
+   float alphaMultiplier = 1.0 - lastFrontColor.a;
+
+   gl_FragData[0].xy = vec2(-MAX_DEPTH);
+   gl_FragData[1] = lastFrontColor;
+   gl_FragData[2] = vec4(0.0);
+
+   if (thisDepth < nearestDepth || thisDepth > farthestDepth)
+   {
+       return;
+   }
+
+   if (thisDepth > nearestDepth && thisDepth < farthestDepth)
+   {
+       gl_FragData[0].xy = vec2(-thisDepth, thisDepth);
+       return;
+   }
+
+   vec4 color = fColor * texture2D(colorTex, vec2(fTexCoord));
+   color = blinnPhong(fPosition, fNormal, color);
+#ifdef USE_ALPHA
+   color.a *= texture2D(alphaTex, vec2(fTexCoord)).a;
+#else
+   color.a *= texture2D(alphaTex, vec2(fTexCoord)).r;
+#endif
+    
+    if (thisDepth == nearestDepth)
+    {
+        gl_FragData[1].rgb += color.rgb * color.a * alphaMultiplier;
+        gl_FragData[2].a = 1.0 - alphaMultiplier * (1.0 - color.a);
+    }
+    else
+    {
+        gl_FragData[2] += color;
+    }
+}
+)"

--- a/lib/gl/shaders/depth_peel_blend_back.frag
+++ b/lib/gl/shaders/depth_peel_blend_back.frag
@@ -1,0 +1,27 @@
+R"(
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+uniform sampler2D lastBackColor;
+
+// adapted from "Order Independent Transparency with Dual Depth Peeling":
+// http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.193.3485&rep=rep1&type=pdf
+// and https://github.com/tsherif/webgl2examples/blob/master/oit-dual-depth-peeling.html
+
+void main()
+{
+    gl_FragColor = texelFetch(lastBackColor, ivec2(gl_FragCoord.xy), 0);
+    if (gl_FragColor.a == 0)
+    {
+        discard;
+    }
+}
+)"

--- a/lib/gl/shaders/depth_peel_finalize.frag
+++ b/lib/gl/shaders/depth_peel_finalize.frag
@@ -1,0 +1,30 @@
+R"(
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+uniform sampler2D lastFrontColor;
+uniform sampler2D lastBackColor;
+
+// adapted from "Order Independent Transparency with Dual Depth Peeling":
+// http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.193.3485&rep=rep1&type=pdf
+// and https://github.com/tsherif/webgl2examples/blob/master/oit-dual-depth-peeling.html
+
+void main()
+{
+    ivec2 iQuadCoord = ivec2(gl_FragCoord.xy);
+    vec4 frontColor = texelFetch(lastFrontColor, iQuadCoord, 0);
+    vec4 backColor  = texelFetch(lastBackColor, iQuadCoord, 0);
+    float alphaMultiplier = 1.0 - frontColor.a;
+
+    gl_FragColor.rgb = frontColor.rgb + alphaMultiplier * backColor.rgb;
+    gl_FragColor.a = frontColor.a + backColor.a;
+}
+)"

--- a/lib/gl/shaders/depth_peel_passthrough.vert
+++ b/lib/gl/shaders/depth_peel_passthrough.vert
@@ -1,0 +1,19 @@
+R"(
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+attribute vec4 vertex;
+
+void main()
+{
+    gl_Position = vertex;
+}
+)"

--- a/lib/gl/shaders/lighting.glsl
+++ b/lib/gl/shaders/lighting.glsl
@@ -67,6 +67,6 @@ vec4 blinnPhong(in vec3 pos, in vec3 norm, in vec4 color)
       float specular_factor = max(dot(half_v, norm), 0.0);
       lit_color += lights[i].specular * material.specular * pow(specular_factor, material.shininess);
    }
-   return lit_color;
+   return vec4(lit_color.rgb, color.a);
 }
 )"

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -304,7 +304,6 @@ bool SdlWindow::createWindow(const char * title, int x, int y, int w, int h,
                << "." << (int)sdl_ver.patch << std::endl);
 
    renderer.reset(new gl3::MeshRenderer);
-   renderer->setSamplesMSAA(GetMultisample());
 #ifndef __EMSCRIPTEN__
    if (!GLEW_VERSION_1_1)
    {

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -740,18 +740,6 @@ void KeyKPressed()
    SendExposeEvent();
 }
 
-void KeyAPressed()
-{
-   bool curr_aa = GetAppWindow()->getRenderer().getAntialiasing();
-   GetAppWindow()->getRenderer().setAntialiasing(!curr_aa);
-
-   cout << "Multisampling/Antialiasing: "
-        << strings_off_on[!curr_aa ? 1 : 0] << endl;
-
-   // vsdata -> EventUpdateColors();
-   SendExposeEvent();
-}
-
 void KeyCommaPressed()
 {
    locscene->matAlphaCenter -= 0.25;
@@ -1111,7 +1099,6 @@ void VisualizationSceneScalarData::Init()
 
       // wnd->setOnKeyDown('a', KeyaPressed);
       wnd->setOnKeyDown('a', Key_Mod_a_Pressed);
-      wnd->setOnKeyDown('A', KeyAPressed);
 
       wnd->setOnKeyDown('r', KeyrPressed);
       wnd->setOnKeyDown('R', KeyRPressed);

--- a/makefile
+++ b/makefile
@@ -213,6 +213,7 @@ Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 # generated with 'echo lib/gl/*.c* lib/*.c*', does not include lib/*.m (Obj-C)
 ALL_SOURCE_FILES = \
  lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp \
+ lib/gl/renderer_msaa.cpp lib/gl/renderer_print.cpp \
  lib/gl/shader.cpp lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp lib/font.cpp \
  lib/gl2ps.c lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/sdl.cpp \
  lib/stream_reader.cpp lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp \
@@ -229,6 +230,7 @@ COMMON_SOURCE_FILES = $(filter-out \
 HEADER_FILES = \
  lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp \
  lib/gl/shader.hpp lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp \
+ lib/gl/renderer_msaa.hpp lib/gl/renderer_print.hpp \
  lib/gl/types.hpp lib/aux_vis.hpp lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h \
  lib/logo.hpp lib/material.hpp lib/openglvis.hpp lib/palettes.hpp lib/sdl.hpp \
  lib/sdl_helper.hpp lib/sdl_mac.hpp lib/sdl_x11.hpp lib/stream_reader.hpp \


### PR DESCRIPTION
- Preliminary refactoring of rendering pipeline into stages, allowing for composable rendering operations
- Implements order-independent transparency using [dual depth peeling](http://developer.download.nvidia.com/SDK/10/opengl/src/dual_depth_peeling/doc/DualDepthPeeling.pdf)

Outstanding issues/TODO
--------------------------
 - Do we want to have configurable number of peeling passes?
 - MSAA is broken when depth peeling is enabled - look into screen-space methods like FXAA?
 - Testing on legacy/WebGL builds to make sure nothing broke