### PR TITLE
Bugfixes for shader handling

### DIFF
--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -185,8 +185,11 @@ std::string ShaderProgram::formatShader(const std::string& inShader,
 
    if (glsl_is_es)
    {
-      // Add precision specifier - required for WebGL
-      formatted = "precision mediump float;\n" + formatted;
+      if (shaderType == GL_FRAGMENT_SHADER)
+      {
+         // Add precision specifier - required for WebGL fragment shaders
+         formatted = "precision mediump float;\n" + formatted;
+      }
       if (num_outputs > 1 && glsl_version == 100)
       {
          // Enable WEBGL_draw_buffers in the shader

--- a/lib/gl/shader.cpp
+++ b/lib/gl/shader.cpp
@@ -157,9 +157,11 @@ std::string ShaderProgram::formatShader(const std::string& inShader,
                // No in-shader output indexing.
                // Output locations will be set using glBindFragDataLocation.
                formatted = outputString + formatted;
-               formatted = std::regex_replace(formatted, std::regex(indexString),
-                                              "fragColor");
             }
+            std::string indexStringRgx = "gl_FragData\\[";
+            indexStringRgx += std::to_string(i) + "\\]";
+            formatted = std::regex_replace(formatted, std::regex(indexStringRgx),
+                                           "fragColor_" + std::to_string(i));
             if (i == 0)
             {
                formatted = std::regex_replace(formatted, std::regex("gl_FragColor"),

--- a/lib/gl/shader.hpp
+++ b/lib/gl/shader.hpp
@@ -65,6 +65,7 @@ private:
    void mapShaderUniforms();
 
    static int glsl_version;
+   const static bool glsl_is_es;
    std::unordered_map<int, std::string> attrib_idx;
    int num_outputs = 0;
 


### PR DESCRIPTION
Fixes a segfault identified by @dylan-copeland, caused by the calling of `glBindFragDataLocation` on an OpenGL version lacking that function.

Also:
- Corrects version checks for when to place in-shader layout specifications for outputs
- Fixes multiple render targets for WebGL 1 by adding a required `#extension GL_EXT_draw_buffers` line
- Replaces some #ifdef-ed sections with a check against a `ShaderProgram::glsl_is_es` flag