### PR TITLE
Removing POSIX dependency from GLVisCommand

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,7 +20,7 @@ Version 4.0.1 (development)
 
 - Refactoring of rendering components, including palette and shader handling.
 
-- Replace pthreads with C++11 standard thread library.
+- Replace pthreads and POSIX-specific code with C++11 standard thread library.
 
 
 Version 4.0, released on Dec 11, 2020

--- a/lib/sdl_x11.hpp
+++ b/lib/sdl_x11.hpp
@@ -84,8 +84,8 @@ public:
 
    ~SdlX11Platform()
    {
-       close(event_pfd[0]);
-       close(event_pfd[1]);
+      close(event_pfd[0]);
+      close(event_pfd[1]);
    }
 
    void WaitEvent()
@@ -113,19 +113,19 @@ public:
       // Read out the pending GLVisCommand-sent events, if any
       do
       {
-          char c[10];
-          n = read(event_pfd[0], c, 10);
+         char c[10];
+         n = read(event_pfd[0], c, 10);
       }
       while (n > 0);
    }
    void SendEvent()
    {
-       char c = 's';
-       if (write(event_pfd[1], &c, 1) != 1)
-       {
+      char c = 's';
+      if (write(event_pfd[1], &c, 1) != 1)
+      {
          perror("write()");
          exit(EXIT_FAILURE);
-       }
+      }
    }
 
 private:

--- a/lib/sdl_x11.hpp
+++ b/lib/sdl_x11.hpp
@@ -121,7 +121,7 @@ public:
    void SendEvent()
    {
        char c = 's';
-       if (write(pfd[1], &c, 1) != 1)
+       if (write(event_pfd[1], &c, 1) != 1)
        {
          perror("write()");
          exit(EXIT_FAILURE);

--- a/lib/sdl_x11.hpp
+++ b/lib/sdl_x11.hpp
@@ -90,8 +90,9 @@ public:
 
    void WaitEvent()
    {
-      int nstr, nfd = 2;
-      struct pollfd pfd[2];
+      constexpr int nfd = 2;
+      int nstr;
+      struct pollfd pfd[nfd];
 
       pfd[0].fd     = ConnectionNumber(disp);
       pfd[0].events = POLLIN;
@@ -113,15 +114,15 @@ public:
       // Read out the pending GLVisCommand-sent events, if any
       do
       {
-         char c[10];
-         n = read(event_pfd[0], c, 10);
+         std::array<char, 16> buf;
+         n = read(event_pfd[0], buf.data(), buf.size());
       }
       while (n > 0);
    }
    void SendEvent()
    {
       char c = 's';
-      if (write(event_pfd[1], &c, 1) != 1)
+      if (write(event_pfd[1], &c, sizeof(c)) != 1)
       {
          perror("write()");
          exit(EXIT_FAILURE);

--- a/lib/sdl_x11.hpp
+++ b/lib/sdl_x11.hpp
@@ -90,7 +90,7 @@ public:
 
    void WaitEvent()
    {
-      int nstr, nfd = 1;
+      int nstr, nfd = 2;
       struct pollfd pfd[2];
 
       pfd[0].fd     = ConnectionNumber(disp);

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -56,6 +56,8 @@ int GLVisCommand::lock()
 
 int GLVisCommand::signal()
 {
+   command_ready = true;
+
    SdlWindow *sdl_window = GetAppWindow();
    if (sdl_window)
    {
@@ -67,6 +69,8 @@ int GLVisCommand::signal()
 
 void GLVisCommand::unlock()
 {
+   command_ready = false;
+
    lock_guard<mutex> scope_lock(glvis_mutex);
    num_waiting--;
    if (num_waiting > 0)
@@ -391,12 +395,9 @@ int GLVisCommand::Autopause(const char *mode)
 
 int GLVisCommand::Execute()
 {
+   if (!command_ready)
    {
-      lock_guard<mutex> scope_lock(glvis_mutex);
-      if (num_waiting == 0)
-      {
-         return 1;
-      }
+      return 1;
    }
 
    switch (command)

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -58,6 +58,8 @@ private:
       PALETTE_REPEAT = 20
    };
 
+   std::atomic<bool> command_ready{false};
+
    // command to be executed
    int command;
 

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -32,7 +32,6 @@ private:
 
    int num_waiting;
    bool terminating;
-   int pfd[2];  // pfd[0] -- reading, pfd[1] -- writing
 
    enum
    {
@@ -95,9 +94,6 @@ public:
    // called by the main execution thread
    GLVisCommand(VisualizationSceneScalarData **_vs,
                 StreamState& thread_state, bool *_keep_attr);
-
-   // to be used by the main execution (visualization) thread
-   int ReadFD() { return pfd[0]; }
 
    // to be used by worker threads
    bool KeepAttrib() { return *keep_attr; } // may need to sync this


### PR DESCRIPTION
Constructing a `pipe()` is needed on the X11 side in order to poll for both WM events and incoming stream commands while minimizing CPU usage. However, on Mac and Windows, we need to use their WM-native event systems to wait for events without burning CPU cycles.

This PR removes the dependency on `pipe()` and other POSIX things in `GLVisCommand`:
-  Read-after-write consistency is now enforced with an atomic `command_ready` flag.
- `SdlX11Platform` now holds an internal pipe to poll along with the window event pipe. POSIX is now only required when building with X11 support.