### PR TITLE
Fix for building with MFEM+gslib

### DIFF
--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -10,7 +10,7 @@
 // CONTRIBUTING.md for details.
 
 #include "palettes.hpp"
-#include "aux_vis.hpp"
+#include "gl/renderer.hpp"
 
 #include <cmath>
 #include <cstdio>


### PR DESCRIPTION
@brendankeith identified an issue where a forward-declared `struct array` in mfem with gslib enabled conflicted with the use of `std::array` in `palettes.cpp`. This is fixed with a header include change.