### PR TITLE
Fix for live site hang

### DIFF
--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -92,7 +92,6 @@ bool SdlWindow::createWindow(const char* title, int x, int y, int w, int h,
 {
 #ifdef __EMSCRIPTEN__
    is_multithreaded = false;
-   GetMainThread().SetSingleThread();
 #endif
    // create a new SDL window
    handle = GetMainThread().GetHandle(this, title, x, y, w, h, legacyGlOnly);

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -73,6 +73,9 @@ SdlMainThread::SdlMainThread()
                << "." << (int)sdl_ver.patch << std::endl);
 
    sdl_init = true;
+#ifdef __EMSCRIPTEN__
+   SetSingleThread();
+#endif
 }
 
 SdlMainThread::~SdlMainThread() = default;
@@ -297,41 +300,53 @@ SdlMainThread::Handle SdlMainThread::GetHandle(SdlWindow* wnd,
 
 void SdlMainThread::DeleteHandle(Handle to_delete)
 {
-   SdlCtrlCommand main_thread_cmd;
-   main_thread_cmd.type = SdlCmdType::Delete;
-   main_thread_cmd.cmd_delete = std::move(to_delete);
+   if (to_delete.isInitialized())
+   {
+      SdlCtrlCommand main_thread_cmd;
+      main_thread_cmd.type = SdlCmdType::Delete;
+      main_thread_cmd.cmd_delete = std::move(to_delete);
 
-   queueWindowEvent(std::move(main_thread_cmd));
+      queueWindowEvent(std::move(main_thread_cmd));
+   }
 }
 
 void SdlMainThread::SetWindowTitle(const Handle& handle, std::string title)
 {
-   SdlCtrlCommand main_thread_cmd;
-   main_thread_cmd.type = SdlCmdType::SetTitle;
-   main_thread_cmd.handle = &handle;
-   main_thread_cmd.cmd_title = std::move(title);
+   if (handle.isInitialized())
+   {
+      SdlCtrlCommand main_thread_cmd;
+      main_thread_cmd.type = SdlCmdType::SetTitle;
+      main_thread_cmd.handle = &handle;
+      main_thread_cmd.cmd_title = std::move(title);
 
-   queueWindowEvent(std::move(main_thread_cmd));
+      queueWindowEvent(std::move(main_thread_cmd));
+   }
 }
 
 void SdlMainThread::SetWindowSize(const Handle& handle, int w, int h)
 {
-   SdlCtrlCommand main_thread_cmd;
-   main_thread_cmd.type = SdlCmdType::SetSize;
-   main_thread_cmd.handle = &handle;
-   main_thread_cmd.cmd_set_size = {w, h};
+   if (handle.isInitialized())
+   {
+      SdlCtrlCommand main_thread_cmd;
+      main_thread_cmd.type = SdlCmdType::SetSize;
+      main_thread_cmd.handle = &handle;
+      main_thread_cmd.cmd_set_size = {w, h};
 
-   queueWindowEvent(std::move(main_thread_cmd));
+      queueWindowEvent(std::move(main_thread_cmd));
+   }
 }
 
 void SdlMainThread::SetWindowPosition(const Handle& handle, int x, int y)
 {
-   SdlCtrlCommand main_thread_cmd;
-   main_thread_cmd.type = SdlCmdType::SetPosition;
-   main_thread_cmd.handle = &handle;
-   main_thread_cmd.cmd_set_position = {x, y};
+   if (handle.isInitialized())
+   {
+      SdlCtrlCommand main_thread_cmd;
+      main_thread_cmd.type = SdlCmdType::SetPosition;
+      main_thread_cmd.handle = &handle;
+      main_thread_cmd.cmd_set_position = {x, y};
 
-   queueWindowEvent(std::move(main_thread_cmd));
+      queueWindowEvent(std::move(main_thread_cmd));
+   }
 }
 
 void SdlMainThread::queueWindowEvent(SdlCtrlCommand cmd)


### PR DESCRIPTION
In the live website, an [event handler](https://github.com/GLVis/web/blob/69df65dc585f60adafcfe131214904572b881fa1/src/live/index.html#L740) which calls `SdlWindow::SetWindowSize()` is attached to the window resize event. However, this may be called before the SdlWindow is actually initialized; the end result is that the live site hangs on a `condition_variable` that is never woken. To fix this:
- We call `SetSingleThread()` earlier in the `SdlMainThread` initialization, so we can avoid calling multithreaded code before the first window is initialized.
- Window-specific functions on `SdlMainThread` first check for the validity of the incoming handle, in order to avoid queuing up events for a null window.