### PR TITLE
Update numbering when a new mesh and solution is read

### DIFF
--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -592,6 +592,7 @@ void VisualizationSceneSolution::NewMeshAndSolution(
    PrepareLevelCurves();
    PrepareBoundary();
    PrepareCP();
+   PrepareNumbering();
    PrepareOrderingCurve();
 }
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -1564,16 +1564,6 @@ double VisualizationSceneSolution::GetElementLengthScale(int k)
 
 void VisualizationSceneSolution::PrepareElementNumbering()
 {
-   int ne = mesh -> GetNE();
-
-   if (ne > MAX_RENDER_NUMBERING)
-   {
-      cout << "Element numbering disabled when #elements > "
-           << MAX_RENDER_NUMBERING << endl;
-      cout << "Rendering the text would be very slow." << endl;
-      return;
-   }
-
    if (2 == shading)
    {
       PrepareElementNumbering2();
@@ -1656,16 +1646,6 @@ void VisualizationSceneSolution::PrepareElementNumbering2()
 
 void VisualizationSceneSolution::PrepareVertexNumbering()
 {
-   int nv = mesh->GetNV();
-
-   if (nv > MAX_RENDER_NUMBERING)
-   {
-      cout << "Vertex numbering disabled when #vertices > "
-           << MAX_RENDER_NUMBERING << endl;
-      cout << "Rendering the text would be very slow." << endl;
-      return;
-   }
-
    if (2 == shading)
    {
       PrepareVertexNumbering2();


### PR DESCRIPTION
Fix to update numberings when a new mesh and solution is read in. This is important, for example, when the new mesh is adaptively refined.
