### PR TITLE
Regression Testing #2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -168,6 +168,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: glvis
+        submodules: recursive
 
     - name: build GLVis (make)
       if: matrix.build-system == 'make'
@@ -179,12 +180,51 @@ jobs:
     - name: build GLVis (cmake)
       if: matrix.build-system == 'cmake'
       run: |
-        build_type="Release"
+        build_type="RelWithDebInfo"
         [[ ${{ matrix.target }} == "debug" ]] && build_type="Debug";
         cd glvis && mkdir build && cd build
         cmake \
           -D CMAKE_BUILD_TYPE:STRING=${build_type} \
+          -D ENABLE_TESTS:BOOL=TRUE \
           -D mfem_DIR:PATH=${GITHUB_WORKSPACE}/${MFEM_TOP_DIR}/build \
+          -D GLVIS_BASELINE_SYS=${{ matrix.os }} \
           ..
         make -j3
 
+    - name: setup Python
+      if: matrix.build-system == 'cmake'
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: setup Python packages for testing
+      if: matrix.build-system == 'cmake'
+      run: |
+        python -m pip install --upgrade pip
+        pip install scikit-image
+
+    - name: setup Linux testing dependencies
+      if: matrix.build-system == 'cmake' && matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get install xvfb
+
+    - name: test GLVis (cmake/linux)
+      if: matrix.build-system == 'cmake' && matrix.os == 'ubuntu-20.04'
+      run: |
+        cd glvis && cd build
+        xvfb-run -a ctest --verbose
+        tar czvf test_screenshots.tar.gz tests/test.*.png
+
+    - name: test GLVis (cmake/mac)
+      if: matrix.build-system == 'cmake' && matrix.os == 'macos-10.15'
+      run: |
+        cd glvis && cd build
+        ctest --verbose
+        tar czvf test_screenshots.tar.gz tests/test.*.png
+
+    - name: upload test screenshots
+      if: matrix.build-system == 'cmake'
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-screenshots-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}
+        path: glvis/build/test_screenshots.tar.gz

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -147,10 +147,13 @@ jobs:
         build-system: ${{ matrix.build-system }}
         mpi: ${{ matrix.mpi }}
 
-    # Install GlVis dependencies with package manager
+    # Install GLVis dependencies with package manager
     - name: get deps (Linux)
       if: matrix.os == 'ubuntu-20.04'
       run: |
+        # We need to add a PPA for SDL 2.0.14 - fixes some initialization
+        # errors for X11
+        sudo add-apt-repository -y ppa:savoury1/multimedia
         sudo apt-get update
         sudo apt-get install libfontconfig1-dev libfreetype6-dev libsdl2-dev libglew-dev libglm-dev libpng-dev
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -31,12 +31,16 @@ jobs:
   builds-and-tests:
     strategy:
       matrix:
+        os: [ubuntu-20.04, macos-10.15]
+        target: [debug, optim]
+        mpi: [sequential]
+        build-system: [cmake]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: optim
             mpi: sequential
             build-system: make
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             target: debug
             mpi: parallel
             build-system: make
@@ -48,17 +52,13 @@ jobs:
             target: debug
             mpi: parallel
             build-system: make
-          - os: ubuntu-18.04
-            target: optim
-            mpi: sequential
-            build-system: cmake
     name: ${{ matrix.os }}-${{ matrix.target }}-${{ matrix.mpi }}-${{ matrix.build-system }}
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: get MPI (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update
         sudo apt-get install mpich libmpich-dev
@@ -149,7 +149,7 @@ jobs:
 
     # Install GlVis dependencies with package manager
     - name: get deps (Linux)
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update
         sudo apt-get install libfontconfig1-dev libfreetype6-dev libsdl2-dev libglew-dev libglm-dev libpng-dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/data"]
+	path = tests/data
+	url = https://github.com/GLVis/data.git

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,11 @@ Version 4.0.1 (development)
 - Added build target ("make app") to build a native Mac OS application bundle
   that can be double-clicked, added to the Dock, etc.
 
+- Added a new regression test suite based on generated screenshots of stream
+  files. See the README in the tests directory for more details.
+
+- Fixed an issue with black screenshots on certain OpenGL implementations.
+
 
 Version 4.0, released on Dec 11, 2020
 =====================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,3 +328,8 @@ add_custom_target(app
         GLVis.app/Contents/Resources/GLVis.icns
         GLVis.app/Contents/Resources/Credits.rtf
     VERBATIM)
+
+if(ENABLE_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif(ENABLE_TESTS)

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1140,6 +1140,7 @@ int main (int argc, char *argv[])
    double      ms_line_width = gl3::LINE_WIDTH_AA;
    int         geom_ref_type = Quadrature1D::ClosedUniform;
    bool        legacy_gl_ctx = false;
+   bool        enable_hidpi  = true;
 
    OptionsParser args(argc, argv);
 
@@ -1206,6 +1207,9 @@ int main (int argc, char *argv[])
    args.AddOption(&legacy_gl_ctx, "-oldgl", "--legacy-gl",
                   "-anygl", "--any-gl",
                   "Only try to create a legacy OpenGL (< 2.1) context.");
+   args.AddOption(&enable_hidpi, "-hidpi", "--high-dpi",
+                  "-nohidpi", "--no-high-dpi",
+                  "Enable/disable support for HiDPI at runtime, if supported.");
 
    cout << endl
         << "       _/_/_/  _/      _/      _/  _/"          << endl
@@ -1279,6 +1283,7 @@ int main (int argc, char *argv[])
    {
       SetLegacyGLOnly(legacy_gl_ctx);
    }
+   SetUseHiDPI(enable_hidpi);
 
    GLVisGeometryRefiner.SetType(geom_ref_type);
 

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -932,6 +932,8 @@ int Screenshot(const char *fname, bool convert)
 #if GLVIS_DEBUG
       cerr << "Screenshot: reading image data from front buffer..." << endl;
 #endif
+      MFEM_WARNING("Screenshot: Reading from the front buffer is unreliable. "
+                   << " Resulting screenshots may be incorrect." << endl);
       glReadBuffer(GL_FRONT);
    }
 #if defined(GLVIS_USE_LIBTIFF)
@@ -1112,6 +1114,7 @@ void KeyS()
       wnd->screenshot(fname);
       cout << "done" << endl;
    }
+   SendExposeEvent();
 }
 
 inline GL2PSvertex CreatePrintVtx(gl3::FeedbackVertex v)

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -319,8 +319,7 @@ void SetVisualizationScene(VisualizationScene * scene, int view,
 
    if (keys)
    {
-      // SendKeySequence(keys);
-      CallKeySequence(keys);
+      SendKeySequence(keys);
    }
    wnd->getRenderer().setPalette(&locscene->palette);
 }

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -48,6 +48,7 @@ float line_w_aa = gl3::LINE_WIDTH_AA;
 
 thread_local SdlWindow * wnd = nullptr;
 bool wndLegacyGl = false;
+bool wndUseHiDPI = false;
 void SDLMainLoop(bool server_mode)
 {
    SdlWindow::StartSDL(server_mode);
@@ -66,6 +67,11 @@ VisualizationScene * GetVisualizationScene()
 void SetLegacyGLOnly(bool status)
 {
    wndLegacyGl = true;
+}
+
+void SetUseHiDPI(bool status)
+{
+   wndUseHiDPI = status;
 }
 
 void MyExpose(GLsizei w, GLsizei h);

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -128,4 +128,6 @@ GlVisFont * GetFont();
 bool SetFont(const vector<std::string>& patterns, int height);
 void SetFont(const std::string& fn);
 
+void SetUseHiDPI(bool status);
+
 #endif

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -105,6 +105,16 @@ bool SdlWindow::createWindow(const char* title, int x, int y, int w, int h,
    window_id = SDL_GetWindowID(handle.hwnd);
 
    GLenum err = glewInit();
+#ifdef GLEW_ERROR_NO_GLX_DISPLAY
+   // NOTE: Hacky workaround for Wayland initialization failure
+   // See https://github.com/nigels-com/glew/issues/172
+   if (err == GLEW_ERROR_NO_GLX_DISPLAY)
+   {
+      cerr << "GLEW: No GLX display found. If you are using Wayland this can "
+              "be ignored." << endl;
+      err = GLEW_OK;
+   }
+#endif
    if (err != GLEW_OK)
    {
       cerr << "FATAL: Failed to initialize GLEW: "

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -466,6 +466,11 @@ void SdlWindow::mainLoop()
    while (running)
    {
       mainIter();
+      if (takeScreenshot)
+      {
+         Screenshot(screenshot_file.c_str(), screenshot_convert);
+         takeScreenshot = false;
+      }
       if (wnd_state == RenderState::SwapPending)
       {
 #ifdef SDL_VIDEO_DRIVER_COCOA
@@ -485,11 +490,6 @@ void SdlWindow::mainLoop()
          SDL_GL_SwapWindow(handle.hwnd);
 #endif
          wnd_state = RenderState::Updated;
-      }
-      if (takeScreenshot)
-      {
-         Screenshot(screenshot_file.c_str());
-         takeScreenshot = false;
       }
    }
 #endif

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -74,6 +74,7 @@ private:
       }
    };
 
+   int window_id = -1;
    Handle handle;
    std::unique_ptr<gl3::MeshRenderer> renderer;
    static const int high_dpi_threshold = 144;

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -125,6 +125,7 @@ private:
    //bool requiresExpose;
    bool takeScreenshot{false};
    std::string screenshot_file;
+   bool screenshot_convert;
 
    // internal event handlers
    void windowEvent(SDL_WindowEvent& ew);
@@ -234,10 +235,14 @@ public:
    std::string getSavedKeys() const { return saved_keys; }
 
    /// Queues a screenshot to be taken.
-   void screenshot(std::string filename)
+   void screenshot(std::string filename, bool convert = false)
    {
       takeScreenshot = true;
       screenshot_file = filename;
+      screenshot_convert = convert;
+      // Queue up an expose, so Screenshot() can pull image from the back
+      // buffer
+      signalExpose();
    }
 
    void swapBuffer();

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -28,6 +28,7 @@
 #endif
 
 extern int GetMultisample();
+extern bool wndUseHiDPI;
 
 struct SdlMainThread::CreateWindowCmd
 {
@@ -582,10 +583,14 @@ void SdlMainThread::createWindowImpl(CreateWindowCmd& cmd)
 {
    Uint32 win_flags = SDL_WINDOW_OPENGL;
    // Hide window until we adjust its size for high-dpi displays
-   win_flags |= SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN;
+   win_flags |= SDL_WINDOW_HIDDEN;
 #ifndef __EMSCRIPTEN__
    win_flags |= SDL_WINDOW_RESIZABLE;
 #endif
+   if (wndUseHiDPI)
+   {
+      win_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+   }
    SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1);
    SDL_GL_SetAttribute( SDL_GL_DEPTH_SIZE, 24);
    probeGLContextSupport(cmd.legacy_gl_only);

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -56,11 +56,17 @@ struct SdlMainThread::SdlCtrlCommand
 
 SdlMainThread::SdlMainThread()
 {
+   SDL_version sdl_ver;
+   SDL_GetVersion(&sdl_ver);
+   PRINT_DEBUG("Using SDL " << (int)sdl_ver.major << "." << (int)sdl_ver.minor
+               << "." << (int)sdl_ver.patch << std::endl);
+
    if (!SDL_WasInit(SDL_INIT_VIDEO | SDL_INIT_EVENTS))
    {
       if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0)
       {
          std::cerr << "FATAL: Failed to initialize SDL: " << SDL_GetError() << endl;
+         return;
       }
       SDL_EnableScreenSaver();
       glvis_event_type = SDL_RegisterEvents(1);
@@ -70,21 +76,21 @@ SdlMainThread::SdlMainThread()
       }
    }
 
-   SDL_version sdl_ver;
-   SDL_GetVersion(&sdl_ver);
-   PRINT_DEBUG("Using SDL " << (int)sdl_ver.major << "." << (int)sdl_ver.minor
-               << "." << (int)sdl_ver.patch << std::endl);
-
    sdl_init = true;
 #ifdef __EMSCRIPTEN__
    SetSingleThread();
 #endif
 }
 
-SdlMainThread::~SdlMainThread() = default;
+SdlMainThread::~SdlMainThread()
+{
+   SDL_Quit();
+}
 
 void SdlMainThread::MainLoop(bool server_mode)
 {
+   if (!sdl_init) { return; }
+
    this->server_mode = server_mode;
    if (server_mode)
    {
@@ -262,6 +268,11 @@ SdlMainThread::Handle SdlMainThread::GetHandle(SdlWindow* wnd,
                                                const std::string& title,
                                                int x, int y, int w, int h, bool legacyGlOnly)
 {
+   if (!sdl_init)
+   {
+      return Handle{};
+   }
+
    CreateWindowCmd cmd_create = { wnd, title, x, y, w, h, legacyGlOnly, false,
                                   {}
                                 };
@@ -613,6 +624,8 @@ void SdlMainThread::createWindowImpl(CreateWindowCmd& cmd)
    {
       PRINT_DEBUG("failed." << endl);
       cerr << "FATAL: window and/or OpenGL context creation failed." << endl;
+      // If not in server mode, this was the only window we were going to open.
+      if (!server_mode) { terminating = true; }
       return;
    }
    else

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -316,6 +316,12 @@ void SdlMainThread::DeleteHandle(Handle to_delete)
 {
    if (to_delete.isInitialized())
    {
+      {
+         lock_guard<mutex> ctx_lock{gl_ctx_mtx};
+         // Unbinding the context before deletion seems to resolve some issues
+         // with thread-local storage on Wayland/EGL.
+         SDL_GL_MakeCurrent(to_delete.hwnd, nullptr);
+      }
       SdlCtrlCommand main_thread_cmd;
       main_thread_cmd.type = SdlCmdType::Delete;
       main_thread_cmd.cmd_delete = std::move(to_delete);

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -50,6 +50,8 @@ struct SdlMainThread::SdlCtrlCommand
    string                   cmd_title;
    pair<int, int>           cmd_set_size;
    pair<int, int>           cmd_set_position;
+   // Promise object for signaling completion of the command on the main thread
+   promise<void>            finished;
 };
 
 SdlMainThread::SdlMainThread()
@@ -333,7 +335,7 @@ void SdlMainThread::SetWindowSize(const Handle& handle, int w, int h)
       main_thread_cmd.handle = &handle;
       main_thread_cmd.cmd_set_size = {w, h};
 
-      queueWindowEvent(std::move(main_thread_cmd));
+      queueWindowEvent(std::move(main_thread_cmd), true);
    }
 }
 
@@ -346,14 +348,19 @@ void SdlMainThread::SetWindowPosition(const Handle& handle, int x, int y)
       main_thread_cmd.handle = &handle;
       main_thread_cmd.cmd_set_position = {x, y};
 
-      queueWindowEvent(std::move(main_thread_cmd));
+      queueWindowEvent(std::move(main_thread_cmd), true);
    }
 }
 
-void SdlMainThread::queueWindowEvent(SdlCtrlCommand cmd)
+void SdlMainThread::queueWindowEvent(SdlCtrlCommand cmd, bool sync)
 {
+   future<void> wait_complete;
    if (sdl_multithread)
    {
+      if (sync)
+      {
+         wait_complete = cmd.finished.get_future();
+      }
       // queue up our event
       {
          lock_guard<mutex> req_lock{window_cmd_mtx};
@@ -361,6 +368,8 @@ void SdlMainThread::queueWindowEvent(SdlCtrlCommand cmd)
       }
       // wake up the main thread to handle our event
       SendEvent();
+
+      if (sync) { wait_complete.get(); }
    }
    else
    {
@@ -407,6 +416,8 @@ void SdlMainThread::handleWindowCmdImpl(SdlCtrlCommand& cmd)
          cerr << "Error in main thread: unknown window control command.\n";
          break;
    }
+   // Signal completion of the command, in case worker thread is waiting.
+   cmd.finished.set_value();
 }
 
 void SdlMainThread::setWindowIcon(SDL_Window* hwnd)

--- a/lib/sdl_main.hpp
+++ b/lib/sdl_main.hpp
@@ -87,7 +87,7 @@ private:
       SetPosition
    };
 
-   void queueWindowEvent(SdlCtrlCommand cmd);
+   void queueWindowEvent(SdlCtrlCommand cmd, bool sync = false);
 
    template<typename T>
    Uint32 getWindowID(const T& eventStruct)

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -435,15 +435,10 @@ int GLVisCommand::Execute()
 
       case SCREENSHOT:
       {
-         cout << "Command: screenshot: " << flush;
-         if (::Screenshot(screenshot_filename.c_str(), true))
-         {
-            cout << "Screenshot(" << screenshot_filename << ") failed." << endl;
-         }
-         else
-         {
-            cout << "-> " << screenshot_filename << endl;
-         }
+         cout << "Command: screenshot -> " << screenshot_filename << endl;
+         // Allow SdlWindow to handle the expose and screenshot action, in case
+         // any actions need to be taken before MyExpose().
+         GetAppWindow()->screenshot(screenshot_filename, true);
          break;
       }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,73 @@
+# Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+# at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+# LICENSE and NOTICE for details. LLNL-CODE-443271.
+#
+# This file is part of the GLVis visualization tool and library. For more
+# information and source code availability see https://glvis.org.
+#
+# GLVis is free software; you can redistribute it and/or modify it under the
+# terms of the BSD-3 license. We welcome feedback and contributions, see file
+# CONTRIBUTING.md for details.
+
+if(NOT EMSCRIPTEN)
+
+# Used for automated testing
+set(GLVIS_BASELINE_SYS local CACHE STRING
+    "The location to use for testing baselines.")
+
+add_custom_target(
+  glvis-test-driver ALL
+  COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/glvis_driver.py
+    ${CMAKE_CURRENT_BINARY_DIR}/glvis_driver.py
+  DEPENDS glvis_driver.py
+  COMMENT "Copying glvis_driver.py")
+
+set(stream_tests
+    "capacitor"
+    "distance"
+    "ex1"
+    "ex2"
+    "ex27"
+    "ex3"
+    "ex5"
+    "ex9"
+    "klein-bottle"
+    "laghos"
+    "mesh-explorer"
+    "mfem-logo"
+    "minimal-surface"
+    "mobius-strip"
+    "navier"
+    "quad"
+    "remhos"
+    "shaper"
+    "shifted"
+    "snake")
+
+add_custom_target(rebaseline)
+
+foreach(test_name IN LISTS stream_tests)
+
+  add_test(NAME stream_${test_name}
+           COMMAND python3 ${CMAKE_CURRENT_BINARY_DIR}/glvis_driver.py
+           -e ${CMAKE_CURRENT_BINARY_DIR}/../glvis
+           -s ${CMAKE_CURRENT_SOURCE_DIR}/data/streams/${test_name}.saved
+           -b ${CMAKE_CURRENT_SOURCE_DIR}/data/baselines/${GLVIS_BASELINE_SYS}
+           -a "-lw 1 -mslw 1 -nohidpi")
+
+  add_custom_target(_rebaseline_stream_${test_name}
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/data/baselines/local
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_CURRENT_BINARY_DIR}/test.${test_name}.saved.png
+        ${CMAKE_CURRENT_SOURCE_DIR}/data/baselines/local
+      DEPENDS
+        ${CMAKE_CURRENT_BINARY_DIR}/test.${test_name}.saved.png
+      VERBATIM)
+
+  add_dependencies(rebaseline _rebaseline_stream_${test_name})
+
+endforeach()
+
+endif(NOT EMSCRIPTEN)

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,3 +97,6 @@ You should leave this variable unset for development purposes, even if your
 development platform shares the same operating system; baselines are usually
 generated in these virtual environments with software rendering, and may not
 match the output of your specific system/graphics hardware.
+
+Reminder: after running `ctest` on master, developers can run `make rebaseline`
+to populate the local baseline with reference figures.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,99 @@
+                           GLVis visualization tool
+
+                     _/_/_/  _/      _/      _/  _/
+                  _/        _/      _/      _/        _/_/_/
+                 _/  _/_/  _/      _/      _/  _/  _/_/
+                _/    _/  _/        _/  _/    _/      _/_/
+                 _/_/_/  _/_/_/_/    _/      _/  _/_/_/
+
+                              http://glvis.org
+
+
+Automated testing for GLVis
+===========================
+This directory contains scripts and data for regression testing of GLVis:
+
+- `glvis_driver.py` is a Python script for running test cases and performing
+  comparisons on generated screenshots. Currently, the only supported mode is
+  *stream-based testing*, where given a saved input stream, commands are added
+  to the end of the stream to generate a screenshot and exit. This screenshot
+  can then be compared against a baseline image.
+
+- Test streams and baselines used in automated testing are stored in another
+  repository, [GLVis/data](https://github.com/GLVis/data), which is linked
+  into this repository as a submodule under the directory data.
+
+  To fetch the test data submodule, call `git submodule update --init` in an
+  existing clone of this repository.
+
+Dependencies
+------------
+Running tests with the test driver requires an installation of Python, with the
+`scikit-image` package. Install it using `pip` or your distribution's package
+manager.
+
+CMake is required to run the automated tests as they are used in Github Actions.
+The tests also expect `.png` images, so GLVis should be built with PNG support.
+
+CMake-based testing
+-------------------
+The test cases for automated testing are defined using `CTest`, and can be found
+in the `CMakeLists.txt` file in this directory. This is the method that is used
+by the Github Actions tests.
+
+To run all the tests:
+- Ensure that you have pulled in the data submodule.
+- Build GLVis using CMake, passing `-DENABLE_TESTS=ON` as a configuration
+  option.
+- Run `ctest` or `make test` to run all the test cases.
+
+Note that a set of baselines need to be generated manually for your specific
+system, due to differences in rendering between operating systems and graphics
+hardware. After the first run of `ctest` on master, run `make rebaseline` in
+the build directory. This will copy the generated images from the test run to a
+system-specific baseline directory.
+
+Standalone testing
+------------------
+You can also run an individual test case outside of `CTest`, with the following
+command:
+
+```sh
+python3 glvis_driver.py -e [path to glvis] \
+                        -s [path to stream file] \
+                        -b [path to stream baseline *directory*] \
+                        -a [additional commands to pass to glvis]
+```
+
+for example
+
+```sh
+python3 glvis_driver.py -e ../glvis -s data/streams/shaper.saved -b data/baselines/local -a "-lw 1 -mslw 1 -nohidpi"
+```
+
+A screenshot named "test.[stream file name].png" will be generated. If no path
+to a stream baseline directory is given, the test will exit; otherwise it will
+attempt to find and open the corresponding screenshot in the baseline directory
+and compare the two images.
+
+Details: Screenshot-based testing
+---------------------------------
+As implemented in the `glvis_driver.py` test,
+[structural similarity (SSIM)](https://en.wikipedia.org/wiki/Structural_similarity)
+is used to determine similarity between the generated test screenshot and the
+baseline screenshot.
+
+The current cutoff for an image and its baseline is set to 0.999; this allows
+for minor differences in rendering output.
+
+Details: Baselines
+------------------
+Two sets of public baselines are maintained: `ubuntu-20.04` and `macos-10.15`,
+each representing their corresponding Github Actions virtual environment. These
+are selected based on the value of the `GLVIS_BASELINE_SYS` CMake variable (set
+to `local` by default).
+
+You should leave this variable unset for development purposes, even if your
+development platform shares the same operating system; baselines are usually
+generated in these virtual environments with software rendering, and may not
+match the output of your specific system/graphics hardware.

--- a/tests/glvis_driver.py
+++ b/tests/glvis_driver.py
@@ -81,7 +81,7 @@ def test_case(exec_path, exec_args, baseline, t_group, t_name, cmd):
 
     ret = os.system("mv {0} {1}".format(screenshot_file, output_name))
     if ret != 0:
-        print("[FAIL] Could not copy output image: exit code {}.".format(ret))
+        print("[FAIL] Could not move output image: exit code {}.".format(ret))
         return False
 
     if baseline:

--- a/tests/glvis_driver.py
+++ b/tests/glvis_driver.py
@@ -1,0 +1,163 @@
+import argparse
+import sys
+import os
+from skimage.io import imread
+from skimage.metrics import structural_similarity
+
+# Below are key commands that are passed to the -keys command-line argument for
+# glvis in order to perform testing on raw mesh/grid function data (i.e. non-
+# streams).
+#
+# Currently not in use.
+test_cases = {
+    "magnify": "*****",
+    "axes1": "a",
+    "axes2": "aa",
+    "mesh1": "m",
+    "mesh2": "mm",
+    "cut_plane": "i",
+    "cut_plane_rotate": "iyyyy",
+    "cut_plane_rotate_back": "iyyyyYYYY",
+    "cut_plane_transl": "izzzz",
+    "cut_plane_transl_back": "izzzzZZZZ",
+    "orient2d_1": "R",
+    "orient2d_2": "RR",
+    "orient2d_3": "RRR",
+    "orient2d_4": "RRRR",
+    "orient2d_5": "RRRRR",
+    "orient2d_6": "RRRRRR",
+    "orient3d": "Rr",
+    "perspective": "j",
+}
+
+screenshot_keys = "Sq"
+screenshot_file = "GLVis_s01.png"
+
+cutoff_ssim = 0.999
+
+def compare_images(baseline_file, output_file, expect_fail=False):
+    # Try to open output image
+    output_img = imread(output_file)
+    if output_img is None:
+        print("[FAIL] Could not open output image.")
+        return False
+
+    # Try to open baseline image
+    baseline_img = imread(baseline_file)
+    if baseline_img is None:
+        print("[IGNORE] No baseline exists to compare against.")
+        return True
+
+    # Compare images with SSIM metrics. For two exactly-equal images, SSIM=1.0.
+    # We set a cutoff of 0.999 to account for possible differences in rendering.
+    ssim = structural_similarity(baseline_img, output_img, multichannel=True)
+    if ssim < cutoff_ssim:
+        if expect_fail:
+            print("[PASS] Differences were detected in the control case.")
+        else:
+            print("[FAIL] Output and baseline are different.")
+    else:
+        if expect_fail:
+            print("[FAIL] Differences were not detected in the control case.")
+        else:
+            print("[PASS] Images match.")
+    print("       actual ssim = {}, cutoff = {}".format(ssim, cutoff_ssim))
+    return ssim >= cutoff_ssim if not expect_fail else ssim < cutoff_ssim
+
+# Function to test a given glvis command with a variety of key-based commands.
+# Not currently in use.
+def test_case(exec_path, exec_args, baseline, t_group, t_name, cmd):
+    print("Testing {0}:{1}...".format(t_group, t_name))
+    full_screenshot_cmd = cmd + screenshot_keys
+    cmd = "{0} {1} -k \"{2}\"".format(exec_path, exec_args, full_screenshot_cmd)
+    print("Exec: {}".format(cmd))
+    ret = os.system(cmd + " > /dev/null 2>&1")
+    if ret != 0:
+        print("[FAIL] GLVis exited with error code {}.".format(ret))
+        return False
+    if not os.path.exists(t_group):
+        os.mkdir(t_group)
+    output_name = "{0}/{1}.png".format(t_group, t_name)
+
+    ret = os.system("mv {0} {1}".format(screenshot_file, output_name))
+    if ret != 0:
+        print("[FAIL] Could not copy output image: exit code {}.".format(ret))
+        return False
+
+    if baseline:
+        baseline_name = "{0}/test.{1}.png".format(baseline, test_name)
+        return compare_images(baseline_name, output_name)
+    else:
+        print("[IGNORE] No baseline exists to compare against.")
+        return True
+
+def test_stream(exec_path, exec_args, save_file, baseline):
+    if exec_args is None:
+        exec_args = ""
+    test_name = os.path.basename(save_file)
+    print("Testing {}...".format(save_file))
+
+    # Create new stream file with command to screenshot and close
+    stream_data = None
+    with open(save_file) as in_f:
+        stream_data = in_f.read()
+
+    output_name = "test.{}.png".format(test_name)
+    output_name_fail = "test.fail.{}.png".format(test_name)
+    tmp_file = "test.saved"
+    with open(tmp_file, 'w') as out_f:
+        out_f.write(stream_data)
+        out_f.write("\nwindow_size 800 600")
+        out_f.write("\nscreenshot {}".format(output_name))
+        # Zooming in should create some difference in the images
+        out_f.write("\nkeys *")
+        out_f.write("\nscreenshot {}".format(output_name_fail))
+        out_f.write("\nkeys q")
+
+    # Run GLVis with modified stream file
+    cmd = "{0} {1} -saved {2}".format(exec_path, exec_args, tmp_file)
+    print("Exec: {}".format(cmd))
+    ret = os.system(cmd)
+    if ret != 0:
+        print("[FAIL] GLVis exited with error code {}.".format(ret))
+        return False
+
+    if baseline:
+        baseline_name = "{0}/test.{1}.png".format(baseline, test_name)
+        test_baseline = compare_images(baseline_name, output_name)
+        test_control = compare_images(baseline_name, output_name_fail,
+                                      expect_fail=True)
+        return (test_baseline and test_control)
+    else:
+        print("[IGNORE] No baseline exists to compare against.")
+        return True
+
+def test_cmd(exec_path, exec_args, tgroup, baseline):
+    try:
+        os.remove(screenshot_file)
+    except OSError:
+        pass
+    all_tests_passed = True
+    for testname, cmds in test_cases.items():
+        result = test_case(exec_path, exec_args, baseline, tgroup, testname, cmds)
+        all_tests_passed = all_tests_passed and result
+
+    if all_tests_passed:
+        print("All tests passed.")
+    else:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--save_stream", help="Path to a GLVis saved stream file.")
+    parser.add_argument("-e", "--exec_cmd", help="Path to the GLVis executable")
+    parser.add_argument("-a", "--exec_args", help="Arguments to pass to GLVis.")
+    parser.add_argument("-n", "--group_name", help="Name of the test group.")
+    parser.add_argument("-b", "--baseline", help="Path to test baseline.")
+    args = parser.parse_args()
+    if args.save_stream is not None:
+        result = test_stream(args.exec_cmd, args.exec_args, args.save_stream, args.baseline)
+        if not result:
+            sys.exit(1)
+    else:
+        test_cmd(args.exec_cmd, args.exec_args, args.group_name, args.baseline)


### PR DESCRIPTION
This PR cleans up the commit history from #176.

Summary
======
- Adds CTest-based regression testing.
  - A test driver, `tests/glvis_driver.py`, runs glvis with a modified stream that generates screenshots.
    Two screenshots are generated: one with the original image from the stream, and one with the `*` key command applied to induce a slight change in the image.
    Screenshots can then be compared against a baseline with the structural similarity metric. A given test case passes if the original image is above the SSIM cutoff of 0.999 and the control image is below this cutoff.
  - Tests are run in headless mode for both `ubuntu-20.04` and `macos-10.15` in Github Actions, with streams and corresponding baselines available in [GLVis/data](https://github.com/GLVis/data)
- Bugfixes/miscellaneous changes:
  - Fix some issues with screenshots on macOS and Linux
  - Improve `SignalKeyDown()` handling for X11
  - Handle resizes synchronously in the main thread
  - Improve error handling with SDL