### PR TITLE
Minor cleanup of thread signaling

### DIFF
--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -626,7 +626,7 @@ void SdlWindow::signalKeyDown(SDL_Keycode k, SDL_Keymod m)
       event.key.keysym.sym = k;
       event.key.keysym.mod = m;
    }
-   SDL_PushEvent(&event);
+   queueEvents({ event });
 }
 
 void SdlWindow::swapBuffer()

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -419,12 +419,22 @@ void SdlWindow::mainIter()
    }
    else if (onIdle)
    {
+      {
+         unique_lock<mutex> event_lock{event_mutex};
+         call_idle_func = false;
+      }
       bool sleep = onIdle();
       if (is_multithreaded && sleep)
       {
          // Wait for next wakeup event from main event thread
          unique_lock<mutex> event_lock{event_mutex};
-         events_available.wait(event_lock);
+         events_available.wait(
+            event_lock,
+            [this]()
+            {
+               // Sleep until events from WM or glvis_command can be handled
+               return !waiting_events.empty() || call_idle_func;
+            });
       }
    }
    if (wnd_state == RenderState::ExposePending)
@@ -498,7 +508,11 @@ void SdlWindow::mainLoop()
 void SdlWindow::signalLoop()
 {
    // Note: not executed from the main thread
-   GetMainThread().SendEvent();
+   {
+      lock_guard<mutex> evt_guard{event_mutex};
+      call_idle_func = true;
+   }
+   events_available.notify_all();
 }
 
 void SdlWindow::getWindowSize(int& w, int& h)

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -137,6 +137,8 @@ private:
 
    bool is_multithreaded{true};
 
+   bool call_idle_func{false};
+
    // Hand off events to the SdlWindow. Intended to be called by the main SDL
    // thread in MainThread::MainLoop().
    void queueEvents(std::vector<SDL_Event> events)

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -238,11 +238,6 @@ void SdlMainThread::DispatchSDLEvents()
       {
          wnd->queueEvents(std::move(wnd_events[windowId]));
       }
-      else
-      {
-         // Wake up the worker thread anyways, to execute onIdle
-         wnd->queueEvents({});
-      }
    }
 }
 

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -35,7 +35,6 @@ struct SdlMainThread::CreateWindowCmd
    std::string title;
    int x, y, w, h;
    bool legacy_gl_only;
-   bool window_create_executed;
    promise<Handle> out_handle;
 };
 
@@ -254,9 +253,7 @@ SdlMainThread::Handle SdlMainThread::GetHandle(SdlWindow* wnd,
                                                const std::string& title,
                                                int x, int y, int w, int h, bool legacyGlOnly)
 {
-   CreateWindowCmd cmd_create = { wnd, title, x, y, w, h, legacyGlOnly, false,
-                                  {}
-                                };
+   CreateWindowCmd cmd_create = { wnd, title, x, y, w, h, legacyGlOnly, {} };
    future<Handle> res_handle = cmd_create.out_handle.get_future();
 
    SdlCtrlCommand main_thread_cmd;
@@ -585,7 +582,6 @@ void SdlMainThread::createWindowImpl(CreateWindowCmd& cmd)
    SDL_GL_SetAttribute( SDL_GL_DEPTH_SIZE, 24);
    probeGLContextSupport(cmd.legacy_gl_only);
    Handle new_handle(cmd.title, cmd.x, cmd.y, cmd.w, cmd.h, win_flags);
-   cmd.window_create_executed = true;
 
    // at this point, window should be up
    if (!new_handle.isInitialized())

--- a/lib/sdl_main.cpp
+++ b/lib/sdl_main.cpp
@@ -59,11 +59,6 @@ SdlMainThread::SdlMainThread()
          std::cerr << "FATAL: Failed to initialize SDL: " << SDL_GetError() << endl;
       }
       SDL_EnableScreenSaver();
-      glvis_event_type = SDL_RegisterEvents(1);
-      if (glvis_event_type == (Uint32)(-1))
-      {
-         cerr << "SDL_RegisterEvents(1) failed: " << SDL_GetError() << endl;
-      }
    }
 
    SDL_version sdl_ver;

--- a/lib/sdl_main.hpp
+++ b/lib/sdl_main.hpp
@@ -31,8 +31,6 @@ public:
 
    bool SdlInitialized() const { return sdl_init; }
 
-   Uint32 GetCustomEvent() const { return glvis_event_type; }
-
    // Handles all SDL operations that are expected to be handled on the main
    // SDL thread (i.e. events and window creation)
    void MainLoop(bool server_mode);
@@ -108,7 +106,6 @@ private:
 
    void handleBackgroundWindowEvent(SDL_WindowEvent e);
 
-   Uint32 glvis_event_type {(Uint32)-1};
    bool sdl_init {false};
    bool sdl_multithread {true};
 

--- a/lib/sdl_main.hpp
+++ b/lib/sdl_main.hpp
@@ -12,7 +12,6 @@
 #ifndef GLVIS_SDL_MAIN_HPP
 #define GLVIS_SDL_MAIN_HPP
 
-#include <atomic>
 #include <set>
 #include <condition_variable>
 

--- a/lib/sdl_main.hpp
+++ b/lib/sdl_main.hpp
@@ -59,17 +59,6 @@ public:
    // Issues a command on the main thread to set the window position.
    void SetWindowPosition(const Handle& handle, int x, int y);
 
-   // Wakes up the main thread, if sleeping.
-   void SendEvent()
-   {
-      std::unique_lock<std::mutex> platform_lk{event_mtx};
-      event_cv.wait(platform_lk, [this]() { return try_create_platform; });
-      if (platform)
-      {
-         platform->SendEvent();
-      }
-   }
-
    SdlNativePlatform* GetPlatform() const { return platform.get(); }
 
 private:
@@ -85,6 +74,17 @@ private:
       SetSize,
       SetPosition
    };
+
+   // Wakes up the main thread, if sleeping.
+   void SendEvent()
+   {
+      std::unique_lock<std::mutex> platform_lk{event_mtx};
+      event_cv.wait(platform_lk, [this]() { return try_create_platform; });
+      if (platform)
+      {
+         platform->SendEvent();
+      }
+   }
 
    void queueWindowEvent(SdlCtrlCommand cmd);
 

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -23,6 +23,8 @@ GLVisCommand::GLVisCommand(
 {
    vs        = _vs;
    keep_attr = _keep_attr;
+   thread_wnd = GetAppWindow(); // should be set in this thread by a call to
+                                // InitVisualization()
 
    num_waiting = 0;
    terminating = false;
@@ -57,10 +59,9 @@ int GLVisCommand::signal()
 {
    command_ready = true;
 
-   SdlWindow *sdl_window = GetAppWindow();
-   if (sdl_window)
+   if (thread_wnd)
    {
-      sdl_window->signalLoop();
+      thread_wnd->signalLoop();
    }
 
    return 0;

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -26,6 +26,7 @@ private:
    VisualizationSceneScalarData **vs;
    StreamState&         curr_state;
    bool                 *keep_attr;
+   SdlWindow            *thread_wnd;
 
    std::mutex glvis_mutex;
    std::condition_variable glvis_cond;


### PR DESCRIPTION
- For `SdlWindow::signalLoop()` and `SdlWindow::signalKeyDown()`: instead of waking the main thread, which then wakes up the worker threads, we just signal the target worker thread directly.
  This avoids waking up all the worker threads to handle just a single thread's pending stream-based event. (i.e. the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem))
- Removes the no-longer-needed custom SDL event mechanism.
- Removes an unused parameter from `SdlMainThread::CreateWindowCmd`.