### PR TITLE
HiDPI fix for JS builds

### DIFF
--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -48,7 +48,7 @@ float line_w_aa = gl3::LINE_WIDTH_AA;
 
 thread_local SdlWindow * wnd = nullptr;
 bool wndLegacyGl = false;
-bool wndUseHiDPI = false;
+bool wndUseHiDPI = true;
 void SDLMainLoop(bool server_mode)
 {
    SdlWindow::StartSDL(server_mode);


### PR DESCRIPTION
PR #189 inadvertently disabled HiDPI support for Javascript builds. This re-enables it.

Along with GLVis/GLVis-js#12, this should fix #182.