### PR TITLE
Reformat with AStyle-3.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ Before you can start, you need a GitHub account, here are a few suggestions:
     documentation in source comments.
   - Consistent code styling is enforced with `make style` in the top-level
     directory. This requires [Artistic Style](http://astyle.sourceforge.net)
-    version 2.05.1 and MFEM's style configuration file, typically located in
+    version 3.1 and MFEM's style configuration file, typically located in
     `../mfem/config/mfem.astylerc`.
   - When manually resolving conflicts during a merge, make sure to mention the
     conflicted files in the commit message.

--- a/lib/gl/attr_traits.hpp
+++ b/lib/gl/attr_traits.hpp
@@ -125,9 +125,9 @@ AttrNormal<TV, decltype((void)TV::norm, 0)>>
    const static GLenum FFArrayIdx = GL_NORMAL_ARRAY;
    static void FFSetupFunc(GLint /*size*/, GLenum type, GLsizei stride,
                            const GLvoid* ptr)
-{
-   glNormalPointer(type, stride, ptr);
-}
+   {
+      glNormalPointer(type, stride, ptr);
+   }
 };
 
 template<typename TV>

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -203,10 +203,10 @@ struct alignas(16) Vertex
    std::array<float, 3> coord;
 
    static Vertex create(double * d)
-{
-   return Vertex {(float) d[0], (float) d[1], (float) d[2]};
-}
-static const int layout = LAYOUT_VTX;
+   {
+      return Vertex {(float) d[0], (float) d[1], (float) d[2]};
+   }
+   static const int layout = LAYOUT_VTX;
 };
 
 struct alignas(16) VertexColor

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -70,6 +70,7 @@ glm::mat4 Camera::RotMatrix()
 {
    GetLeft();
 
+   // *INDENT-OFF*
    double mat[16] =
    {
       -left[0], up[0], -dir[0], 0.0,
@@ -77,19 +78,22 @@ glm::mat4 Camera::RotMatrix()
       -left[2], up[2], -dir[2], 0.0,
       0.0, 0.0, 0.0, 1.0
    };
+   // *INDENT-ON*
    return glm::make_mat4(mat);
 }
 
 glm::mat4 Camera::TransposeRotMatrix()
 {
    GetLeft();
+   // *INDENT-OFF*
    double mat_t[16] =
    {
       -left[0], -left[1], -left[2], 0.0,
-      up[0],    up[1],    up[2],   0.0,
-      -dir[0],  -dir[1],  -dir[2],  0.0,
+         up[0],    up[1],    up[2], 0.0,
+       -dir[0],  -dir[1],  -dir[2], 0.0,
       0.0, 0.0, 0.0, 1.0
    };
+   // *INDENT-ON*
    return glm::make_mat4(mat_t);
 }
 


### PR DESCRIPTION
MFEM switched to AStyle-3.1 in https://github.com/mfem/mfem/pull/2506.

This PR applies the new formatting in GLVis.