### PR TITLE
Add 3D scene export to glTF format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,9 @@
 Version 4.1.1 (development)
 ===========================
 
+- Added 3D scene export to glTF format (https://www.khronos.org/gltf) which is
+  bound to the key 'G'.
+
 - Added a third mode to keys 'b'/'B' in 2D to display the mesh boundary colored
   by boundary element attribute.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,7 +13,8 @@ Version 4.1.1 (development)
 ===========================
 
 - Added 3D scene export to glTF format (https://www.khronos.org/gltf) which is
-  bound to the key 'G'.
+  bound to the key 'G'. This can be used to import GLVis scenes for rendering in
+  Blender, as well as for augmented reality, see https://modelviewer.dev/editor.
 
 - Added a third mode to keys 'b'/'B' in 2D to display the mesh boundary colored
   by boundary element attribute.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND SOURCES
   gl/types.cpp
   aux_vis.cpp
   font.cpp
+  gltf.cpp
   material.cpp
   openglvis.cpp
   palettes.cpp
@@ -39,6 +40,7 @@ list(APPEND HEADERS
   aux_vis.hpp
   font.hpp
   geom_utils.hpp
+  gltf.hpp
   logo.hpp
   material.hpp
   openglvis.hpp

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -891,7 +891,8 @@ int InvertSurfaceVertical(SDL_Surface *surface)
 }
 
 #ifdef GLVIS_USE_LIBPNG
-int SaveAsPNG(const char *fname, int w, int h, bool is_hidpi, bool with_alpha)
+int SaveAsPNG(const char *fname, int w, int h, bool is_hidpi, bool with_alpha,
+              std::function<void(int,void*)> get_row)
 {
    png_byte *pixels = new png_byte[(with_alpha ? 4 : 3)*w];
    if (!pixels)
@@ -944,8 +945,15 @@ int SaveAsPNG(const char *fname, int w, int h, bool is_hidpi, bool with_alpha)
    png_write_info(png_ptr, info_ptr);
    for (int i = 0; i < h; i++)
    {
-      glReadPixels(0, h-1-i, w, 1, with_alpha ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE,
-                   pixels);
+      if (!get_row)
+      {
+         glReadPixels(0, h-1-i, w, 1, with_alpha ? GL_RGBA : GL_RGB,
+                      GL_UNSIGNED_BYTE, pixels);
+      }
+      else
+      {
+         get_row(i, pixels);
+      }
       png_write_row(png_ptr, pixels);
    }
    png_write_end(png_ptr, info_ptr);

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -19,6 +19,8 @@
 #include "sdl.hpp"
 #include "font.hpp"
 
+#include <functional>
+
 void SDLMainLoop(bool server_mode = false);
 
 /// Initializes the visualization and some keys.
@@ -102,7 +104,8 @@ void SetWindowTitle(const char *title);
 int Screenshot(const char *fname, bool convert = false);
 #ifdef GLVIS_USE_LIBPNG
 int SaveAsPNG(const char *fname, int w, int h, bool is_hidpi,
-              bool with_alpha=false);
+              bool with_alpha = false,
+              std::function<void(int,void*)> get_row = nullptr);
 #endif
 
 /// Send a sequence of keystrokes to the visualization window

--- a/lib/gl/types.cpp
+++ b/lib/gl/types.cpp
@@ -96,7 +96,7 @@ void GlDrawable::addCone(float x, float y, float z,
 void GlBuilder::saveVertex(const GlBuilder::FFState& v)
 {
    GLenum dst_buf = is_line ? GL_LINES : GL_TRIANGLES;
-   if (!use_norm)
+   if (is_line || !use_norm)
    {
       if (use_color)
       {

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -35,6 +35,8 @@
 
 using namespace std;
 
+class VisualizationScene;
+
 namespace gl3
 {
 
@@ -599,6 +601,7 @@ private:
 
    friend class GlBuilder;
    friend class MeshRenderer;
+   friend class ::VisualizationScene; // needed for glTF export
 
    template<typename Vert>
    VertexBuffer<Vert> * getBuffer(GLenum shape)

--- a/lib/gltf.cpp
+++ b/lib/gltf.cpp
@@ -1,0 +1,631 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "gltf.hpp"
+#include "aux_vis.hpp" // SaveAsPNG
+
+
+glTF_Builder::buffer_id
+glTF_Builder::addBuffer(const std::string &bufferName)
+{
+   buffers.resize(buffers.size() + 1);
+   auto &buf = buffers.back();
+   buf.uri.value = file_prefix + "." + bufferName + ".bin";
+   buf.uri.valid = true;
+   buf.byteLength.value = 0;
+   buf.byteLength.valid = true;
+   buf.file.open(buf.uri.value, std::ios::out | std::ios::binary);
+
+   return {(unsigned)buffers.size() - 1};
+}
+
+glTF_Builder::buffer_view_id
+glTF_Builder::addBufferView(buffer_id buffer,
+                            const void *data,
+                            size_t byteLength,
+                            size_t byteStride,
+                            size_t byteAlign,
+                            target_type target)
+{
+   if (buffer.id >= buffers.size()) { return {INVALID_ID}; }
+
+   buffer_views.resize(buffer_views.size() + 1);
+   auto &buf_view = buffer_views.back();
+   auto &buf = buffers[buffer.id];
+
+   buf_view.buffer.value = buffer.id;
+   buf_view.buffer.valid = true;
+
+   const unsigned buf_offset = buf.byteLength.value;
+   const unsigned new_offset = byteAlign*((buf_offset+byteAlign-1)/byteAlign);
+   buf_view.byteOffset.value = new_offset;
+   buf_view.byteOffset.valid = true;
+
+   buf_view.byteLength.value = byteLength;
+   buf_view.byteLength.valid = true;
+
+   if (target == target_type::ARRAY_BUFFER)
+   {
+      buf_view.byteStride.value = byteStride;
+      buf_view.byteStride.valid = true;
+   }
+
+   buf_view.target.value = (unsigned)target;
+   buf_view.target.valid = true;
+
+   // append padding to file
+   for (unsigned i = buf_offset; i != new_offset; ++i) { buf.file.put('\0'); }
+   // write data to file
+   buf.file.write(reinterpret_cast<const char *>(data), byteLength);
+
+   buf.byteLength.value = new_offset + byteLength;
+
+   return {(unsigned)buffer_views.size() - 1};
+}
+
+void glTF_Builder::appendToBufferView(buffer_view_id bufferView,
+                                      const void *data,
+                                      size_t byteLength)
+{
+   if (bufferView.id >= buffer_views.size()) { return; }
+
+   auto &buf_view = buffer_views[bufferView.id];
+   auto &buf = buffers[buf_view.buffer.value];
+
+   buf_view.byteLength.value += byteLength;
+
+   buf.file.write(reinterpret_cast<const char *>(data), byteLength);
+   buf.byteLength.value += byteLength;
+}
+
+glTF_Builder::accessor_id
+glTF_Builder::addAccessor(buffer_view_id bufferView,
+                          size_t byteOffset,
+                          component_type componentType,
+                          size_t count,
+                          tensor_type tensorType)
+{
+   if (bufferView.id >= buffer_views.size() || count == 0)
+   {
+      return {INVALID_ID};
+   }
+
+   accessors.resize(accessors.size() + 1);
+   auto &acc = accessors.back();
+
+   acc.bufferView.value = bufferView.id;
+   acc.bufferView.valid = true;
+
+   acc.byteOffset.value = byteOffset;
+   acc.byteOffset.valid = true;
+
+   acc.componentType.value = (unsigned)componentType;
+   acc.componentType.valid = true;
+
+   acc.count.value = count;
+   acc.count.valid = true;
+
+   acc.type.value = tensorTypes[(unsigned)tensorType];
+   acc.type.valid = true;
+
+   // Note: acc.min and acc.max remain invalid and will not be written too file
+
+   if (componentType != component_type::FLOAT &&
+       buffer_views[bufferView.id].target.value !=
+       (unsigned)target_type::ELEMENT_ARRAY_BUFFER)
+   {
+      acc.normalized.value = true;
+      acc.normalized.valid = true;
+   }
+
+   return {(unsigned)accessors.size() - 1};
+}
+
+glTF_Builder::accessor_id
+glTF_Builder::addAccessorVec2f(buffer_view_id bufferView,
+                               size_t byteOffset,
+                               size_t count,
+                               vec2f min,
+                               vec2f max)
+{
+   auto id = addAccessor(bufferView,
+                         byteOffset,
+                         component_type::FLOAT,
+                         count,
+                         tensor_type::VEC2);
+
+   if (id.id != INVALID_ID)
+   {
+      auto &acc = accessors[id.id];
+      acc.min.value.assign(min.begin(), min.end());
+      acc.min.valid = true;
+      acc.max.value.assign(max.begin(), max.end());
+      acc.max.valid = true;
+   }
+
+   return id;
+}
+
+glTF_Builder::accessor_id
+glTF_Builder::addAccessorVec3f(buffer_view_id bufferView,
+                               size_t byteOffset,
+                               size_t count,
+                               vec3f min,
+                               vec3f max)
+{
+   auto id = addAccessor(bufferView,
+                         byteOffset,
+                         component_type::FLOAT,
+                         count,
+                         tensor_type::VEC3);
+
+   if (id.id != INVALID_ID)
+   {
+      auto &acc = accessors[id.id];
+      acc.min.value.assign(min.begin(), min.end());
+      acc.min.valid = true;
+      acc.max.value.assign(max.begin(), max.end());
+      acc.max.valid = true;
+   }
+
+   return id;
+}
+
+glTF_Builder::image_id
+glTF_Builder::addImage(const std::string &imageName,
+                       int width,
+                       int height,
+                       const color4f *pixels)
+{
+#ifndef GLVIS_USE_LIBPNG
+
+   return {INVALID_ID};
+
+#else
+
+   images.resize(images.size() + 1);
+   auto &img = images.back();
+
+   img.uri.value = file_prefix + "." + imageName + ".png";
+   img.uri.valid = true;
+
+   img.name.value = imageName;
+   img.name.valid = true;
+
+   // write the image
+   auto get_row = [&](int row, void *pxls)
+   {
+      auto pxls_out = reinterpret_cast<array<uint8_t,4>*>(pxls);
+      auto pxls_in = pixels + row*width;
+      for (int i = 0; i < width; ++i)
+      {
+         for (int j = 0; j < 4; ++j)
+         {
+            pxls_out[i][j] = std::min(int(pxls_in[i][j]*256), 255);
+         }
+      }
+   };
+   SaveAsPNG(img.uri.value.c_str(), width, height,
+             /* is_hidpi: */ false, /* with_alpha: */ true, get_row);
+
+   return {(unsigned)images.size() - 1};
+
+#endif // GLVIS_USE_LIBPNG
+}
+
+glTF_Builder::sampler_id
+glTF_Builder::addSampler(mag_filter magFilter,
+                         min_filter minFilter,
+                         wrap_type wrapS,
+                         wrap_type wrapT)
+{
+   samplers.resize(samplers.size() + 1);
+   auto &sampler = samplers.back();
+
+   sampler.magFilter.value = (unsigned)magFilter;
+   sampler.magFilter.valid = true;
+
+   sampler.minFilter.value = (unsigned)minFilter;
+   sampler.minFilter.valid= true;
+
+   sampler.wrapS.value = (unsigned)wrapS;
+   sampler.wrapS.valid = true;
+
+   sampler.wrapT.value = (unsigned)wrapT;
+   sampler.wrapT.valid = true;
+
+   return {(unsigned)samplers.size() - 1};
+}
+
+glTF_Builder::texture_id
+glTF_Builder::addTexture(sampler_id sampler, image_id source)
+{
+   if (sampler.id >= samplers.size() || source.id >= images.size())
+   {
+      return {INVALID_ID};
+   }
+
+   textures.resize(textures.size() + 1);
+   auto &tex = textures.back();
+
+   tex.sampler.value = sampler.id;
+   tex.sampler.valid = true;
+
+   tex.source.value = source.id;
+   tex.source.valid = true;
+
+   return {(unsigned)textures.size() - 1};
+}
+
+glTF_Builder::material_id
+glTF_Builder::addMaterial(const std::string &materialName,
+                          const pbr_matallic_roughness &pbrMetallicRoughness,
+                          bool doubleSided)
+{
+   if (pbrMetallicRoughness.haveTexture &&
+       pbrMetallicRoughness.baseColorTexture.id >= textures.size())
+   {
+      return {INVALID_ID};
+   }
+
+   materials.resize(materials.size() + 1);
+   auto &mat = materials.back();
+
+   mat.name.value = materialName;
+   mat.name.valid = true;
+
+   auto &pbr = mat.pbrMetallicRoughness.value;
+
+   pbr.baseColorFactor.value = pbrMetallicRoughness.baseColorFactor;
+   pbr.baseColorFactor.valid = true;
+
+   auto &tex_info = pbr.baseColorTexture.value;
+
+   tex_info.index.value = pbrMetallicRoughness.baseColorTexture.id;
+   tex_info.index.valid = true;
+
+   tex_info.texCoord.value = 0;
+   tex_info.texCoord.valid = true;
+
+   pbr.baseColorTexture.valid = pbrMetallicRoughness.haveTexture;
+
+   pbr.metallicFactor.value = pbrMetallicRoughness.metallicFactor;
+   pbr.metallicFactor.valid = true;
+
+   pbr.roughnessFactor.value = pbrMetallicRoughness.roughnessFactor;
+   pbr.roughnessFactor.valid = true;
+
+   mat.pbrMetallicRoughness.valid = true;
+
+   mat.doubleSided.value = doubleSided;
+   mat.doubleSided.valid = true;
+
+   return {(unsigned)materials.size() - 1};
+}
+
+glTF_Builder::mesh_id
+glTF_Builder::addMesh(const std::string &meshName)
+{
+   meshes.resize(meshes.size() + 1);
+   auto &mesh = meshes.back();
+
+   mesh.name.value = meshName;
+   mesh.name.valid = true;
+
+   return {(unsigned)meshes.size() - 1};
+}
+
+void glTF_Builder::addMeshTriangles(mesh_id mesh,
+                                    accessor_id vertexPositions,
+                                    accessor_id vertexNormals,
+                                    accessor_id vertexTexCoords0,
+                                    accessor_id vertexIndices,
+                                    material_id material)
+{
+   if (mesh.id >= meshes.size() || vertexPositions.id >= accessors.size())
+   { return; }
+
+   auto &primitives = meshes[mesh.id].primitives;
+   primitives.resize(primitives.size() + 1);
+   auto &pri = primitives.back();
+
+   pri.attributes.value.POSITION.value = vertexPositions.id;
+   pri.attributes.value.POSITION.valid = true;
+
+   if (vertexNormals.id < accessors.size())
+   {
+      pri.attributes.value.NORMAL.value = vertexNormals.id;
+      pri.attributes.value.NORMAL.valid = true;
+   }
+
+   if (vertexTexCoords0.id < accessors.size())
+   {
+      pri.attributes.value.TEXCOORD_0.value = vertexTexCoords0.id;
+      pri.attributes.value.TEXCOORD_0.valid = true;
+   }
+
+   pri.attributes.valid = true;
+
+   if (vertexIndices.id < accessors.size())
+   {
+      pri.indices.value = vertexIndices.id;
+      pri.indices.valid = true;
+   }
+
+   if (material.id < materials.size())
+   {
+      pri.material.value = material.id;
+      pri.material.valid = true;
+   }
+
+   // pri.mode remains undefined since default is 4 = TRIANGLES
+}
+
+void glTF_Builder::addMeshLines(mesh_id mesh,
+                                accessor_id vertexPositions,
+                                accessor_id vertexTexcoords0,
+                                accessor_id vertexColors0,
+                                material_id material)
+{
+   if (mesh.id >= meshes.size()) { return; }
+
+   auto &primitives = meshes[mesh.id].primitives;
+   primitives.resize(primitives.size() + 1);
+   auto &pri = primitives.back();
+
+   pri.attributes.value.POSITION.value = vertexPositions.id;
+   pri.attributes.value.POSITION.valid = true;
+
+   if (vertexTexcoords0.id < accessors.size())
+   {
+      pri.attributes.value.TEXCOORD_0.value = vertexTexcoords0.id;
+      pri.attributes.value.TEXCOORD_0.valid = true;
+   }
+   else if (vertexColors0.id < accessors.size())
+   {
+      pri.attributes.value.COLOR_0.value = vertexColors0.id;
+      pri.attributes.value.COLOR_0.valid = true;
+   }
+
+   // NORMAL remains undefined
+
+   pri.attributes.valid = true;
+
+   // pri.indices remain undefined
+
+   if (material.id < materials.size())
+   {
+      pri.material.value = material.id;
+      pri.material.valid = true;
+   }
+
+   pri.mode.value = 1; // = LINES
+   pri.mode.valid = true;
+}
+
+glTF_Builder::node_id
+glTF_Builder::addNode(const std::string &nodeName)
+{
+   nodes.resize(nodes.size() + 1);
+   auto &node = nodes.back();
+
+   node.name.value = nodeName;
+   node.name.valid = true;
+
+   return {(unsigned)nodes.size() - 1};
+}
+
+void glTF_Builder::addNodeMesh(node_id node, mesh_id mesh)
+{
+   if (node.id >= nodes.size()) { return; }
+
+   nodes[node.id].mesh.value = mesh.id;
+   nodes[node.id].mesh.valid = true;
+}
+
+void glTF_Builder::addNodeScale(node_id node, vec3f scale)
+{
+   if (node.id >= nodes.size()) { return; }
+
+   nodes[node.id].scale.value = scale;
+   nodes[node.id].scale.valid = true;
+}
+
+void glTF_Builder::addNodeTranslation(node_id node, vec3f translation)
+{
+   if (node.id >= nodes.size()) { return; }
+
+   nodes[node.id].translation.value = translation;
+   nodes[node.id].translation.valid = true;
+}
+
+void glTF_Builder::getMaterialPBRMR(material_id material,
+                                    pbr_matallic_roughness &pbr_mr_copy)
+{
+   if (material.id >= materials.size()) { return; }
+
+   auto &mat = materials[material.id];
+   auto &pbr = mat.pbrMetallicRoughness.value;
+
+   pbr_mr_copy.haveTexture = pbr.baseColorTexture.valid;
+   pbr_mr_copy.baseColorFactor = pbr.baseColorFactor.value;
+   pbr_mr_copy.baseColorTexture = {pbr.baseColorTexture.value.index.value};
+   pbr_mr_copy.metallicFactor = pbr.metallicFactor.value;
+   pbr_mr_copy.roughnessFactor = pbr.roughnessFactor.value;
+}
+
+int glTF_Builder::writeFile()
+{
+   if (nodes.size() == 0)
+   {
+      return 1;
+   }
+
+   ofstream gltf(file_prefix + ".gltf");
+   gltf.precision(8);
+   gltf.setf(ios::boolalpha);
+
+   // ~~~ Tutorial ~~~
+   // https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/README.md
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-scene
+   gltf <<
+        "{\n"
+        "  \"scene\": 0,\n"
+        "  \"scenes\" : [ {\n"
+        "      \"nodes\" : [";
+   for (size_t i = 0; i != nodes.size(); ++i) { gltf << sep(i) << ' ' << i; }
+   gltf <<
+        " ]\n"
+        "  } ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-node
+   gltf << "  \"nodes\" : [";
+   for (size_t i = 0; i != nodes.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", nodes[i].name);
+      print_node(gltf, pos, "\n    ", nodes[i].mesh);
+      print_node(gltf, pos, "\n    ", nodes[i].scale);
+      print_node(gltf, pos, "\n    ", nodes[i].translation);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-mesh
+   gltf << "  \"meshes\" : [";
+   for (size_t i = 0; i != meshes.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", meshes[i].name);
+      gltf << sep(pos++) << "\n    \"primitives\" : [";
+      auto &primitives = meshes[i].primitives;
+      for (size_t j = 0; j != primitives.size(); ++j)
+      {
+         gltf << sep(j) << " {";
+         int pos2 = 0;
+         print_node(gltf, pos2, "\n      ", primitives[j].attributes);
+         print_node(gltf, pos2, "\n      ", primitives[j].indices);
+         print_node(gltf, pos2, "\n      ", primitives[j].material);
+         print_node(gltf, pos2, "\n      ", primitives[j].mode);
+         gltf << "\n    }";
+      }
+      gltf << " ]\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material
+   gltf << "  \"materials\" : [";
+   for (size_t i = 0; i != materials.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", materials[i].name);
+      print_node(gltf, pos, "\n    ", materials[i].pbrMetallicRoughness);
+      print_node(gltf, pos, "\n    ", materials[i].doubleSided);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   gltf << "  \"textures\" : [";
+   for (size_t i = 0; i != textures.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", textures[i].sampler);
+      print_node(gltf, pos, "\n    ", textures[i].source);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   gltf << "  \"images\" : [";
+   for (size_t i = 0; i != images.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", images[i].name);
+      print_node(gltf, pos, "\n    ", images[i].uri);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-sampler
+   // see also: PaletteState::{ToTextureDiscrete(),ToTextureSmooth()}
+   gltf << "  \"samplers\" : [";
+   for (size_t i = 0; i != samplers.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", samplers[i].magFilter);
+      print_node(gltf, pos, "\n    ", samplers[i].minFilter);
+      print_node(gltf, pos, "\n    ", samplers[i].wrapS);
+      print_node(gltf, pos, "\n    ", samplers[i].wrapT);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-buffer
+   gltf << "  \"buffers\" : [";
+   for (size_t i = 0; i != buffers.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", buffers[i].uri);
+      print_node(gltf, pos, "\n    ", buffers[i].byteLength);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-bufferview
+   gltf << "  \"bufferViews\" : [";
+   for (size_t i = 0; i != buffer_views.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", buffer_views[i].buffer);
+      print_node(gltf, pos, "\n    ", buffer_views[i].byteOffset);
+      print_node(gltf, pos, "\n    ", buffer_views[i].byteLength);
+      print_node(gltf, pos, "\n    ", buffer_views[i].byteStride);
+      print_node(gltf, pos, "\n    ", buffer_views[i].target);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-accessor
+   gltf << "  \"accessors\" : [";
+   for (size_t i = 0; i != accessors.size(); ++i)
+   {
+      gltf << sep(i) << " {";
+      int pos = 0;
+      print_node(gltf, pos, "\n    ", accessors[i].bufferView);
+      print_node(gltf, pos, "\n    ", accessors[i].byteOffset);
+      print_node(gltf, pos, "\n    ", accessors[i].componentType);
+      print_node(gltf, pos, "\n    ", accessors[i].count);
+      print_node(gltf, pos, "\n    ", accessors[i].type);
+      print_node(gltf, pos, "\n    ", accessors[i].min);
+      print_node(gltf, pos, "\n    ", accessors[i].max);
+      print_node(gltf, pos, "\n    ", accessors[i].normalized);
+      gltf << "\n  }";
+   }
+   gltf << " ],\n\n";
+
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-asset
+   gltf <<
+        "  \"asset\" : {\n"
+        "    \"version\" : \"2.0\",\n"
+        "    \"generator\" : \"GLVis\"\n"
+        "  }\n"
+        "}\n";
+
+   return 0;
+}

--- a/lib/gltf.cpp
+++ b/lib/gltf.cpp
@@ -13,6 +13,11 @@
 #include "aux_vis.hpp" // SaveAsPNG
 
 
+const char *glTF_Builder::tensorTypes[] =
+{
+   "SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"
+};
+
 glTF_Builder::buffer_id
 glTF_Builder::addBuffer(const std::string &bufferName)
 {

--- a/lib/gltf.hpp
+++ b/lib/gltf.hpp
@@ -1,0 +1,366 @@
+// Copyright (c) 2010-2021, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_GLTF_HPP
+#define GLVIS_GLTF_HPP
+
+#include <string>
+#include <vector>
+#include <array>
+#include <tuple>
+#include <fstream>
+#include <limits>
+
+
+class glTF_Builder
+{
+public:
+   typedef std::array<float,2> vec2f;
+   typedef std::array<float,3> vec3f;
+   typedef std::array<float,4> color4f;
+   typedef std::vector<float> vecnf;
+
+protected:
+   template <typename T>
+   struct node_type
+   {
+      bool valid;
+      std::string key;
+      T value;
+   };
+
+   typedef node_type<bool>        node_bool;
+   typedef node_type<unsigned>    node_unsigned;
+   typedef node_type<float>       node_float;
+   typedef node_type<std::string> node_string;
+   typedef node_type<vec3f>       node_vec3f;
+   typedef node_type<color4f>     node_color4f;
+   typedef node_type<vecnf>       node_vecnf;
+
+   struct struct_buffer
+   {
+      node_string uri = { false, "uri", "" };
+      node_unsigned byteLength = { false, "byteLength", 0 };
+
+      std::ofstream file;
+   };
+   struct struct_buffer_view
+   {
+      node_unsigned buffer = { false, "buffer", 0 };
+      node_unsigned byteOffset = { false, "byteOffset", 0 };
+      node_unsigned byteLength = { false, "byteLength", 0 };
+      node_unsigned byteStride = { false, "byteStride", 0};
+      node_unsigned target = { false, "target", 0 };
+   };
+   struct struct_accessor
+   {
+      node_unsigned bufferView = { false, "bufferView", 0 };
+      node_unsigned byteOffset = { false, "byteOffset", 0 };
+      node_unsigned componentType = { false, "componentType", 0 };
+      node_unsigned count = { false, "count", 0 };
+      node_string type = { false, "type", "" };
+      node_vecnf min = { false, "min", {} };
+      node_vecnf max = { false, "max", {} };
+      node_bool normalized = { false, "normalized", false };
+   };
+   struct struct_image
+   {
+      node_string uri = { false, "uri", "" };
+      node_string name = { false, "name", "" };
+   };
+   struct struct_sampler
+   {
+      node_unsigned magFilter = { false, "magFilter", 0 };
+      node_unsigned minFilter = { false, "minFilter", 0 };
+      node_unsigned wrapS = { false, "wrapS", 0 };
+      node_unsigned wrapT = { false, "wrapT", 0 };
+   };
+   struct struct_texture
+   {
+      node_unsigned sampler = { false, "sampler", 0 };
+      node_unsigned source = { false, "source", 0 };
+   };
+   struct struct_texture_info
+   {
+      node_unsigned index = { false, "index", 0 };
+      node_unsigned texCoord = { false, "texCoord", 0 };
+   };
+   struct struct_pbrMetallicRoughness
+   {
+      node_color4f baseColorFactor =
+      { false, "baseColorFactor", {0.f, 0.f, 0.f, 0.f} };
+      node_type<struct_texture_info> baseColorTexture =
+      { false, "baseColorTexture", {} };
+      node_float metallicFactor = { false, "metallicFactor", 0.f };
+      node_float roughnessFactor = { false, "roughnessFactor", 0.f };
+   };
+   struct struct_material
+   {
+      node_type<struct_pbrMetallicRoughness> pbrMetallicRoughness =
+      { false, "pbrMetallicRoughness", {} };
+      node_bool doubleSided = { false, "doubleSided", false };
+      node_string name = { false, "name", "" };
+   };
+   struct struct_attributes
+   {
+      node_unsigned POSITION = { false, "POSITION", 0 };
+      node_unsigned NORMAL = { false, "NORMAL", 0 };
+      node_unsigned TEXCOORD_0 = { false, "TEXCOORD_0", 0 };
+      node_unsigned COLOR_0 = { false, "COLOR_0", 0 };
+
+   };
+   struct struct_primitive
+   {
+      node_type<struct_attributes> attributes = { false, "attributes", {} };
+      node_unsigned indices = { false, "indices", 0 };
+      node_unsigned material = { false, "material", 0 };
+      node_unsigned mode = { false, "mode", 0 };
+   };
+   struct struct_mesh
+   {
+      std::vector<struct_primitive> primitives;
+      node_string name = { false, "name", "" };
+   };
+   struct struct_node
+   {
+      node_unsigned mesh = { false, "mesh", 0 };
+      node_vec3f scale = { false, "scale", {0.f, 0.f, 0.f} };
+      node_vec3f translation = { false, "translation", {0.f, 0.f, 0.f} };
+      node_string name = { false, "name", "" };
+   };
+
+   // begin: printing functions
+   static const char *sep(size_t i) { return (i==0) ? "" : ","; }
+   template <typename T>
+   static void print_node(std::ostream &out,
+                          int &pfx_counter,
+                          const std::string &pfx,
+                          const node_type<T> &n)
+   {
+      if (n.valid)
+      {
+         out << sep(pfx_counter++) << pfx << '"' << n.key << "\" : ";
+         print(out, n.value);
+      }
+   }
+
+   static void print(std::ostream &out, const bool &v) { out << v; }
+   static void print(std::ostream &out, const unsigned &v) { out << v; }
+   static void print(std::ostream &out, const float &v) { out << v; }
+   static void print(std::ostream &out, const std::string &v)
+   { out << '"' << v << '"'; }
+   template <typename T, size_t s>
+   static void print(std::ostream &out, const std::array<T,s> &v)
+   {
+      out << '[';
+      for (size_t i = 0; i != s; ++i) { out << sep(i) << ' ' << v[i]; }
+      out << " ]";
+   }
+   template <typename T>
+   static void print(std::ostream &out, const std::vector<T> &v)
+   {
+      out << '[';
+      for (size_t i = 0; i != v.size(); ++i) { out << sep(i) << ' ' << v[i]; }
+      out << " ]";
+   }
+   static void print(std::ostream &out, const struct_attributes &a)
+   {
+      out << '{';
+      int pos = 0;
+      print_node(out, pos, "\n        ", a.POSITION);
+      print_node(out, pos, "\n        ", a.NORMAL);
+      print_node(out, pos, "\n        ", a.TEXCOORD_0);
+      print_node(out, pos, "\n        ", a.COLOR_0);
+      out << "\n      }";
+   }
+   static void print(std::ostream &out, const struct_texture_info &ti)
+   {
+      out << '{';
+      int pos = 0;
+      print_node(out, pos, "\n        ", ti.index);
+      print_node(out, pos, "\n        ", ti.texCoord);
+      out << "\n      }";
+   }
+   static void print(std::ostream &out, const struct_pbrMetallicRoughness &pbr)
+   {
+      out << '{';
+      int pos = 0;
+      print_node(out, pos, "\n      ", pbr.baseColorFactor);
+      print_node(out, pos, "\n      ", pbr.baseColorTexture);
+      print_node(out, pos, "\n      ", pbr.metallicFactor);
+      print_node(out, pos, "\n      ", pbr.roughnessFactor);
+      out << "\n    }";
+   }
+   // end: printing functions
+
+   const std::string file_prefix;
+
+   std::vector<struct_buffer> buffers;
+   std::vector<struct_buffer_view> buffer_views;
+   std::vector<struct_accessor> accessors;
+   std::vector<struct_image> images;
+   std::vector<struct_sampler> samplers;
+   std::vector<struct_texture> textures;
+   std::vector<struct_material> materials;
+   std::vector<struct_mesh> meshes;
+   std::vector<struct_node> nodes;
+
+public:
+   enum { INVALID_ID = std::numeric_limits<unsigned>::max() };
+   typedef struct { unsigned id; } buffer_id;
+   typedef struct { unsigned id; } buffer_view_id;
+   typedef struct { unsigned id; } accessor_id;
+   typedef struct { unsigned id; } image_id;
+   typedef struct { unsigned id; } sampler_id;
+   typedef struct { unsigned id; } texture_id;
+   typedef struct { unsigned id; } material_id;
+   typedef struct { unsigned id; } mesh_id;
+   typedef struct { unsigned id; } node_id;
+
+   // buffer view option
+   enum struct target_type
+   {
+      ARRAY_BUFFER = 34962,
+      ELEMENT_ARRAY_BUFFER = 34963
+   };
+
+   // accessor option
+   enum struct component_type
+   {
+      BYTE           = 5120,
+      UNSIGNED_BYTE  = 5121,
+      SHORT          = 5122,
+      UNSIGNED_SHORT = 5123,
+      UNSIGNED_INT   = 5125,
+      FLOAT          = 5126
+   };
+   // accessor option
+   enum struct tensor_type
+   {
+      SCALAR = 0, VEC2, VEC3, VEC4, MAT2, MAT3, MAT4
+   };
+   // string constants corresponding to the tensor_type constants
+   static constexpr const char *tensorTypes[] =
+   {
+      "SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"
+   };
+
+   // sampler option: magnification filter
+   enum struct mag_filter { NEAREST = 9728, LINEAR = 9729 };
+   // sampler optioin: minification filter
+   enum struct min_filter
+   {
+      NEAREST = 9728, LINEAR = 9729, NEAREST_MIPMAP_NEAREST = 9984,
+      LINEAR_MIPMAP_NEAREST = 9985, NEAREST_MIPMAP_LINEAR = 9986,
+      LINEAR_MIPMAP_LINEAR = 9987
+   };
+   // sampler option: S/T (or U/V) wrapping mode
+   enum struct wrap_type
+   {
+      CLAMP_TO_EDGE = 33071, MIRRORED_REPEAT = 33648, REPEAT = 10497
+   };
+
+   struct pbr_matallic_roughness
+   {
+      bool haveTexture;  // if true, baseColorTexture must be defined
+      color4f baseColorFactor;
+      texture_id baseColorTexture;
+      float metallicFactor;
+      float roughnessFactor;
+   };
+
+
+   glTF_Builder(const std::string &filePrefix)
+      : file_prefix(filePrefix)
+   { }
+
+   buffer_id addBuffer(const std::string &bufferName);
+
+   buffer_view_id addBufferView(buffer_id buffer,
+                                const void *data,
+                                size_t byteLength,
+                                size_t byteStride,
+                                size_t byteAlign,
+                                target_type target);
+
+   // can be called after the call to addBufferView() that created the given
+   // bufferView but only before the next call to addBufferView()
+   void appendToBufferView(buffer_view_id bufferView,
+                           const void *data,
+                           size_t byteLength);
+
+   // count must be >= 1
+   accessor_id addAccessor(buffer_view_id bufferView,
+                           size_t byteOffset,
+                           component_type componentType,
+                           size_t count,
+                           tensor_type tensorType);
+
+   // count must be >= 1
+   accessor_id addAccessorVec2f(buffer_view_id bufferView,
+                                size_t byteOffset,
+                                size_t count,
+                                vec2f min,
+                                vec2f max);
+
+   // count must be >= 1
+   accessor_id addAccessorVec3f(buffer_view_id bufferView,
+                                size_t byteOffset,
+                                size_t count,
+                                vec3f min,
+                                vec3f max);
+
+   image_id addImage(const std::string &imageName,
+                     int width,
+                     int height,
+                     const color4f *pixels);
+
+   sampler_id addSampler(mag_filter magFilter = mag_filter::NEAREST,
+                         min_filter minFilter = min_filter::NEAREST,
+                         wrap_type wrapS = wrap_type::CLAMP_TO_EDGE,
+                         wrap_type wrapT = wrap_type::CLAMP_TO_EDGE);
+
+   texture_id addTexture(sampler_id sampler, image_id source);
+
+   material_id addMaterial(const std::string &materialName,
+                           const pbr_matallic_roughness &pbrMetallicRoughness,
+                           bool doubleSided = false);
+
+   mesh_id addMesh(const std::string &meshName);
+
+   void addMeshTriangles(mesh_id mesh,
+                         accessor_id vertexPositions,
+                         accessor_id vertexNormals,
+                         accessor_id vertexTexCoords0,
+                         accessor_id vertexIndices,
+                         material_id material);
+
+   void addMeshLines(mesh_id mesh,
+                     accessor_id vertexPositions,
+                     accessor_id vertexTexcoords0,
+                     accessor_id vertexColors0,
+                     material_id material);
+
+   node_id addNode(const std::string &nodeName);
+
+   void addNodeMesh(node_id node, mesh_id mesh);
+
+   void addNodeScale(node_id node, vec3f scale);
+
+   void addNodeTranslation(node_id node, vec3f translation);
+
+   void getMaterialPBRMR(material_id material,
+                         pbr_matallic_roughness &pbr_mr_copy);
+
+   int writeFile();
+};
+
+#endif // GLVIS_GLTF_HPP

--- a/lib/gltf.hpp
+++ b/lib/gltf.hpp
@@ -248,10 +248,7 @@ public:
       SCALAR = 0, VEC2, VEC3, VEC4, MAT2, MAT3, MAT4
    };
    // string constants corresponding to the tensor_type constants
-   static constexpr const char *tensorTypes[] =
-   {
-      "SCALAR", "VEC2", "VEC3", "VEC4", "MAT2", "MAT3", "MAT4"
-   };
+   static const char *tensorTypes[];
 
    // sampler option: magnification filter
    enum struct mag_filter { NEAREST = 9728, LINEAR = 9729 };

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -225,6 +225,7 @@ void VisualizationScene
 
    if (normals_opt != 0 && normals_opt != -1)
    {
+      Normalize(normals);
       std::vector<gl3::VertexNormTex> vertices;
       std::vector<int> indices;
       vertices.reserve(pts.Size());
@@ -307,7 +308,569 @@ void VisualizationScene
    }
 }
 
+glTF_Builder::material_id
+VisualizationScene::AddPaletteMaterial(glTF_Builder &bld)
+{
+#ifdef GLVIS_USE_LIBPNG
+   const bool palette_smooth = palette.GetSmoothSetting();
+   auto sampler =
+      bld.addSampler(
+         /* magFilter: */
+         palette_smooth ? glTF_Builder::mag_filter::LINEAR :
+         /**/             glTF_Builder::mag_filter::NEAREST,
+         /* minFilter: */
+         palette_smooth ? glTF_Builder::min_filter::LINEAR :
+         /**/             glTF_Builder::min_filter::NEAREST,
+         /* wrapS: */ glTF_Builder::wrap_type::CLAMP_TO_EDGE,
+         /* wrapT: */ glTF_Builder::wrap_type::CLAMP_TO_EDGE);
+   // create palette image
+   const int palette_size = palette.GetNumColors();
+   vector<array<float,4>> palette_data(palette_size);
+#if 0
+   glGetTextureImage(
+      palette.GetColorTexture(), 0,
+      gl3::GLDevice::useLegacyTextureFmts() ? GL_RGBA : GL_RGBA32F,
+      GL_FLOAT,
+      palette_size,
+      palette_data.data());
+#elif 0
+   glGetTexImage(GL_TEXTURE_2D, 0,
+                 gl3::GLDevice::useLegacyTextureFmts() ? GL_RGBA : GL_RGBA32F,
+                 GL_FLOAT, palette_data.data());
+#else
+   const double *palette_data_raw = palette.GetData();
+   for (int i = 0; i < palette_size; ++i)
+   {
+      for (int j = 0; j < 3; ++j)
+      {
+         palette_data[i][j] = (float) palette_data_raw[j + 3*i];
+      }
+      palette_data[i][3] = 1.0f;
+   }
+#endif
+   auto palette_img =
+      bld.addImage(
+         /* imageName: */      "palette",
+         /* width: */           palette_size,
+         /* height: */          1,
+         /* color4f *pixels: */ palette_data.data());
+   auto palette_tex = bld.addTexture(sampler, palette_img);
+   glTF_Builder::pbr_matallic_roughness palette_pbr_mr =
+   {
+      /* haveTexture: */       true,
+      /* baseColorFactor: */   { 1.f, 1.f, 1.f, 1.f },
+      /* baseColorTexture: */  palette_tex,
+      /* metallicFactor: */    1.f,
+      /* roughnessFactor: */   .3f
+   };
+#else // GLVIS_USE_LIBPNG
+   glTF_Builder::pbr_matallic_roughness palette_pbr_mr =
+   {
+      /* haveTexture: */       false,
+      /* baseColorFactor: */   { 0.f, 1.f, .5f, 1.f },
+      /* baseColorTexture: */  {0},
+      /* metallicFactor: */    1.f,
+      /* roughnessFactor: */   .3f
+   };
+#endif // GLVIS_USE_LIBPNG
+   auto palette_mat =
+      bld.addMaterial(
+         /* materialName: */         "Palette Material",
+         /* pbrMetallicRoughness: */ palette_pbr_mr,
+         /* doubleSided: */          true);
 
+   return palette_mat;
+}
+
+glTF_Builder::material_id
+VisualizationScene::AddBlackMaterial(glTF_Builder &bld)
+{
+   glTF_Builder::pbr_matallic_roughness black_pbr_mr =
+   {
+      /* haveTexture: */       false,
+      /* baseColorFactor: */   GetLineColor(),
+      /* baseColorTexture: */  {0},
+      /* metallicFactor: */    1.f,
+      /* roughnessFactor: */   1.f
+   };
+   auto black_mat =
+      bld.addMaterial(
+         /* materialName: */         "Black Material",
+         /* pbrMetallicRoughness: */ black_pbr_mr,
+         /* doubleSided: */          true);
+
+   return black_mat;
+}
+
+glTF_Builder::material_id
+VisualizationScene::AddPaletteLinesMaterial(
+   glTF_Builder &bld, glTF_Builder::material_id palette_mat)
+{
+   glTF_Builder::pbr_matallic_roughness palette_pbr_mr_copy;
+   bld.getMaterialPBRMR(palette_mat, palette_pbr_mr_copy);
+   palette_pbr_mr_copy.metallicFactor = 1.f;
+   palette_pbr_mr_copy.roughnessFactor = 1.f;
+   auto palette_lines_mat =
+      bld.addMaterial(
+         /* materialName: */         "PaletteLines Material",
+         /* pbrMetallicRoughness: */ palette_pbr_mr_copy,
+         /* doubleSided: */          true);
+   return palette_lines_mat;
+}
+
+glTF_Builder::node_id
+VisualizationScene::AddModelNode(glTF_Builder &bld, const string &nodeName)
+{
+   auto new_node = bld.addNode(nodeName);
+   // Coordinate system switch: (x,y,z) -> (x,z,-y).
+   // In glTF, the translation (T), rotation (R), and scale (S) properties are
+   // applied in the order: T * R * S.
+   // In GLVis, we apply them in the order: R * S * T.
+   bld.addNodeScale(
+      new_node, { (float)xscale, (float)zscale, (float)yscale });
+   bld.addNodeTranslation(
+      new_node, { float(-xscale*(x[0]+x[1])/2),
+                  float(-zscale*z[0]),
+                  float(yscale*(y[0]+y[1])/2)
+                });
+   return new_node;
+}
+
+// Used in VisualizationScene::AddTriangles() below.
+void minmax(const float *data, size_t components, size_t stride, size_t count,
+            vector<float> &mins, vector<float> &maxs)
+{
+   if (count == 0)
+   {
+      mins.assign(components, +numeric_limits<float>::infinity());
+      maxs.assign(components, -numeric_limits<float>::infinity());
+      return;
+   }
+   mins.resize(components);
+   maxs.resize(components);
+   for (size_t c = 0; c != components; ++c)
+   {
+      const auto entry = data[c];
+      mins[c] = entry;
+      maxs[c] = entry;
+   }
+   if (count == 1) { return; }
+   for (size_t i = 1; i != count; ++i)
+   {
+      data += stride;
+      for (size_t c = 0; c != components; ++c)
+      {
+         const auto entry = data[c];
+         if (entry < mins[c]) { mins[c] = entry; }
+         else if (entry > maxs[c]) { maxs[c] = entry; }
+      }
+   }
+}
+
+int VisualizationScene::AddTriangles(glTF_Builder &bld,
+                                     glTF_Builder::mesh_id mesh,
+                                     glTF_Builder::buffer_id buffer,
+                                     glTF_Builder::material_id material,
+                                     const gl3::GlDrawable &gl_drawable)
+{
+   int num_buf = 0, buf_layout = -1;
+   for (int layout = 0; layout < gl3::NUM_LAYOUTS; ++layout)
+   {
+      const gl3::IVertexBuffer *buf = gl_drawable.buffers[layout][1].get();
+      if (buf && buf->count() != 0)
+      {
+         num_buf++;
+         buf_layout = layout;
+         cout << "triangles: layout = " << layout << ", # vertices = "
+              << buf->count() << '\n';
+      }
+   }
+   int num_ibuf = 0, ibuf_layout = -1;
+   for (int layout = 0; layout < gl3::NUM_LAYOUTS; ++layout)
+   {
+      const gl3::IIndexedBuffer *ibuf =
+         gl_drawable.indexed_buffers[layout][1].get();
+      if (ibuf && ibuf->getIndices().size() != 0)
+      {
+         num_ibuf++;
+         ibuf_layout = layout;
+         cout << "indexed triangles: layout = " << layout << ", # vertices = "
+              << ibuf->count() << ", # indices = " << ibuf->getIndices().size()
+              << '\n';
+      }
+   }
+   if (num_buf + num_ibuf == 0) { return 0; }
+
+   if (num_buf + num_ibuf > 1)
+   {
+      cout << "glTF export: skipping" << num_buf + num_ibuf - 1
+           << " triangle buffer(s).\n";
+   }
+   const gl3::IVertexBuffer *surf_buf = nullptr;
+   const gl3::IIndexedBuffer *surf_ibuf = nullptr;
+   const vector<int> *surf_indices = nullptr;
+   if (num_ibuf)
+   {
+      surf_buf = surf_ibuf = gl_drawable.indexed_buffers[ibuf_layout][1].get();
+      surf_indices = &surf_ibuf->getIndices();
+      buf_layout = ibuf_layout;
+   }
+   else
+   {
+      surf_buf = gl_drawable.buffers[buf_layout][1].get();
+   }
+   const size_t surf_vertices_count = surf_buf->count();
+   const size_t surf_vertices_stride = surf_buf->getStride(); // in bytes
+   const float *surf_vertices_data =
+      reinterpret_cast<const float *>(surf_buf->getData());
+   vector<float> vmins, vmaxs;
+   int components = surf_vertices_stride/sizeof(float);
+   switch (buf_layout)
+   {
+      case gl3::LAYOUT_VTX:
+      case gl3::LAYOUT_VTX_COLOR: components = 3; break;
+      case gl3::LAYOUT_VTX_TEXTURE0: components = 5; break;
+      case gl3::LAYOUT_VTX_NORMAL:
+      case gl3::LAYOUT_VTX_NORMAL_COLOR: components = 6; break;
+      case gl3::LAYOUT_VTX_NORMAL_TEXTURE0: components = 8; break;
+   }
+   minmax(surf_vertices_data, components, surf_vertices_stride/sizeof(float),
+          surf_vertices_count, vmins, vmaxs);
+
+   glTF_Builder::buffer_view_id surf_indices_buf_view;
+   if (surf_indices)
+   {
+      surf_indices_buf_view =
+         bld.addBufferView(
+            /* buffer: */     buffer,
+            /* data: */       surf_indices->data(),
+            /* byteLength: */ surf_indices->size()*sizeof(int),
+            /* byteStride: */ sizeof(int),
+            /* byteAlign: */  sizeof(int),
+            /* target: */ glTF_Builder::target_type::ELEMENT_ARRAY_BUFFER);
+   }
+#if 0
+   auto surf_vertices_buf_view =
+      bld.addBufferView(
+         /* buffer: */     buffer,
+         /* data: */       surf_vertices_data,
+         /* byteLength: */ surf_vertices_count*surf_vertices_stride,
+         /* byteStride: */ surf_vertices_stride,
+         /* byteAlign: */  sizeof(float),
+         /* target: */     glTF_Builder::target_type::ARRAY_BUFFER);
+#else
+   auto surf_vertices_buf_view =
+      bld.addBufferView(
+         /* buffer: */     buffer,
+         /* data: */       surf_vertices_data,
+         /* byteLength: */ 0,
+         /* byteStride: */ surf_vertices_stride,
+         /* byteAlign: */  sizeof(float),
+         /* target: */     glTF_Builder::target_type::ARRAY_BUFFER);
+   // Coordinate system switch: (x,y,z) -> (x,z,-y), see:
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units
+   switch (buf_layout)
+   {
+      case gl3::Vertex::layout:
+      {
+         auto surf_vert_data =
+            reinterpret_cast<const gl3::Vertex *>(surf_vertices_data);
+         for (size_t i = 0; i != surf_vertices_count; ++i)
+         {
+            auto &v = surf_vert_data[i];
+            gl3::Vertex vtx = { { v.coord[0], v.coord[2], -v.coord[1] } };
+            bld.appendToBufferView(surf_vertices_buf_view, &vtx, sizeof(vtx));
+         }
+         break;
+      }
+      case gl3::VertexNorm::layout:
+      {
+         auto surf_vert_data =
+            reinterpret_cast<const gl3::VertexNorm *>(surf_vertices_data);
+         for (size_t i = 0; i != surf_vertices_count; ++i)
+         {
+            auto &v = surf_vert_data[i];
+            gl3::VertexNorm vn =
+            {
+               { v.coord[0], v.coord[2], -v.coord[1] },
+               { v.norm[0], v.norm[2], -v.norm[1] }
+            };
+            bld.appendToBufferView(surf_vertices_buf_view, &vn, sizeof(vn));
+         }
+         break;
+      }
+      case gl3::VertexNormTex::layout:
+      {
+         auto surf_vert_data =
+            reinterpret_cast<const gl3::VertexNormTex *>(surf_vertices_data);
+         for (size_t i = 0; i != surf_vertices_count; ++i)
+         {
+            auto &v = surf_vert_data[i];
+            gl3::VertexNormTex tv =
+            {
+               { v.coord[0], v.coord[2], -v.coord[1] },
+               { v.norm[0], v.norm[2], -v.norm[1] },
+               v.texCoord
+            };
+            bld.appendToBufferView(surf_vertices_buf_view, &tv, sizeof(tv));
+         }
+         break;
+      }
+      default:
+      {
+         cout << "glTF export: coorditate switch for layout " << buf_layout
+              << " is not implemented here:" << MFEM_LOCATION;
+         bld.appendToBufferView(surf_vertices_buf_view,
+                                surf_vertices_data,
+                                surf_vertices_count*surf_vertices_stride);
+         break;
+      }
+   }
+#endif
+   glTF_Builder::accessor_id surf_indices_acc {glTF_Builder::INVALID_ID};
+   if (surf_indices)
+   {
+      surf_indices_acc =
+         bld.addAccessor(
+            /* bufferView: */    surf_indices_buf_view,
+            /* byteOffset: */    0,
+            /* componentType: */ glTF_Builder::component_type::UNSIGNED_INT,
+            /* count: */         surf_indices->size(),
+            /* tensorType: */    glTF_Builder::tensor_type::SCALAR);
+   }
+   auto surf_vertices_pos_acc =
+      bld.addAccessorVec3f(
+         /* bufferView: */ surf_vertices_buf_view,
+         /* byteOffset: */ 0,
+         /* count: */      surf_vertices_count,
+         // Coordinate system switch: (x,y,z) -> (x,z,-y), see above
+         /* vec3f min: */  { vmins[0], vmins[2], -vmaxs[1] },
+         /* vec3f max: */  { vmaxs[0], vmaxs[2], -vmins[1] });
+   unsigned floatOffset = 3;
+   glTF_Builder::accessor_id surf_vertices_nor_acc{glTF_Builder::INVALID_ID};
+   const bool have_normals =
+      (buf_layout == gl3::LAYOUT_VTX_NORMAL ||
+       buf_layout == gl3::LAYOUT_VTX_NORMAL_COLOR ||
+       buf_layout == gl3::LAYOUT_VTX_NORMAL_TEXTURE0);
+   if (have_normals)
+   {
+      surf_vertices_nor_acc =
+         bld.addAccessor(
+            /* bufferView: */    surf_vertices_buf_view,
+            /* byteOffset: */    floatOffset*sizeof(float),
+            /* componentType: */ glTF_Builder::component_type::FLOAT,
+            /* count: */         surf_vertices_count,
+            /* tensorType: */    glTF_Builder::tensor_type::VEC3);
+      floatOffset += 3;
+   }
+   glTF_Builder::accessor_id surf_vertices_tex_acc{glTF_Builder::INVALID_ID};
+   const bool have_texcoords =
+      (buf_layout == gl3::LAYOUT_VTX_TEXTURE0 ||
+       buf_layout == gl3::LAYOUT_VTX_NORMAL_TEXTURE0);
+   if (have_texcoords)
+   {
+      surf_vertices_tex_acc =
+         bld.addAccessorVec2f(
+            /* bufferView: */ surf_vertices_buf_view,
+            /* byteOffset: */ floatOffset*sizeof(float),
+            /* count: */      surf_vertices_count,
+            /* vec2f min: */  { vmins[floatOffset], vmins[floatOffset+1] },
+            /* vec2f max: */  { vmaxs[floatOffset], vmaxs[floatOffset+1] });
+      // floatOffset += 2;
+   }
+   bld.addMeshTriangles(
+      /* mesh: */             mesh,
+      /* vertexPositions: */  surf_vertices_pos_acc,
+      /* vertexNormals: */    surf_vertices_nor_acc,
+      /* vertexTexCoords0: */ surf_vertices_tex_acc,
+      /* vertexIndices: */    surf_indices_acc,
+      /* material: */         material);
+
+   return surf_indices ? surf_indices->size()/3 : surf_vertices_count/3;
+}
+
+int VisualizationScene::AddLines(glTF_Builder &bld,
+                                 glTF_Builder::mesh_id mesh,
+                                 glTF_Builder::buffer_id buffer,
+                                 glTF_Builder::material_id material,
+                                 const gl3::GlDrawable &gl_drawable)
+{
+   int num_buf = 0, buf_layout = -1;
+   for (int layout = 0; layout < gl3::NUM_LAYOUTS; ++layout)
+   {
+      const gl3::IVertexBuffer *buf = gl_drawable.buffers[layout][0].get();
+      if (buf && buf->count() != 0)
+      {
+         num_buf++;
+         buf_layout = layout;
+         cout << "lines: layout = " << layout << ", # vertices = "
+              << buf->count() << '\n';
+      }
+   }
+   int num_ibuf = 0, ibuf_layout = -1;
+   for (int layout = 0; layout < gl3::NUM_LAYOUTS; ++layout)
+   {
+      const gl3::IIndexedBuffer *ibuf =
+         gl_drawable.indexed_buffers[layout][0].get();
+      if (ibuf && ibuf->getIndices().size() != 0)
+      {
+         num_ibuf++;
+         ibuf_layout = layout;
+         cout << "indexed lines: layout = " << layout << ", # vertices = "
+              << ibuf->count() << ", # indices = " << ibuf->getIndices().size()
+              << '\n';
+      }
+   }
+   if (num_buf + num_ibuf == 0) { return 0; }
+   if (num_buf == 0)
+   {
+      cout << "glTF export: indexed lines are not implemented.\n";
+      return 0;
+   }
+   if (num_buf + num_ibuf > 1)
+   {
+      cout << "glTF export: skipping" << num_buf + num_ibuf - 1
+           << " line buffer(s).\n";
+   }
+   const gl3::IVertexBuffer *lines_buf =
+      gl_drawable.buffers[buf_layout][0].get();
+   const size_t lines_vertices_count = lines_buf->count();
+   const size_t lines_vertices_stride = lines_buf->getStride(); // in bytes
+   const float *lines_vertices_data =
+      reinterpret_cast<const float *>(lines_buf->getData());
+   vector<float> vmins, vmaxs;
+   int components = lines_vertices_stride/sizeof(float);
+   switch (buf_layout)
+   {
+      case gl3::LAYOUT_VTX:
+      case gl3::LAYOUT_VTX_COLOR: components = 3; break;
+      case gl3::LAYOUT_VTX_TEXTURE0: components = 5; break;
+      case gl3::LAYOUT_VTX_NORMAL:
+      case gl3::LAYOUT_VTX_NORMAL_COLOR: components = 6; break;
+      case gl3::LAYOUT_VTX_NORMAL_TEXTURE0: components = 8; break;
+   }
+   minmax(lines_vertices_data, components, lines_vertices_stride/sizeof(float),
+          lines_vertices_count, vmins, vmaxs);
+
+#if 0
+   auto lines_vertices_buf_view =
+      bld.addBufferView(
+         /* buffer: */     buffer,
+         /* data: */       lines_vertices_data,
+         /* byteLength: */ lines_vertices_count*lines_vertices_stride,
+         /* byteStride: */ lines_vertices_stride,
+         /* byteAlign: */  sizeof(float),
+         /* target: */     glTF_Builder::target_type::ARRAY_BUFFER);
+#else
+   auto lines_vertices_buf_view =
+      bld.addBufferView(
+         /* buffer: */     buffer,
+         /* data: */       lines_vertices_data,
+         /* byteLength: */ 0,
+         /* byteStride: */ lines_vertices_stride,
+         /* byteAlign: */  sizeof(float),
+         /* target: */     glTF_Builder::target_type::ARRAY_BUFFER);
+   // Coordinate system switch: (x,y,z) -> (x,z,-y), see:
+   // https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units
+   switch (buf_layout)
+   {
+      case gl3::Vertex::layout:
+      {
+         auto lines_vert_data =
+            reinterpret_cast<const gl3::Vertex *>(lines_vertices_data);
+         for (size_t i = 0; i != lines_vertices_count; ++i)
+         {
+            auto &v = lines_vert_data[i];
+            gl3::Vertex vtx = { { v.coord[0], v.coord[2], -v.coord[1] } };
+            bld.appendToBufferView(lines_vertices_buf_view, &vtx, sizeof(vtx));
+         }
+         break;
+      }
+      case gl3::VertexColor::layout:
+      {
+         auto lines_vert_data =
+            reinterpret_cast<const gl3::VertexColor *>(lines_vertices_data);
+         for (size_t i = 0; i != lines_vertices_count; ++i)
+         {
+            auto &v = lines_vert_data[i];
+            gl3::VertexColor vc =
+            {
+               { v.coord[0], v.coord[2], -v.coord[1] }, v.color
+            };
+            bld.appendToBufferView(lines_vertices_buf_view, &vc, sizeof(vc));
+         }
+         break;
+      }
+      case gl3::VertexTex::layout:
+      {
+         auto lines_vert_data =
+            reinterpret_cast<const gl3::VertexTex *>(lines_vertices_data);
+         for (size_t i = 0; i != lines_vertices_count; ++i)
+         {
+            auto &v = lines_vert_data[i];
+            gl3::VertexTex vt =
+            {
+               { v.coord[0], v.coord[2], -v.coord[1] }, v.texCoord
+            };
+            bld.appendToBufferView(lines_vertices_buf_view, &vt, sizeof(vt));
+         }
+         break;
+      }
+      default:
+      {
+         cout << "glTF export: coorditate switch for layout " << buf_layout
+              << " is not implemented here:" << MFEM_LOCATION;
+         bld.appendToBufferView(lines_vertices_buf_view,
+                                lines_vertices_data,
+                                lines_vertices_count*lines_vertices_stride);
+         break;
+      }
+   }
+#endif
+   auto lines_vertices_pos_acc =
+      bld.addAccessorVec3f(
+         /* bufferView: */ lines_vertices_buf_view,
+         /* byteOffset: */ 0,
+         /* count: */      lines_vertices_count,
+         // Coordinate system switch: (x,y,z) -> (x,z,-y), see above
+         /* vec3f min: */  { vmins[0], vmins[2], -vmaxs[1] },
+         /* vec3f max: */  { vmaxs[0], vmaxs[2], -vmins[1] });
+   unsigned floatOffset = 3;
+   glTF_Builder::accessor_id lines_vertices_col_acc{glTF_Builder::INVALID_ID};
+   const bool have_colors = (buf_layout == gl3::LAYOUT_VTX_COLOR);
+   if (have_colors)
+   {
+      lines_vertices_col_acc =
+         bld.addAccessor(
+            /* bufferView: */    lines_vertices_buf_view,
+            /* byteOffset: */    floatOffset*sizeof(float),
+            /* componentType: */ glTF_Builder::component_type::UNSIGNED_BYTE,
+            /* count: */         lines_vertices_count,
+            /* tensorType: */    glTF_Builder::tensor_type::VEC4);
+      // floatOffset += 2;
+   }
+   glTF_Builder::accessor_id lines_vertices_tex_acc{glTF_Builder::INVALID_ID};
+   const bool have_texcoords = (buf_layout == gl3::LAYOUT_VTX_TEXTURE0);
+   if (have_texcoords)
+   {
+      lines_vertices_tex_acc =
+         bld.addAccessorVec2f(
+            /* bufferView: */ lines_vertices_buf_view,
+            /* byteOffset: */ floatOffset*sizeof(float),
+            /* count: */      lines_vertices_count,
+            /* vec2f min: */  { vmins[floatOffset], vmins[floatOffset+1] },
+            /* vec2f max: */  { vmaxs[floatOffset], vmaxs[floatOffset+1] });
+      // floatOffset += 2;
+   }
+   bld.addMeshLines(
+      /* mesh: */             mesh,
+      /* vertexPositions: */  lines_vertices_pos_acc,
+      /* vertexTexcoords0: */ lines_vertices_tex_acc,
+      /* vertexColors0: */    lines_vertices_col_acc,
+      /* material: */         material);
+
+   return lines_vertices_count/2;
+}
 
 gl3::RenderParams VisualizationScene::GetMeshDrawParams()
 {

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -707,7 +707,7 @@ int VisualizationScene::AddLines(glTF_Builder &bld,
               << buf->count() << '\n';
       }
    }
-   int num_ibuf = 0, ibuf_layout = -1;
+   int num_ibuf = 0 /* , ibuf_layout = -1 */;
    for (int layout = 0; layout < gl3::NUM_LAYOUTS; ++layout)
    {
       const gl3::IIndexedBuffer *ibuf =
@@ -715,7 +715,7 @@ int VisualizationScene::AddLines(glTF_Builder &bld,
       if (ibuf && ibuf->getIndices().size() != 0)
       {
          num_ibuf++;
-         ibuf_layout = layout;
+         /* ibuf_layout = layout; */
          cout << "indexed lines: layout = " << layout << ", # vertices = "
               << ibuf->count() << ", # indices = " << ibuf->getIndices().size()
               << '\n';

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -19,6 +19,7 @@
 #include "mfem.hpp"
 #include "geom_utils.hpp"
 #include "sdl.hpp"
+#include "gltf.hpp"
 
 // Visualization header file
 
@@ -129,6 +130,28 @@ protected:
                   mfem::Vector &vals, mfem::DenseMatrix &normals,
                   const int n, const mfem::Array<int> &ind, const double minv,
                   const double maxv, const int normals_opt = 0);
+
+   glTF_Builder::material_id AddPaletteMaterial(glTF_Builder &bld);
+   glTF_Builder::material_id AddBlackMaterial(glTF_Builder &bld);
+   glTF_Builder::material_id AddPaletteLinesMaterial(
+      glTF_Builder &bld, glTF_Builder::material_id palette_mat);
+
+   glTF_Builder::node_id AddModelNode(glTF_Builder &bld,
+                                      const std::string &nodeName);
+
+   // returns number of triangles
+   int AddTriangles(glTF_Builder &bld,
+                    glTF_Builder::mesh_id mesh,
+                    glTF_Builder::buffer_id buffer,
+                    glTF_Builder::material_id material,
+                    const gl3::GlDrawable &gl_drawable);
+
+   // returns number of lines
+   int AddLines(glTF_Builder &bld,
+                glTF_Builder::mesh_id mesh,
+                glTF_Builder::buffer_id buffer,
+                glTF_Builder::material_id material,
+                const gl3::GlDrawable &gl_drawable);
 
 public:
    VisualizationScene();

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -198,6 +198,19 @@ public:
 
    virtual gl3::SceneInfo GetSceneObjs();
 
+   void glTF_ExportBox(glTF_Builder &bld,
+                       glTF_Builder::buffer_id buffer,
+                       glTF_Builder::material_id black_mat);
+   void glTF_ExportElements(glTF_Builder &bld,
+                            glTF_Builder::buffer_id buffer,
+                            glTF_Builder::material_id palette_mat,
+                            const gl3::GlDrawable &gl_drawable);
+   void glTF_ExportMesh(glTF_Builder &bld,
+                        glTF_Builder::buffer_id buffer,
+                        glTF_Builder::material_id black_mat,
+                        const gl3::GlDrawable &gl_drawable);
+   virtual void glTF_Export();
+
    double &GetMinV() { return minv; }
    double &GetMaxV() { return maxv; }
 

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -138,6 +138,11 @@ public:
 
    virtual gl3::SceneInfo GetSceneObjs();
 
+   void glTF_ExportBoundary(glTF_Builder &bld,
+                            glTF_Builder::buffer_id buffer,
+                            glTF_Builder::material_id black_mat);
+   virtual void glTF_Export();
+
    void ToggleDrawBdr();
 
    virtual void ToggleDrawElems();

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -14,6 +14,7 @@
 
 #include "mfem.hpp"
 #include "gl/types.hpp"
+#include "vsdata.hpp"
 #include <map>
 using namespace mfem;
 
@@ -123,6 +124,8 @@ public:
    virtual void PrepareOrderingCurve1(gl3::GlDrawable& buf, bool arrows,
                                       bool color);
    virtual gl3::SceneInfo GetSceneObjs();
+
+   virtual void glTF_Export();
 
    void ToggleDrawElems()
    { drawelems = !drawelems; Prepare(); }

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -1033,3 +1033,49 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
 
    return scene;
 }
+
+void VisualizationSceneVector::glTF_Export()
+{
+   string name = "GLVis_scene_000";
+
+   glTF_Builder bld(name);
+
+   auto palette_mat = AddPaletteMaterial(bld);
+   auto pal_lines_mat = AddPaletteLinesMaterial(bld, palette_mat);
+   auto black_mat = AddBlackMaterial(bld);
+   auto buf = bld.addBuffer("buffer");
+   if (drawvector)
+   {
+      auto vec_node = AddModelNode(bld, "Vectors");
+      auto vec_mesh = bld.addMesh("Vectors Mesh");
+      bld.addNodeMesh(vec_node, vec_mesh);
+
+      int ntria = AddTriangles(
+                     bld,
+                     vec_mesh,
+                     buf,
+                     (drawvector == 1) ? black_mat : palette_mat,
+                     vector_buf);
+      int nlines = AddLines(
+                      bld,
+                      vec_mesh,
+                      buf,
+                      (drawvector == 1) ? black_mat : pal_lines_mat,
+                      vector_buf);
+      if (ntria == 0 || nlines == 0)
+      {
+         cout << "glTF export: no vectors found to export!" << endl;
+      }
+   }
+   if (drawelems) { glTF_ExportElements(bld, buf, palette_mat, disp_buf); }
+   if (drawmesh)
+   {
+      glTF_ExportMesh(bld, buf, black_mat,
+                      (drawmesh == 1) ? line_buf : lcurve_buf);
+   }
+   if (drawbdr) { glTF_ExportBoundary(bld, buf, black_mat); }
+   if (drawaxes) { glTF_ExportBox(bld, buf, black_mat); }
+   bld.writeFile();
+
+   cout << "Exported glTF -> " << name << ".gltf" << endl;
+}

--- a/lib/vsvector.hpp
+++ b/lib/vsvector.hpp
@@ -14,6 +14,7 @@
 
 #include "mfem.hpp"
 #include "gl/types.hpp"
+#include "vssolution.hpp"
 using namespace mfem;
 
 class VisualizationSceneVector : public VisualizationSceneSolution
@@ -74,6 +75,8 @@ public:
    }
 
    virtual gl3::SceneInfo GetSceneObjs();
+
+   virtual void glTF_Export();
 
    virtual void EventUpdateColors() { Prepare(); PrepareVectorField(); }
 

--- a/makefile
+++ b/makefile
@@ -227,11 +227,11 @@ Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 # generated with 'echo lib/gl/*.c* lib/*.c*', does not include lib/*.m (Obj-C)
 ALL_SOURCE_FILES = \
  lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp \
- lib/gl/shader.cpp lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp lib/font.cpp \
- lib/gl2ps.c lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/sdl.cpp \
- lib/sdl_helper.cpp lib/sdl_main.cpp lib/stream_reader.cpp lib/threads.cpp \
- lib/vsdata.cpp lib/vssolution.cpp lib/vssolution3d.cpp lib/vsvector.cpp \
- lib/vsvector3d.cpp
+ lib/gl/shader.cpp lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp \
+ lib/font.cpp lib/gl2ps.c lib/gltf.cpp lib/material.cpp lib/openglvis.cpp \
+ lib/palettes.cpp lib/sdl.cpp lib/sdl_helper.cpp lib/sdl_main.cpp \
+ lib/stream_reader.cpp lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp \
+ lib/vssolution3d.cpp lib/vsvector.cpp lib/vsvector3d.cpp
 OBJC_SOURCE_FILES = $(if $(NOTMAC),,lib/sdl_mac.mm)
 DESKTOP_ONLY_SOURCE_FILES = \
  lib/gl/renderer_ff.cpp lib/threads.cpp lib/gl2ps.c lib/sdl_x11.cpp


### PR DESCRIPTION
The export function is bound to the key `G`.

This format can be imported in Blender and many other programs.

The output files (`*.gltf`, `*.palette.png`, and `*.buffer.bin`) can be view in a browser by dragging and dropping them on one of the following web pages:

   https://github.khronos.org/glTF-Sample-Viewer-Release
   https://modelviewer.dev/editor