### PR TITLE
Fix vector FE fields on surface meshes

### DIFF
--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -348,7 +348,7 @@ ProjectVectorFEGridFunction(std::unique_ptr<GridFunction> gf)
            << " discontinuous vector grid function..." << endl;
       int dim = gf->FESpace()->GetMesh()->Dimension();
       FiniteElementCollection *d_fec =
-         (p == 1) ?
+         (p == 1 && dim == 3) ?
          (FiniteElementCollection*)new LinearDiscont3DFECollection :
          (FiniteElementCollection*)new L2_FECollection(p, dim, 1);
       FiniteElementSpace *d_fespace =


### PR DESCRIPTION
This fixes a small bug introduced in #177 (pyramid-dev) that broke the visualization for vector FE fields on surface meshes.
