### PR TITLE
Support for faces with holes in 3D

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,9 @@
 Version 4.1.1 (development)
 ===========================
 
+- Added the option to cut a portion of the interiors of 3D faces to expose more
+  of the mesh. Useful as an alternative to transparency. See keys Ctrl+F3/F4.
+
 - Added 3D scene export to glTF format (https://www.khronos.org/gltf) which is
   bound to the key 'G'. This can be used to import GLVis scenes for rendering in
   Blender, as well as for augmented reality, see https://modelviewer.dev/editor.

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -126,6 +126,9 @@ VisualizationScene::VisualizationScene()
    ViewCenterX = 0.0;
    ViewCenterY = 0.0;
 
+   cut_lambda = 0.0;
+   cut_updated = false;
+
    background = BG_WHITE;
    GetAppWindow()->getRenderer().setClearColor(1.f, 1.f, 1.f, 1.f);
    _use_cust_l0_pos = false;
@@ -136,6 +139,113 @@ VisualizationScene::VisualizationScene()
 }
 
 VisualizationScene::~VisualizationScene() {}
+
+
+void VisualizationScene
+:: DrawCutTriangle(gl3::GlDrawable& buff,
+                   const double (&p)[4][3], const double (&cv)[4],
+                   const double minv, const double maxv)
+{
+   // element center
+   double c[3];
+   c[0] = c[1] = c[2] = 0.0;
+   for (int j = 0; j < 3; j++)
+   {
+      c[0] += p[j][0]; c[1] += p[j][1]; c[2] += p[j][2];
+   }
+   c[0] /= 3.0; c[1] /= 3.0; c[2] /= 3.0;
+
+   double l = cut_lambda;
+   double q[3][3];
+
+   for (int j = 0; j < 3; j++)
+   {
+      q[j][0] = l*p[j][0] + (1-l)*c[0];
+      q[j][1] = l*p[j][1] + (1-l)*c[1];
+      q[j][2] = l*p[j][2] + (1-l)*c[2];
+   }
+
+   double d[4][3];
+
+   double cvv[4];
+
+   // bottom, diagonal and left trapezoids
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[0][k]; d[1][k] = p[1][k]; d[2][k] = q[1][k]; d[3][k] = q[0][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[1][k]; d[1][k] = p[2][k]; d[2][k] = q[2][k]; d[3][k] = q[1][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[2][k]; d[1][k] = p[0][k]; d[2][k] = q[0][k]; d[3][k] = q[2][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+}
+
+
+void VisualizationScene
+:: DrawCutQuad(gl3::GlDrawable& buff,
+               const double (&p)[4][3], const double (&cv)[4],
+               const double minv, const double maxv)
+{
+   // element center
+   double c[3];
+   c[0] = c[1] = c[2] = 0.0;
+   for (int j = 0; j < 4; j++)
+   {
+      c[0] += p[j][0]; c[1] += p[j][1]; c[2] += p[j][2];
+   }
+   c[0] /= 4.0; c[1] /= 4.0; c[2] /= 4.0;
+
+   double l = cut_lambda;
+   double q[4][3];
+
+   for (int j = 0; j < 4; j++)
+   {
+      q[j][0] = l*p[j][0] + (1-l)*c[0];
+      q[j][1] = l*p[j][1] + (1-l)*c[1];
+      q[j][2] = l*p[j][2] + (1-l)*c[2];
+   }
+
+   double d[4][3];
+
+   double cvv[4];
+
+   // bottom, right, top and left trapezoids
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[0][k]; d[1][k] = p[1][k]; d[2][k] = q[1][k]; d[3][k] = q[0][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[1][k]; d[1][k] = p[2][k]; d[2][k] = q[2][k]; d[3][k] = q[1][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[2][k]; d[1][k] = p[3][k]; d[2][k] = q[3][k]; d[3][k] = q[2][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+
+   for (int k = 0; k < 3; k++)
+   {
+      d[0][k] = p[3][k]; d[1][k] = p[0][k]; d[2][k] = q[0][k]; d[3][k] = q[3][k];
+   }
+   DrawQuad(buff, d, cvv, minv, maxv);
+}
+
 
 void VisualizationScene
 ::DrawTriangle(gl3::GlDrawable& buff,

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -158,31 +158,32 @@ void VisualizationScene
    double l = cut_lambda;
    double q[3][3];
 
+   // corners of the cut frame
    for (int j = 0; j < 3; j++)
    {
-      q[j][0] = l*p[j][0] + (1-l)*c[0];
-      q[j][1] = l*p[j][1] + (1-l)*c[1];
-      q[j][2] = l*p[j][2] + (1-l)*c[2];
+      q[j][0] = l*p[j][0] + (1.0-l)*c[0];
+      q[j][1] = l*p[j][1] + (1.0-l)*c[1];
+      q[j][2] = l*p[j][2] + (1.0-l)*c[2];
    }
 
    double d[4][3];
-
    double cvv[4];
 
-   // bottom, diagonal and left trapezoids
-
+   // bottom trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[0][k]; d[1][k] = p[1][k]; d[2][k] = q[1][k]; d[3][k] = q[0][k];
    }
    DrawQuad(buff, d, cvv, minv, maxv);
 
+   // diagonal trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[1][k]; d[1][k] = p[2][k]; d[2][k] = q[2][k]; d[3][k] = q[1][k];
    }
    DrawQuad(buff, d, cvv, minv, maxv);
 
+   // left trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[2][k]; d[1][k] = p[0][k]; d[2][k] = q[0][k]; d[3][k] = q[2][k];
@@ -208,37 +209,39 @@ void VisualizationScene
    double l = cut_lambda;
    double q[4][3];
 
+   // corners of the cut frame
    for (int j = 0; j < 4; j++)
    {
-      q[j][0] = l*p[j][0] + (1-l)*c[0];
-      q[j][1] = l*p[j][1] + (1-l)*c[1];
-      q[j][2] = l*p[j][2] + (1-l)*c[2];
+      q[j][0] = l*p[j][0] + (1.0-l)*c[0];
+      q[j][1] = l*p[j][1] + (1.0-l)*c[1];
+      q[j][2] = l*p[j][2] + (1.0-l)*c[2];
    }
 
    double d[4][3];
-
    double cvv[4];
 
-   // bottom, right, top and left trapezoids
-
+   // bottom trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[0][k]; d[1][k] = p[1][k]; d[2][k] = q[1][k]; d[3][k] = q[0][k];
    }
    DrawQuad(buff, d, cvv, minv, maxv);
 
+   // right trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[1][k]; d[1][k] = p[2][k]; d[2][k] = q[2][k]; d[3][k] = q[1][k];
    }
    DrawQuad(buff, d, cvv, minv, maxv);
 
+   // top trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[2][k]; d[1][k] = p[3][k]; d[2][k] = q[3][k]; d[3][k] = q[2][k];
    }
    DrawQuad(buff, d, cvv, minv, maxv);
 
+   // left trapezoid
    for (int k = 0; k < 3; k++)
    {
       d[0][k] = p[3][k]; d[1][k] = p[0][k]; d[2][k] = q[0][k]; d[3][k] = q[3][k];

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -88,7 +88,6 @@ protected:
    int light_mat_idx;
    bool use_light;
 
-
    gl3::RenderParams GetMeshDrawParams();
    glm::mat4 GetModelViewMtx();
 
@@ -125,6 +124,18 @@ protected:
    void DrawQuad(gl3::GlDrawable& buff,
                  const double (&pts)[4][3], const double (&cv)[4],
                  const double minv, const double maxv);
+
+   /// Draw a 3D triangle with a central triangle removed. The cut is controlled
+   /// by the value of cut_lambda. See keys Ctrl+F3/F4.
+   void DrawCutTriangle(gl3::GlDrawable& buff,
+                        const double (&pts)[4][3], const double (&cv)[4],
+                        const double minv, const double maxv);
+
+   /// Draw a 3D quad with a central square removed. The cut is controlled by
+   /// the value of cut_lambda. See keys Ctrl+F3/F4.
+   void DrawCutQuad(gl3::GlDrawable& buff,
+                    const double (&pts)[4][3], const double (&cv)[4],
+                    const double minv, const double maxv);
 
    void DrawPatch(gl3::GlDrawable& buff, const mfem::DenseMatrix &pts,
                   mfem::Vector &vals, mfem::DenseMatrix &normals,
@@ -166,6 +177,11 @@ public:
 
    /// Bounding box.
    double x[2], y[2], z[2];
+
+   /// Amount of face cutting with keys Ctrl-F3/F4 (0: no cut, 1: cut to edges)
+   double cut_lambda;
+   /// Have the reference geometries been updated for the cut?
+   bool cut_updated;
 
    glm::mat4 rotmat;
    glm::mat4 translmat;

--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -125,14 +125,16 @@ protected:
                  const double (&pts)[4][3], const double (&cv)[4],
                  const double minv, const double maxv);
 
-   /// Draw a 3D triangle with a central triangle removed. The cut is controlled
-   /// by the value of cut_lambda. See keys Ctrl+F3/F4.
+   /// Draw a 3D triangle in physical space with a central triangle removed. The
+   /// cut is controlled by value of cut_lambda. See keys Ctrl+F3/F4. Similar to
+   /// CutReferenceTriangle in lib/vssolution3d.cpp.
    void DrawCutTriangle(gl3::GlDrawable& buff,
                         const double (&pts)[4][3], const double (&cv)[4],
                         const double minv, const double maxv);
 
-   /// Draw a 3D quad with a central square removed. The cut is controlled by
-   /// the value of cut_lambda. See keys Ctrl+F3/F4.
+   /// Draw a 3D quad in physical space with a central square removed. The cut
+   /// is controlled by the value of cut_lambda. See keys Ctrl+F3/F4. Similar to
+   /// CutReferenceSquare in lib/vssolution3d.cpp.
    void DrawCutQuad(gl3::GlDrawable& buff,
                     const double (&pts)[4][3], const double (&cv)[4],
                     const double minv, const double maxv);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -488,7 +488,7 @@ static void KeyF4Pressed(GLenum state)
       {
          vssol3d->cut_lambda -= 0.05;
          vssol3d->cut_updated = false;
-     }
+      }
       vssol3d->Prepare();
       SendExposeEvent();
    }
@@ -1674,7 +1674,8 @@ void VisualizationSceneSolution3d::PrepareFlat2()
          }
 
          IntegrationRule &RefPts = (cut_lambda > 0) ?
-             ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+                                   ((sides == 3) ? cut_TriPts : cut_QuadPts) :
+                                   RefG->RefPts;
          GridF -> GetFaceValues (fn, di, RefPts, values, pointmat);
          GetFaceNormals(fn, di, RefPts,normals);
          have_normals = 1;
@@ -1691,7 +1692,8 @@ void VisualizationSceneSolution3d::PrepareFlat2()
             cut_updated = true;
          }
          const IntegrationRule &ir = (cut_lambda > 0) ?
-            ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+                                     ((sides == 3) ? cut_TriPts : cut_QuadPts) :
+                                     RefG->RefPts;
          GridF->GetValues(i, ir, values, pointmat);
          normals.SetSize(3, values.Size());
          mesh->GetElementTransformation(i, &T);
@@ -1746,7 +1748,8 @@ void VisualizationSceneSolution3d::PrepareFlat2()
       // have_normals = have_normals ? 1 : 0;
 
       Array<int> &RefGeoms = (cut_lambda > 0) ?
-         ((sides == 3) ? cut_TriGeoms : cut_QuadGeoms) : RefG->RefGeoms;
+                             ((sides == 3) ? cut_TriGeoms : cut_QuadGeoms) :
+                             RefG->RefGeoms;
       int psides = (cut_lambda > 0) ? 4 : sides;
       DrawPatch(disp_buf, pointmat, values, normals, psides, RefGeoms,
                 minv, maxv, have_normals);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -2894,11 +2894,11 @@ void VisualizationSceneSolution3d::PrepareCuttingPlane2()
 
             if (nodes.Size() == 3)
             {
-               DrawCutTriangle(cplane_buf, p, c, minv, maxv);
+               DrawTriangle(cplane_buf, p, c, minv, maxv);
             }
             else
             {
-               DrawCutQuad(cplane_buf, p, c, minv, maxv);
+               DrawQuad(cplane_buf, p, c, minv, maxv);
             }
          }
          else // shading == 2

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -24,6 +24,15 @@ using namespace std;
 thread_local VisualizationSceneSolution3d *vssol3d;
 extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
+// Reference geometries with a cut in the middle, based on subdivision of
+// GLVisGeometryRefiner in 3-4 quads. Updated when cut_lambda is updated, see
+// keys Ctrl+F3/F4. We need these variables because the GLVisGeometryRefiner
+// cashes its RefinedGeometry objects.
+thread_local IntegrationRule cut_QuadPts;
+thread_local Array<int> cut_QuadGeoms;
+thread_local IntegrationRule cut_TriPts;
+thread_local Array<int> cut_TriGeoms;
+
 // Definitions of some more keys
 
 std::string VisualizationSceneSolution3d::GetHelpString() const
@@ -74,6 +83,7 @@ std::string VisualizationSceneSolution3d::GetHelpString() const
       << "| F1 - X window info and keystrokes  |" << endl
       << "| F2 - Update colors, etc.           |" << endl
       << "| F3/F4 - Shrink/Zoom bdr elements   |" << endl
+      << "| Ctrl+F3/F4 - Cut face bdr elements |" << endl
       << "| F5 - Set level lines               |" << endl
       << "| F6 - Palette options               |" << endl
       << "| F7 - Manually set min/max value    |" << endl
@@ -433,49 +443,76 @@ void ToggleMagicKey()
    magic_key_pressed = 1-magic_key_pressed;
 }
 
-static void KeyF3Pressed()
+static void KeyF3Pressed(GLenum state)
 {
-   if (vssol3d->GetShading() == 2)
+   if (state & KMOD_CTRL)
    {
-      if (vssol3d->GetMesh()->Dimension() == 3 && vssol3d->bdrc.Width() == 0)
+      if (vssol3d->cut_lambda <= 0.95)
       {
-         vssol3d->ComputeBdrAttrCenter();
-      }
-      if (vssol3d->GetMesh()->Dimension() == 2 && vssol3d->matc.Width() == 0)
-      {
-         vssol3d->ComputeElemAttrCenter();
-      }
-      vssol3d->shrink *= 0.9;
-      if (magic_key_pressed)
-      {
-         vssol3d -> Scale(1.11111111111111111111111);
+         vssol3d->cut_lambda += 0.05;
+         vssol3d->cut_updated = false;
       }
       vssol3d->Prepare();
-      vssol3d->PrepareLines();
       SendExposeEvent();
+   }
+   else
+   {
+      if (vssol3d->GetShading() == 2)
+      {
+         if (vssol3d->GetMesh()->Dimension() == 3 && vssol3d->bdrc.Width() == 0)
+         {
+            vssol3d->ComputeBdrAttrCenter();
+         }
+         if (vssol3d->GetMesh()->Dimension() == 2 && vssol3d->matc.Width() == 0)
+         {
+            vssol3d->ComputeElemAttrCenter();
+         }
+         vssol3d->shrink *= 0.9;
+         if (magic_key_pressed)
+         {
+            vssol3d -> Scale(1.11111111111111111111111);
+         }
+         SendExposeEvent();
+         vssol3d->Prepare();
+         vssol3d->PrepareLines();
+         SendExposeEvent();
+      }
    }
 }
 
-static void KeyF4Pressed()
+static void KeyF4Pressed(GLenum state)
 {
-   if (vssol3d->GetShading() == 2)
+   if (state & KMOD_CTRL)
    {
-      if (vssol3d->GetMesh()->Dimension() == 3 && vssol3d->bdrc.Width() == 0)
+      if (vssol3d->cut_lambda >= 0.05)
       {
-         vssol3d->ComputeBdrAttrCenter();
-      }
-      if (vssol3d->GetMesh()->Dimension() == 2 && vssol3d->matc.Width() == 0)
-      {
-         vssol3d->ComputeElemAttrCenter();
-      }
-      vssol3d->shrink *= 1.11111111111111111111111;
-      if (magic_key_pressed)
-      {
-         vssol3d -> Scale(0.9);
-      }
+         vssol3d->cut_lambda -= 0.05;
+         vssol3d->cut_updated = false;
+     }
       vssol3d->Prepare();
-      vssol3d->PrepareLines();
       SendExposeEvent();
+   }
+   else
+   {
+      if (vssol3d->GetShading() == 2)
+      {
+         if (vssol3d->GetMesh()->Dimension() == 3 && vssol3d->bdrc.Width() == 0)
+         {
+            vssol3d->ComputeBdrAttrCenter();
+         }
+         if (vssol3d->GetMesh()->Dimension() == 2 && vssol3d->matc.Width() == 0)
+         {
+            vssol3d->ComputeElemAttrCenter();
+         }
+         vssol3d->shrink *= 1.11111111111111111111111;
+         if (magic_key_pressed)
+         {
+            vssol3d -> Scale(0.9);
+         }
+         vssol3d->Prepare();
+         vssol3d->PrepareLines();
+         SendExposeEvent();
+      }
    }
 }
 
@@ -1429,14 +1466,129 @@ void VisualizationSceneSolution3d::PrepareFlat()
       }
       if (j == 3)
       {
-         DrawTriangle(disp_buf, p, c, minv, maxv);
+         DrawCutTriangle(disp_buf, p, c, minv, maxv);
       }
       else
       {
-         DrawQuad(disp_buf, p, c, minv, maxv);
+         DrawCutQuad(disp_buf, p, c, minv, maxv);
       }
    }
    updated_bufs.emplace_back(&disp_buf);
+}
+
+
+// Cut the reference square by subdividing it into 4 trapezoids with a central
+// square removed: (fl,fl)-(fr,fl)-(fr,fr)-(fl,fr). The input RefG corresponds
+// to the reference square. The value of lambda controls the cut: 0 = no cut, 1
+// = full cut. See keys Ctrl+F3/F4.
+static void CutReferenceSquare(RefinedGeometry *RefG, double lambda,
+                               IntegrationRule &RefPts, Array<int> &RefGeoms)
+{
+   // lambda * vertex + (1-lambda) * center
+   double fl = (1-lambda)/2; // left corner of the cut frame
+   double fr = (1+lambda)/2; // right corner of the cut frame
+
+   int np = RefG->RefPts.Size();
+   RefPts.SetSize(4*np);
+   for (int i = 0; i < np; i++)
+   {
+      double X = RefG->RefPts[i].x;
+      double Y = RefG->RefPts[i].y;
+
+      // First order unit square basis functions
+      double phi3 = (1-X)*Y,     phi2 = X*Y;     // (0,1)-(1,1)
+      double phi0 = (1-X)*(1-Y), phi1 = X*(1-Y); // (0,0)-(1,0)
+
+      // bottom trapezoid: (0,0)-(1,1)-(fr,fl)-(fl,fl)
+      RefPts[i].x      = phi1 + fr * phi2 + fl * phi3;
+      RefPts[i].y      =        fl * phi2 + fl * phi3;
+
+      // right trapezoid: (fr,fl)-(1,0)-(1,1)-(fr,fr)
+      RefPts[i+np].x   = fr * phi0 + phi1 + phi2 + fr * phi3;
+      RefPts[i+np].y   = fl * phi0 +        phi2 + fr * phi3;
+
+      // top trapezoid: (fl,fr)-(fr,fr)-(1,1)-(0,1)
+      RefPts[i+2*np].x = fl * phi0 + fr * phi1 + phi2;
+      RefPts[i+2*np].y = fr * phi0 + fr * phi1 + phi2 + phi3;
+
+      // left trapezoid: (0,0)-(fl,fl)-(fl,fr)-(0,1)
+      RefPts[i+3*np].x = fl * phi1 + fl * phi2;
+      RefPts[i+3*np].y = fl * phi1 + fr * phi2 + phi3;
+
+      RefPts[i].z      = RefG->RefPts[i].z;
+      RefPts[i+np].z   = RefG->RefPts[i].z;
+      RefPts[i+2*np].z = RefG->RefPts[i].z;
+      RefPts[i+3*np].z = RefG->RefPts[i].z;
+   }
+
+   int ne = RefG->RefGeoms.Size();
+   RefGeoms.SetSize(4*ne);
+   for (int i = 0; i < ne; i++)
+   {
+      RefGeoms[i]      = RefG->RefGeoms[i];
+      RefGeoms[i+ne]   = RefG->RefGeoms[i] + np;
+      RefGeoms[i+2*ne] = RefG->RefGeoms[i] + 2*np;
+      RefGeoms[i+3*ne] = RefG->RefGeoms[i] + 3*np;
+   }
+}
+
+// Cut the reference triangle by subdividing it into 3 trapezoids with a central
+// triangle removed: (fl,fl)-(fr,fl)-(fl,fr). Note that the input RefG
+// corresponds to a reference square, not reference triangle. The value of
+// lambda controls the cut: 0 = no cut, 1 = full cut. See keys Ctrl+F3/F4.
+static void CutReferenceTriangle(RefinedGeometry *RefG, double lambda,
+                                 IntegrationRule &RefPts, Array<int> &RefGeoms)
+{
+   // lambda * vertex + (1-lambda) * center
+   double fl = (1-lambda)/3;   // left corner of the cut frame
+   double fr = (1+2*lambda)/3; // right corner of the cut frame
+
+   int np = RefG->RefPts.Size();
+   RefPts.SetSize(3*np);
+   for (int i = 0; i < np; i++)
+   {
+      double X = RefG->RefPts[i].x;
+      double Y = RefG->RefPts[i].y;
+
+      // First order unit square basis functions
+      double phi3 = (1-X)*Y,     phi2 = X*Y;     // (0,1)-(1,1)
+      double phi0 = (1-X)*(1-Y), phi1 = X*(1-Y); // (0,0)-(1,0)
+
+      // bottom trapezoid: (0,0)-(1,0)-(fr,fl)-(fl,fl)
+      RefPts[i].x      = phi1 + fr * phi2 + fl * phi3;
+      RefPts[i].y      =        fl * phi2 + fl * phi3;
+
+      // diagonal trapezoid: (fr,fl)-(1,0)-(0,1)-(fl,fr)
+      RefPts[i+np].x   = fr * phi0 + phi1        + fl * phi3;
+      RefPts[i+np].y   = fl * phi0        + phi2 + fr * phi3;
+
+      // left trapezoid: (0,0)-(fl,fl)-(fl,fr)-(0,1)
+      RefPts[i+2*np].x = fl * phi1 + fl * phi2;
+      RefPts[i+2*np].y = fl * phi1 + fr * phi2 + phi3;
+
+      RefPts[i].z      = RefG->RefPts[i].z;
+      RefPts[i+np].z   = RefG->RefPts[i].z;
+      RefPts[i+2*np].z = RefG->RefPts[i].z;
+   }
+
+   int ne = RefG->RefGeoms.Size();
+   RefGeoms.SetSize(3*ne);
+   for (int i = 0; i < ne; i++)
+   {
+      RefGeoms[i]      = RefG->RefGeoms[i];
+      RefGeoms[i+ne]   = RefG->RefGeoms[i] + np;
+      RefGeoms[i+2*ne] = RefG->RefGeoms[i] + 2*np;
+   }
+}
+
+// Call CutReferenceTriangle and CutReferenceSquare to update the global
+// variables cut_TriPts, cut_TriGeoms, cut_QuadPts, cut_QuadGeoms.
+void CutReferenceElements(int TimesToRefine, double lambda)
+{
+   RefinedGeometry *RefG =
+      GLVisGeometryRefiner.Refine(Geometry::SQUARE, TimesToRefine);
+   CutReferenceTriangle(RefG, lambda, cut_TriPts, cut_TriGeoms);
+   CutReferenceSquare(RefG, lambda, cut_QuadPts, cut_QuadGeoms);
 }
 
 void VisualizationSceneSolution3d::PrepareFlat2()
@@ -1463,6 +1615,19 @@ void VisualizationSceneSolution3d::PrepareFlat2()
    vmax = -vmin;
    for (i = 0; i < nbe; i++)
    {
+      int sides;
+      switch ((dim == 3) ? mesh->GetBdrElementType(i) : mesh->GetElementType(i))
+      {
+         case Element::TRIANGLE:
+            sides = 3;
+            break;
+
+         case Element::QUADRILATERAL:
+         default:
+            sides = 4;
+            break;
+      }
+
       if (dim == 3)
       {
          if (!bdr_attr_to_show[mesh->GetBdrAttribute(i)-1]) { continue; }
@@ -1485,22 +1650,33 @@ void VisualizationSceneSolution3d::PrepareFlat2()
          if (!bdr_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
          mesh->GetElementVertices(i, vertices);
       }
+
       if (cplane == 2 && CheckPositions(vertices)) { continue; }
+
       if (dim == 3)
       {
          mesh -> GetBdrElementFace (i, &fn, &fo);
          RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceBaseGeometry (fn),
                                             TimesToRefine);
-         // di = GridF -> GetFaceValues (fn, 2, RefG->RefPts, values, pointmat);
+         if (!cut_updated)
+         {
+            // Update the cut version of the reference geometries
+            CutReferenceElements(TimesToRefine, cut_lambda);
+            cut_updated = true;
+         }
 
+         // di = GridF -> GetFaceValues (fn, 2, RefG->RefPts, values, pointmat);
          // this assumes the interior boundary faces are properly oriented ...
          di = fo % 2;
          if (di == 1 && !mesh->FaceIsInterior(fn))
          {
             di = 0;
          }
-         GridF -> GetFaceValues (fn, di, RefG->RefPts, values, pointmat);
-         GetFaceNormals(fn, di, RefG->RefPts, normals);
+
+         IntegrationRule &RefPts = (cut_lambda > 0) ?
+             ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+         GridF -> GetFaceValues (fn, di, RefPts, values, pointmat);
+         GetFaceNormals(fn, di, RefPts,normals);
          have_normals = 1;
          ShrinkPoints(pointmat, i, fn, di);
       }
@@ -1508,7 +1684,14 @@ void VisualizationSceneSolution3d::PrepareFlat2()
       {
          RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
                                             TimesToRefine);
-         const IntegrationRule &ir = RefG->RefPts;
+         if (!cut_updated)
+         {
+            // Update the cut version of the reference geometries
+            CutReferenceElements(TimesToRefine, cut_lambda);
+            cut_updated = true;
+         }
+         const IntegrationRule &ir = (cut_lambda > 0) ?
+            ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
          GridF->GetValues(i, ir, values, pointmat);
          normals.SetSize(3, values.Size());
          mesh->GetElementTransformation(i, &T);
@@ -1527,19 +1710,6 @@ void VisualizationSceneSolution3d::PrepareFlat2()
 
       vmin = fmin(vmin, values.Min());
       vmax = fmax(vmax, values.Max());
-
-      int sides;
-      switch ((dim == 3) ? mesh->GetBdrElementType(i) : mesh->GetElementType(i))
-      {
-         case Element::TRIANGLE:
-            sides = 3;
-            break;
-
-         case Element::QUADRILATERAL:
-         default:
-            sides = 4;
-            break;
-      }
 
       // compute an average normal direction for the current face
       if (sc != 0.0)
@@ -1574,7 +1744,11 @@ void VisualizationSceneSolution3d::PrepareFlat2()
       // Comment the above lines and use the below version in order to remove
       // the 3D dark artifacts (indicating wrong boundary element orientation)
       // have_normals = have_normals ? 1 : 0;
-      DrawPatch(disp_buf, pointmat, values, normals, sides, RefG->RefGeoms,
+
+      Array<int> &RefGeoms = (cut_lambda > 0) ?
+         ((sides == 3) ? cut_TriGeoms : cut_QuadGeoms) : RefG->RefGeoms;
+      int psides = (cut_lambda > 0) ? 4 : sides;
+      DrawPatch(disp_buf, pointmat, values, normals, psides, RefGeoms,
                 minv, maxv, have_normals);
    }
    updated_bufs.emplace_back(&disp_buf);
@@ -2695,11 +2869,11 @@ void VisualizationSceneSolution3d::PrepareCuttingPlane2()
 
             if (nodes.Size() == 3)
             {
-               DrawTriangle(cplane_buf, p, c, minv, maxv);
+               DrawCutTriangle(cplane_buf, p, c, minv, maxv);
             }
             else
             {
-               DrawQuad(cplane_buf, p, c, minv, maxv);
+               DrawCutQuad(cplane_buf, p, c, minv, maxv);
             }
          }
          else // shading == 2

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -452,6 +452,10 @@ static void KeyF3Pressed(GLenum state)
          vssol3d->cut_lambda += 0.05;
          vssol3d->cut_updated = false;
       }
+      if (fabs(vssol3d->cut_lambda-1.0) < 1e-12) // snap to 1
+      {
+         vssol3d->cut_lambda = 1.0;
+      }
       vssol3d->Prepare();
       SendExposeEvent();
    }
@@ -488,6 +492,10 @@ static void KeyF4Pressed(GLenum state)
       {
          vssol3d->cut_lambda -= 0.05;
          vssol3d->cut_updated = false;
+      }
+      if (fabs(vssol3d->cut_lambda-0.0) < 1e-12) // snap to 0
+      {
+         vssol3d->cut_lambda = 0.0;
       }
       vssol3d->Prepare();
       SendExposeEvent();
@@ -1466,11 +1474,25 @@ void VisualizationSceneSolution3d::PrepareFlat()
       }
       if (j == 3)
       {
-         DrawCutTriangle(disp_buf, p, c, minv, maxv);
+         if (cut_lambda > 0)
+         {
+            DrawCutTriangle(disp_buf, p, c, minv, maxv);
+         }
+         else
+         {
+            DrawTriangle(disp_buf, p, c, minv, maxv);
+         }
       }
       else
       {
-         DrawCutQuad(disp_buf, p, c, minv, maxv);
+         if (cut_lambda > 0)
+         {
+            DrawCutQuad(disp_buf, p, c, minv, maxv);
+         }
+         else
+         {
+            DrawQuad(disp_buf, p, c, minv, maxv);
+         }
       }
    }
    updated_bufs.emplace_back(&disp_buf);
@@ -1485,8 +1507,8 @@ static void CutReferenceSquare(RefinedGeometry *RefG, double lambda,
                                IntegrationRule &RefPts, Array<int> &RefGeoms)
 {
    // lambda * vertex + (1-lambda) * center
-   double fl = (1-lambda)/2; // left corner of the cut frame
-   double fr = (1+lambda)/2; // right corner of the cut frame
+   double fl = (1.0-lambda)/2.0; // left corner of the cut frame
+   double fr = (1.0+lambda)/2.0; // right corner of the cut frame
 
    int np = RefG->RefPts.Size();
    RefPts.SetSize(4*np);
@@ -1496,8 +1518,8 @@ static void CutReferenceSquare(RefinedGeometry *RefG, double lambda,
       double Y = RefG->RefPts[i].y;
 
       // First order unit square basis functions
-      double phi3 = (1-X)*Y,     phi2 = X*Y;     // (0,1)-(1,1)
-      double phi0 = (1-X)*(1-Y), phi1 = X*(1-Y); // (0,0)-(1,0)
+      double phi3 = (1.0-X)*Y,       phi2 = X*Y;       // (0,1)-(1,1)
+      double phi0 = (1.0-X)*(1.0-Y), phi1 = X*(1.0-Y); // (0,0)-(1,0)
 
       // bottom trapezoid: (0,0)-(1,1)-(fr,fl)-(fl,fl)
       RefPts[i].x      = phi1 + fr * phi2 + fl * phi3;
@@ -1540,8 +1562,8 @@ static void CutReferenceTriangle(RefinedGeometry *RefG, double lambda,
                                  IntegrationRule &RefPts, Array<int> &RefGeoms)
 {
    // lambda * vertex + (1-lambda) * center
-   double fl = (1-lambda)/3;   // left corner of the cut frame
-   double fr = (1+2*lambda)/3; // right corner of the cut frame
+   double fl = (1.0-lambda)/3.0;     // left corner of the cut frame
+   double fr = (1.0+2.0*lambda)/3.0; // right corner of the cut frame
 
    int np = RefG->RefPts.Size();
    RefPts.SetSize(3*np);
@@ -1551,8 +1573,8 @@ static void CutReferenceTriangle(RefinedGeometry *RefG, double lambda,
       double Y = RefG->RefPts[i].y;
 
       // First order unit square basis functions
-      double phi3 = (1-X)*Y,     phi2 = X*Y;     // (0,1)-(1,1)
-      double phi0 = (1-X)*(1-Y), phi1 = X*(1-Y); // (0,0)-(1,0)
+      double phi3 = (1.0-X)*Y,       phi2 = X*Y;       // (0,1)-(1,1)
+      double phi0 = (1.0-X)*(1.0-Y), phi1 = X*(1.0-Y); // (0,0)-(1,0)
 
       // bottom trapezoid: (0,0)-(1,0)-(fr,fl)-(fl,fl)
       RefPts[i].x      = phi1 + fr * phi2 + fl * phi3;

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -560,11 +560,25 @@ void VisualizationSceneVector3d::PrepareFlat()
       }
       if (j == 3)
       {
-         DrawTriangle(disp_buf, p, c, minv, maxv);
+         if (cut_lambda > 0)
+         {
+            DrawCutTriangle(disp_buf, p, c, minv, maxv);
+         }
+         else
+         {
+            DrawTriangle(disp_buf, p, c, minv, maxv);
+         }
       }
       else
       {
-         DrawQuad(disp_buf, p, c, minv, maxv);
+         if (cut_lambda > 0)
+         {
+            DrawCutQuad(disp_buf, p, c, minv, maxv);
+         }
+         else
+         {
+            DrawQuad(disp_buf, p, c, minv, maxv);
+         }
       }
    }
    updated_bufs.emplace_back(&disp_buf);

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -570,62 +570,6 @@ void VisualizationSceneVector3d::PrepareFlat()
    updated_bufs.emplace_back(&disp_buf);
 }
 
-static void CutHoleInPatch(DenseMatrix &pts, Vector &vals, DenseMatrix &normals,
-                    const int sides, const Array<int> &old_ind, Array<int> &ind,
-                    double lambda)
-{
-   if (sides != 4) { ind = old_ind; return; }
-
-   cout << "lambda = " << lambda << endl;
-
-   if (lambda < 0.1) { ind = old_ind; return; }
-
-   int n = sqrt(pts.Width())-1; // n x n LOR elements
-
-   int l = (1-lambda)*n/2 + lambda*1;
-
-   if (l == 0) { l = 1; }
-
-   if (n-2*l <= 0) { ind = old_ind; return; }
-
-   cout << "n = " << n << "l = " << l << endl;
-
-   ind.SetSize(sides * (n*n - (n-2*l)*(n-2*l)));
-
-   int k = 0;
-   for (int m = 0; m < l; m++)
-   {
-      for (int i = 0; i < n; i++)
-      {
-         for (int j = 0; j < sides; j++)
-         {
-            ind[k++] = old_ind[sides*(n*m+i)+j];
-         }
-         for (int j = 0; j < sides; j++)
-         {
-            ind[k++] = old_ind[sides*(n*(n-m-1)+i)+j];
-         }
-      }
-   }
-
-   for (int i = l; i < n-l; i++)
-   {
-      for (int m = 0; m < l; m++)
-      {
-         for (int j = 0; j < sides; j++)
-         {
-            ind[k++] = old_ind[sides*(n*i+m)+j];
-         }
-         for (int j = 0; j < sides; j++)
-         {
-            ind[k++] = old_ind[sides*(n*i+n-1-m)+j];
-         }
-      }
-   }
-
-   return;
-}
-
 void VisualizationSceneVector3d::PrepareFlat2()
 {
    int i, k, fn, fo, di = 0, have_normals;
@@ -710,7 +654,8 @@ void VisualizationSceneVector3d::PrepareFlat2()
          }
 
          IntegrationRule &RefPts = (cut_lambda > 0) ?
-             ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+                                   ((sides == 3) ? cut_TriPts : cut_QuadPts) :
+                                   RefG->RefPts;
          GridF->GetFaceValues(fn, di, RefPts, values, pointmat);
          if (ianim > 0)
          {
@@ -737,7 +682,8 @@ void VisualizationSceneVector3d::PrepareFlat2()
             cut_updated = true;
          }
          IntegrationRule &RefPts = (cut_lambda > 0) ?
-            ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+                                   ((sides == 3) ? cut_TriPts : cut_QuadPts) :
+                                   RefG->RefPts;
          GridF->GetValues(i, RefPts, values, pointmat);
          if (ianim > 0)
          {
@@ -748,7 +694,8 @@ void VisualizationSceneVector3d::PrepareFlat2()
          else
          {
             const IntegrationRule &ir = (cut_lambda > 0) ?
-               ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+                                        ((sides == 3) ? cut_TriPts : cut_QuadPts) :
+                                        RefG->RefPts;
             normals.SetSize(3, values.Size());
             mesh->GetElementTransformation(i, &T);
             for (int j = 0; j < values.Size(); j++)
@@ -798,7 +745,8 @@ void VisualizationSceneVector3d::PrepareFlat2()
       }
 
       Array<int> &RefGeoms = (cut_lambda > 0) ?
-         ((sides == 3) ? cut_TriGeoms : cut_QuadGeoms) : RefG->RefGeoms;
+                             ((sides == 3) ? cut_TriGeoms : cut_QuadGeoms) :
+                             RefG->RefGeoms;
       int psides = (cut_lambda > 0) ? 4 : sides;
       DrawPatch(disp_buf, pointmat, values, normals, psides, RefGeoms,
                 minv, maxv, have_normals);

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -20,6 +20,16 @@ using namespace mfem;
 
 using namespace std;
 
+// Reference geometry with a cut in the middle, which subdivides GeometryRefiner
+// when cut_lambda is updated, see keys Ctrl+F3/F4. These variables are defined
+// in lib/vssolution3d.cpp.
+extern thread_local IntegrationRule cut_QuadPts;
+extern thread_local Array<int> cut_QuadGeoms;
+extern thread_local IntegrationRule cut_TriPts;
+extern thread_local Array<int> cut_TriGeoms;
+extern void CutReferenceElements(int TimesToRefine, double lambda);
+
+
 std::string VisualizationSceneVector3d::GetHelpString() const
 {
    std::stringstream os;
@@ -70,6 +80,7 @@ std::string VisualizationSceneVector3d::GetHelpString() const
       << "| F1 - X window info and keystrokes  |" << endl
       << "| F2 - Update colors, etc.           |" << endl
       << "| F3/F4 - Shrink/Zoom bdr elements   |" << endl
+      << "| Ctrl+F3/F4 - Cut face bdr elements |" << endl
       << "| F6 - Palette options               |" << endl
       << "| F7 - Manually set min/max value    |" << endl
       << "| F8 - List of subdomains to show    |" << endl
@@ -559,6 +570,62 @@ void VisualizationSceneVector3d::PrepareFlat()
    updated_bufs.emplace_back(&disp_buf);
 }
 
+static void CutHoleInPatch(DenseMatrix &pts, Vector &vals, DenseMatrix &normals,
+                    const int sides, const Array<int> &old_ind, Array<int> &ind,
+                    double lambda)
+{
+   if (sides != 4) { ind = old_ind; return; }
+
+   cout << "lambda = " << lambda << endl;
+
+   if (lambda < 0.1) { ind = old_ind; return; }
+
+   int n = sqrt(pts.Width())-1; // n x n LOR elements
+
+   int l = (1-lambda)*n/2 + lambda*1;
+
+   if (l == 0) { l = 1; }
+
+   if (n-2*l <= 0) { ind = old_ind; return; }
+
+   cout << "n = " << n << "l = " << l << endl;
+
+   ind.SetSize(sides * (n*n - (n-2*l)*(n-2*l)));
+
+   int k = 0;
+   for (int m = 0; m < l; m++)
+   {
+      for (int i = 0; i < n; i++)
+      {
+         for (int j = 0; j < sides; j++)
+         {
+            ind[k++] = old_ind[sides*(n*m+i)+j];
+         }
+         for (int j = 0; j < sides; j++)
+         {
+            ind[k++] = old_ind[sides*(n*(n-m-1)+i)+j];
+         }
+      }
+   }
+
+   for (int i = l; i < n-l; i++)
+   {
+      for (int m = 0; m < l; m++)
+      {
+         for (int j = 0; j < sides; j++)
+         {
+            ind[k++] = old_ind[sides*(n*i+m)+j];
+         }
+         for (int j = 0; j < sides; j++)
+         {
+            ind[k++] = old_ind[sides*(n*i+n-1-m)+j];
+         }
+      }
+   }
+
+   return;
+}
+
 void VisualizationSceneVector3d::PrepareFlat2()
 {
    int i, k, fn, fo, di = 0, have_normals;
@@ -585,6 +652,19 @@ void VisualizationSceneVector3d::PrepareFlat2()
    vmax = -vmin;
    for (i = 0; i < ne; i++)
    {
+      int sides;
+      switch ((dim == 3) ? mesh->GetBdrElementType(i) : mesh->GetElementType(i))
+      {
+         case Element::TRIANGLE:
+            sides = 3;
+            break;
+
+         case Element::QUADRILATERAL:
+         default:
+            sides = 4;
+            break;
+      }
+
       if (dim == 3)
       {
          if (!bdr_attr_to_show[mesh->GetBdrAttribute(i)-1]) { continue; }
@@ -605,7 +685,6 @@ void VisualizationSceneVector3d::PrepareFlat2()
       else
       {
          if (!bdr_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
-
          mesh->GetElementVertices(i, vertices);
       }
 
@@ -616,23 +695,33 @@ void VisualizationSceneVector3d::PrepareFlat2()
          mesh -> GetBdrElementFace (i, &fn, &fo);
          RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceBaseGeometry (fn),
                                             TimesToRefine);
+         if (!cut_updated)
+         {
+            // Update the cut version of the reference geometries
+            CutReferenceElements(TimesToRefine, cut_lambda);
+            cut_updated = true;
+         }
+
          // di = GridF->GetFaceValues(fn, 2, RefG->RefPts, values, pointmat);
          di = fo % 2;
          if (di == 1 && !mesh->FaceIsInterior(fn))
          {
             di = 0;
          }
-         GridF->GetFaceValues(fn, di, RefG->RefPts, values, pointmat);
+
+         IntegrationRule &RefPts = (cut_lambda > 0) ?
+             ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+         GridF->GetFaceValues(fn, di, RefPts, values, pointmat);
          if (ianim > 0)
          {
-            VecGridF->GetFaceVectorValues(fn, di, RefG->RefPts, vec_vals,
+            VecGridF->GetFaceVectorValues(fn, di, RefPts, vec_vals,
                                           pointmat);
             pointmat.Add(double(ianim)/ianimmax, vec_vals);
             have_normals = 0;
          }
          else
          {
-            GetFaceNormals(fn, di, RefG->RefPts, normals);
+            GetFaceNormals(fn, di, RefPts, normals);
             have_normals = 1;
          }
          ShrinkPoints(pointmat, i, fn, di);
@@ -641,16 +730,25 @@ void VisualizationSceneVector3d::PrepareFlat2()
       {
          RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
                                             TimesToRefine);
-         GridF->GetValues(i, RefG->RefPts, values, pointmat);
+         if (!cut_updated)
+         {
+            // Update the cut version of the reference geometries
+            CutReferenceElements(TimesToRefine, cut_lambda);
+            cut_updated = true;
+         }
+         IntegrationRule &RefPts = (cut_lambda > 0) ?
+            ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
+         GridF->GetValues(i, RefPts, values, pointmat);
          if (ianim > 0)
          {
-            VecGridF->GetVectorValues(i, RefG->RefPts, vec_vals, pointmat);
+            VecGridF->GetVectorValues(i, RefPts, vec_vals, pointmat);
             pointmat.Add(double(ianim)/ianimmax, vec_vals);
             have_normals = 0;
          }
          else
          {
-            const IntegrationRule &ir = RefG->RefPts;
+            const IntegrationRule &ir = (cut_lambda > 0) ?
+               ((sides == 3) ? cut_TriPts : cut_QuadPts) : RefG->RefPts;
             normals.SetSize(3, values.Size());
             mesh->GetElementTransformation(i, &T);
             for (int j = 0; j < values.Size(); j++)
@@ -668,19 +766,6 @@ void VisualizationSceneVector3d::PrepareFlat2()
 
       vmin = fmin(vmin, values.Min());
       vmax = fmax(vmax, values.Max());
-
-      int sides;
-      switch ((dim == 3) ? mesh->GetBdrElementType(i) : mesh->GetElementType(i))
-      {
-         case Element::TRIANGLE:
-            sides = 3;
-            break;
-
-         case Element::QUADRILATERAL:
-         default:
-            sides = 4;
-            break;
-      }
 
       if (sc != 0.0 && have_normals)
       {
@@ -711,7 +796,11 @@ void VisualizationSceneVector3d::PrepareFlat2()
       {
          have_normals = -1 - have_normals;
       }
-      DrawPatch(disp_buf, pointmat, values, normals, sides, RefG->RefGeoms,
+
+      Array<int> &RefGeoms = (cut_lambda > 0) ?
+         ((sides == 3) ? cut_TriGeoms : cut_QuadGeoms) : RefG->RefGeoms;
+      int psides = (cut_lambda > 0) ? 4 : sides;
+      DrawPatch(disp_buf, pointmat, values, normals, psides, RefGeoms,
                 minv, maxv, have_normals);
    }
    updated_bufs.emplace_back(&disp_buf);


### PR DESCRIPTION
 Added the option to cut a portion of the interiors of 3D faces to expose more of the mesh. Useful as an alternative to transparency. 

See keys <kbd>Ctrl</kbd> + <kbd>F3</kbd> / <kbd>F4</kbd>.

**Example:**

<img width="699" alt="Screen Shot 2022-05-13 at 5 46 51 PM" src="https://user-images.githubusercontent.com/1278247/168404491-d4b7a601-1526-47aa-b8ff-1bdbe31fb42d.png">

**Inspired by:**

<table>
  <tr>
    <td> <img src="https://user-images.githubusercontent.com/1278247/168404621-e5d23b5d-3259-4a1c-a2f5-b6d47a4bff2c.jpg"  height = 500px ></td>
    <td><img src="https://user-images.githubusercontent.com/1278247/168404660-d289e206-9936-49db-80dd-b27c4106a8d7.png" height = 500px></td>
   </tr> 
</table>
