### PR TITLE
Memory usage improvements

### DIFF
--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -543,6 +543,13 @@ public:
          vertex_indices[i] += index_offset;
       }
    }
+
+   void addVertices(size_t nverts, const T* verts,
+                    size_t ninds, const int* ids)
+   {
+      vertex_data.insert(vertex_data.end(), verts, verts+nverts);
+      vertex_indices.insert(vertex_indices.end(), ids, ids+ninds);
+   }
 };
 
 class TextBuffer : public IVertexBuffer
@@ -705,6 +712,15 @@ public:
                            const std::vector<int>& inds)
    {
       getIndexedBuffer<Vert>(GL_TRIANGLES)->addVertices(verts, inds);
+   }
+
+   template<typename Vert>
+   void addTriangleIndexed(size_t nverts,
+                           const Vert* verts,
+                           size_t ninds,
+                           const int* inds)
+   {
+      getIndexedBuffer<Vert>(GL_TRIANGLES)->addVertices(nverts, verts, ninds, inds);
    }
 
    template<typename Vert>

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -215,7 +215,10 @@ void VisualizationSceneScalarData::Arrow3(gl3::GlDrawable& buf,
    xfrm = glm::translate(xfrm, glm::vec3(0, 0, 1));
    xfrm = glm::scale(xfrm, glm::vec3(cone_scale));
 
-   Cone(buf, xfrm, cval);
+   if (cone_scale > 0.0)
+   {
+      Cone(buf, xfrm, cval);
+   }
 }
 
 void VisualizationSceneScalarData::Arrow2(gl3::GlDrawable& buf,

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -198,6 +198,8 @@ public:
 
    virtual gl3::SceneInfo GetSceneObjs();
 
+   void ProcessUpdatedBufs(gl3::SceneInfo& scene);
+
    void glTF_ExportBox(glTF_Builder &bld,
                        glTF_Builder::buffer_id buffer,
                        glTF_Builder::material_id black_mat);

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -124,7 +124,7 @@ protected:
 
    void FixValueRange();
 
-   void Cone(gl3::GlBuilder& builder, glm::mat4 transform);
+   void Cone(gl3::GlDrawable& buf, glm::mat4 transform, double cval);
 
 public:
    Plane *CuttingPlane;
@@ -218,20 +218,23 @@ public:
 
    void SetLevelLines(double min, double max, int n, int adj = 1);
 
-   void Arrow(gl3::GlBuilder& builder,
+   void Arrow(gl3::GlDrawable& buffer,
               double px, double py, double pz,
               double vx, double vy, double vz, double length,
-              double cone_scale = 0.075);
-   void Arrow2(gl3::GlBuilder& builder,
+              double cone_scale = 0.075,
+              double cval = HUGE_VAL);
+   void Arrow2(gl3::GlDrawable& buffer,
                double px, double py, double pz,
                double vx, double vy, double vz,
                double length,
-               double cone_scale = 0.075);
-   void Arrow3(gl3::GlBuilder& builder,
+               double cone_scale = 0.075,
+               double cval = HUGE_VAL);
+   void Arrow3(gl3::GlDrawable& buffer,
                double px, double py, double pz,
                double vx, double vy, double vz,
                double length,
-               double cone_scale = 0.075);
+               double cone_scale = 0.075,
+               double cval = HUGE_VAL);
 
    void DrawPolygonLevelLines(gl3::GlBuilder& builder, double *point, int n,
                               Array<double> &level, bool log_vals);

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -2336,6 +2336,7 @@ gl3::SceneInfo VisualizationSceneSolution::GetSceneObjs()
    {
       scene.queue.emplace_back(params, &order_buf);
    }
+   ProcessUpdatedBufs(scene);
 
    return scene;
 }

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -1869,7 +1869,6 @@ void VisualizationSceneSolution::PrepareOrderingCurve1(gl3::GlDrawable& buf,
                                                        bool arrows,
                                                        bool color)
 {
-   gl3::GlBuilder builder = buf.createBuilder();
    DenseMatrix pointmat;
    Array<int> vertices;
 
@@ -1920,25 +1919,25 @@ void VisualizationSceneSolution::PrepareOrderingCurve1(gl3::GlDrawable& buf,
       double du = us1-us;
       double ds = sqrt(dx*dx+dy*dy+du*du);
 
+      double cval = HUGE_VAL;
       if (color)
       {
-         double cval = minv+double(k)/ne*(maxv-minv);
-         MySetColor(builder, cval, minv, maxv);
+         cval = minv+double(k)/ne*(maxv-minv);
       }
 
       if (arrows)
       {
-         Arrow3(builder,
+         Arrow3(buf,
                 xs,ys,us,
                 dx,dy,du,
-                ds,0.05);
+                ds,0.05,cval);
       }
       else
       {
-         Arrow3(builder,
+         Arrow3(buf,
                 xs,ys,us,
                 dx,dy,du,
-                ds,0.0);
+                ds,0.0,cval);
       }
    }
 }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -4000,6 +4000,7 @@ gl3::SceneInfo VisualizationSceneSolution3d::GetSceneObjs()
    {
       scene.queue.emplace_back(params, &order_buf);
    }
+   ProcessUpdatedBufs(scene);
    return scene;
 }
 

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -144,8 +144,6 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(gl3::GlDrawable& buf,
                                                          bool arrows,
                                                          bool color)
 {
-   gl3::GlBuilder builder = buf.createBuilder();
-
    // make the lines of the ordering curve thicker
    double ThicknessFactor = 2.0;
    double MS_Thickness = 2.0;
@@ -211,25 +209,25 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(gl3::GlDrawable& buf,
       double dz = zs1-zs;
       double ds = sqrt(dx*dx+dy*dy+dz*dz);
 
+      double cval = HUGE_VAL;
       if (color)
       {
-         double cval = minv+double(k)/ne*(maxv-minv);
-         MySetColor(builder, cval, minv, maxv);
+         cval = minv+double(k)/ne*(maxv-minv);
       }
 
       if (arrows)
       {
-         Arrow3(builder,
+         Arrow3(buf,
                 xs,ys,zs,
                 dx,dy,dz,
-                ds,0.05);
+                ds,0.05,cval);
       }
       else
       {
-         Arrow3(builder,
+         Arrow3(buf,
                 xs,ys,zs,
                 dx,dy,dz,
-                ds,0.0);
+                ds,0.0,cval);
       }
    }
 

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -846,13 +846,11 @@ void VisualizationSceneVector::DrawVector(double px, double py, double vx,
 {
    double zc = 0.5*(bb.z[0]+bb.z[1]);
 
-   gl3::GlBuilder builder = vector_buf.createBuilder();
-
    if (drawvector == 1)
    {
       arrow_type = 0;
       arrow_scaling_type = 0;
-      Arrow(builder, px, py, zc, vx, vy, 0.0, 1.0, 1./4./3.);
+      Arrow(vector_buf, px, py, zc, vx, vy, 0.0, 1.0, 1./4./3.);
    }
    else if (drawvector > 0)
    {
@@ -862,17 +860,15 @@ void VisualizationSceneVector::DrawVector(double px, double py, double vx,
       arrow_type = 1;
       arrow_scaling_type = 1;
 
-      MySetColor(builder, cval, minv, maxv);
-
       if (drawvector == 2)
       {
-         Arrow(builder, px, py, zc, vx, vy, 0.0, h, 0.125);
+         Arrow(vector_buf, px, py, zc, vx, vy, 0.0, h, 0.125, cval);
       }
       else
       {
          double len = VecLength(vx, vy);
-         Arrow(builder, px, py, zc, vx, vy, 0.0,
-               h*max(0.01, len/maxlen), 0.125);
+         Arrow(vector_buf, px, py, zc, vx, vy, 0.0,
+               h*max(0.01, len/maxlen), 0.125, cval);
          if (len > new_maxlen)
          {
             new_maxlen = len;

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -1030,6 +1030,7 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
       }
       scene.queue.emplace_back(params, &displine_buf);
    }
+   ProcessUpdatedBufs(scene);
 
    return scene;
 }

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -1252,7 +1252,7 @@ int ArrowDrawOrNot (double v, int nl, Array<double> & level)
    return 0;
 }
 
-void VisualizationSceneVector3d::DrawVector(gl3::GlBuilder& builder,
+void VisualizationSceneVector3d::DrawVector(gl3::GlDrawable& buf,
                                             int type, double v0, double v1,
                                             double v2, double sx, double sy,
                                             double sz, double s)
@@ -1269,7 +1269,7 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlBuilder& builder,
          arrow_type = 0;
          arrow_scaling_type = 0;
          // glColor3f(0, 0, 0); // color is set in Draw()
-         Arrow(builder,v0,v1,v2,sx,sy,sz,s);
+         Arrow(buf,v0,v1,v2,sx,sy,sz,s);
       }
       break;
 
@@ -1277,8 +1277,7 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlBuilder& builder,
       {
          arrow_type = 1;
          arrow_scaling_type = 1;
-         MySetColor(builder, s, minv, maxv);
-         Arrow(builder,v0,v1,v2,sx,sy,sz,h,0.125);
+         Arrow(buf,v0,v1,v2,sx,sy,sz,h,0.125,s);
       }
       break;
 
@@ -1286,9 +1285,7 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlBuilder& builder,
       {
          arrow_type = 1;
          arrow_scaling_type = 1;
-         // MySetColor(s,maxv,minv);
-         MySetColor(builder, s, minv, maxv);
-         Arrow(builder,v0,v1,v2,sx,sy,sz,h*s/maxv,0.125);
+         Arrow(buf,v0,v1,v2,sx,sy,sz,h*s/maxv,0.125,s);
       }
       break;
 
@@ -1297,8 +1294,8 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlBuilder& builder,
       {
          arrow_type = 1;
          arrow_scaling_type = 1;
-         builder.glColor3f(0.3, 0.3, 0.3);
-         Arrow(builder,v0,v1,v2,sx,sy,sz,hh*s/maxv,0.125);
+         // glColor3f(0.3, 0.3, 0.3); // color is set in Draw
+         Arrow(buf,v0,v1,v2,sx,sy,sz,hh*s/maxv,0.125);
       }
       break;
    }
@@ -1310,7 +1307,6 @@ void VisualizationSceneVector3d::PrepareVectorField()
    double *vertex;
 
    vector_buf.clear();
-   gl3::GlBuilder builder = vector_buf.createBuilder();
 
    switch (drawvector)
    {
@@ -1322,7 +1318,7 @@ void VisualizationSceneVector3d::PrepareVectorField()
             if (drawmesh != 2 || ArrowDrawOrNot((*sol)(i), nl, level))
             {
                vertex = mesh->GetVertex(i);
-               DrawVector(builder, drawvector, vertex[0], vertex[1], vertex[2],
+               DrawVector(vector_buf, drawvector, vertex[0], vertex[1], vertex[2],
                           (*solx)(i), (*soly)(i), (*solz)(i), (*sol)(i));
             }
          break;
@@ -1335,7 +1331,7 @@ void VisualizationSceneVector3d::PrepareVectorField()
             if (drawmesh != 2 || ArrowDrawOrNot((*sol)(i), nl, level))
             {
                vertex = mesh->GetVertex(i);
-               DrawVector(builder, drawvector, vertex[0], vertex[1], vertex[2],
+               DrawVector(vector_buf, drawvector, vertex[0], vertex[1], vertex[2],
                           (*solx)(i), (*soly)(i), (*solz)(i), (*sol)(i));
             }
       }
@@ -1350,7 +1346,7 @@ void VisualizationSceneVector3d::PrepareVectorField()
             if (drawmesh != 2 || ArrowDrawOrNot((*sol)(i), nl, level))
             {
                vertex = mesh->GetVertex(i);
-               DrawVector(builder, drawvector, vertex[0], vertex[1], vertex[2],
+               DrawVector(vector_buf, drawvector, vertex[0], vertex[1], vertex[2],
                           (*solx)(i), (*soly)(i), (*solz)(i), (*sol)(i));
             }
       }
@@ -1369,7 +1365,7 @@ void VisualizationSceneVector3d::PrepareVectorField()
             for (j = 0; j < l[i].Size(); j++)
             {
                vertex = mesh->GetVertex( l[i][j] );
-               DrawVector(builder, drawvector, vertex[0], vertex[1], vertex[2],
+               DrawVector(vector_buf, drawvector, vertex[0], vertex[1], vertex[2],
                           (*solx)(l[i][j]), (*soly)(l[i][j]), (*solz)(l[i][j]),
                           (*sol)(l[i][j]));
             }
@@ -1402,7 +1398,7 @@ void VisualizationSceneVector3d::PrepareVectorField()
                i = vertices[j];
                if (vert_marker[i]) { continue; }
                vertex = mesh->GetVertex(i);
-               DrawVector(builder, drawvector, vertex[0], vertex[1], vertex[2],
+               DrawVector(vector_buf, drawvector, vertex[0], vertex[1], vertex[2],
                           (*solx)(i), (*soly)(i), (*solz)(i), (*sol)(i));
                vert_marker[i] = true;
             }
@@ -1529,7 +1525,7 @@ void VisualizationSceneVector3d::PrepareCuttingPlane()
             builder.glEnd();
             if (drawvector)
                for (j=0; j<n; j++)
-                  DrawVector(builder, drawvector, point[n][0], point[n][1], point[n][2],
+                  DrawVector(cplane_buf, drawvector, point[n][0], point[n][1], point[n][2],
                              val[n][0],val[n][1], val[n][2], point[n][3]);
          }
          else
@@ -1547,7 +1543,7 @@ void VisualizationSceneVector3d::PrepareCuttingPlane()
             builder.glEnd();
             if (drawvector)
                for (j=n-1; j>=0; j--)
-                  DrawVector(builder, drawvector, point[n][0], point[n][1], point[n][2],
+                  DrawVector(cplane_buf, drawvector, point[n][0], point[n][1], point[n][2],
                              val[n][0],val[n][1], val[n][2], point[n][3]);
          }
       }
@@ -1597,16 +1593,16 @@ gl3::SceneInfo VisualizationSceneVector3d::GetSceneObjs()
    params.contains_translucent = false;
    params.num_pt_lights = 0;
 
-   if (drawvector > 3)
-   {
-      scene.queue.emplace_back(params, &vector_buf);
-   }
-
    params.mesh_material = VisualizationScene::BLK_MAT;
-   params.static_color = GetLineColor();
 
    if (drawvector == 1)
    {
+      params.static_color = GetLineColor();
+      scene.queue.emplace_back(params, &vector_buf);
+   }
+   else if (drawvector > 3)
+   {
+      params.static_color = {0.3,0.3,0.3,1.0};
       scene.queue.emplace_back(params, &vector_buf);
    }
 

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -1629,5 +1629,6 @@ gl3::SceneInfo VisualizationSceneVector3d::GetSceneObjs()
       params.use_clip_plane = false;
       scene.queue.emplace_back(params, &cplines_buf);
    }
+   ProcessUpdatedBufs(scene);
    return scene;
 }

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -53,7 +53,7 @@ public:
    void PrepareFlat2();
    void PrepareLines2();
 
-   void DrawVector (gl3::GlBuilder& builder,
+   void DrawVector (gl3::GlDrawable& buf,
                     int type, double v0, double v1, double v2,
                     double sx, double sy, double sz, double s);
    virtual void PrepareVectorField();


### PR DESCRIPTION
# Summary

- Defer buffering objects to the GPU until they're actually used in a pending frame
- Use indexed buffers to hold ordering curve
- Don't draw cones when cone_scale is 0 (`PrepareOrderingCurves()` uses `Arrow3` to draw the no-arrow curve)

With these changes, I get around 0.97GB of memory usage for the command in #236, which puts us almost at where we were at version glvis-4.0.

## Things to try:

- [ ] Remove second texture coordinate - this should drop us down from 32 to 16 bytes/vertex when storing `VertexTex` due to alignment