### PR TITLE
Typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Key commands
     - Decrease element subdivision factor: `s1 -= s2`
     - Increase boundary subdivision factor: `s2++`
     - Decrease boundary subdivision factor: `s2--`
-  - <kbd>o</kbd> – performs the curently selected function
+  - <kbd>o</kbd> – performs the currently selected function
 - <kbd>b</kbd> – Toggle the boundary in 2D scalar mode. The options are:
   - no boundary
   - black boundary

--- a/lib/gl2ps.c
+++ b/lib/gl2ps.c
@@ -4615,7 +4615,7 @@ static int gl2psPrintPDFShaderMask(int obj, int childobj)
   return offs;
 }
 
-/* Writes a Extended graphics state for a shaded triangle mask if
+/* Writes an Extended graphics state for a shaded triangle mask if
    simplealpha is true the childobj argument is ignored and a /ca
    statement will be written instead */
 

--- a/lib/gl2ps.c
+++ b/lib/gl2ps.c
@@ -2532,7 +2532,7 @@ static void gl2psPrintPostScriptPixmap(GLfloat x, GLfloat y, GL2PSimage *im)
   /* FIXME: should we define an option for these? Or just keep the
      8-bit per component case? */
   int greyscale = 0; /* set to 1 to output greyscale image */
-  int nbit = 8; /* number of bits per color compoment (2, 4 or 8) */
+  int nbit = 8; /* number of bits per color component (2, 4 or 8) */
 
   if((width <= 0) || (height <= 0)) return;
 
@@ -3831,7 +3831,7 @@ static void gl2psPDFgroupListWriteMainStream(void)
                         prim->verts[0].xyz[0], prim->verts[0].xyz[1]);
         }
         else{
-          /* the two segements are connected, so we just append to the
+          /* the two segments are connected, so we just append to the
              current path */
           gl2ps->streamlength +=
             gl2psPrintf("%f %f l\n",
@@ -4616,7 +4616,7 @@ static int gl2psPrintPDFShaderMask(int obj, int childobj)
 }
 
 /* Writes a Extended graphics state for a shaded triangle mask if
-   simplealpha ist true the childobj argument is ignored and a /ca
+   simplealpha is true the childobj argument is ignored and a /ca
    statement will be written instead */
 
 static int gl2psPrintPDFShaderExtGS(int obj, int childobj)

--- a/lib/openglvis.cpp
+++ b/lib/openglvis.cpp
@@ -729,7 +729,7 @@ int VisualizationScene::AddTriangles(glTF_Builder &bld,
       }
       default:
       {
-         cout << "glTF export: coorditate switch for layout " << buf_layout
+         cout << "glTF export: coordinate switch for layout " << buf_layout
               << " is not implemented here:" << MFEM_LOCATION;
          bld.appendToBufferView(surf_vertices_buf_view,
                                 surf_vertices_data,
@@ -929,7 +929,7 @@ int VisualizationScene::AddLines(glTF_Builder &bld,
       }
       default:
       {
-         cout << "glTF export: coorditate switch for layout " << buf_layout
+         cout << "glTF export: coordinate switch for layout " << buf_layout
               << " is not implemented here:" << MFEM_LOCATION;
          bld.appendToBufferView(lines_vertices_buf_view,
                                 lines_vertices_data,

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -451,7 +451,7 @@ void SdlWindow::mainIter()
          // On SDL, when the OpenGL context is on a separate thread from the
          // main thread, the call to [NSOpenGLContext update] after a resize or
          // move event is only scheduled for after the next swap event. Any
-         // rendering/OpenGL commands occuring before this update will be
+         // rendering/OpenGL commands occurring before this update will be
          // corrupted.
          //
          // To avoid this issue, we just call [NSOpenGLContext update]

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -31,7 +31,7 @@ extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 #ifdef GLVIS_ISFINITE
 /* This test for INFs or NaNs is the same as the one used in hypre's PCG and
-   should work on all IEEE-compliant compilers. For detail see "Lecture Notes on
+   should work on all IEEE-compliant compilers. For details see "Lecture Notes on
    the Status of IEEE 754" by W. Kahan, http://tinyurl.com/cfz5d88 */
 int isfinite(double x)
 {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -31,7 +31,7 @@ extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 #ifdef GLVIS_ISFINITE
 /* This test for INFs or NaNs is the same as the one used in hypre's PCG and
-   should work on all IEEE-compliant compilers. Fro detail see "Lecture Notes on
+   should work on all IEEE-compliant compilers. For detail see "Lecture Notes on
    the Status of IEEE 754" by W. Kahan, http://tinyurl.com/cfz5d88 */
 int isfinite(double x)
 {

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -27,7 +27,7 @@ extern thread_local GeometryRefiner GLVisGeometryRefiner;
 // Reference geometries with a cut in the middle, based on subdivision of
 // GLVisGeometryRefiner in 3-4 quads. Updated when cut_lambda is updated, see
 // keys Ctrl+F3/F4. We need these variables because the GLVisGeometryRefiner
-// cashes its RefinedGeometry objects.
+// caches its RefinedGeometry objects.
 thread_local IntegrationRule cut_QuadPts;
 thread_local Array<int> cut_QuadGeoms;
 thread_local IntegrationRule cut_TriPts;


### PR DESCRIPTION
Found with

```
codespell -q 3 -L allright,ba,bu,childs,equil,esy,fo,fom,hda,localy,lod,mone,nd,ned,nnumber,numer,ot,pres,ro,seh,shat,solfes,strat,tbe,te,tthe,warmup
```

See https://github.com/mfem/mfem/pull/3254