### PR TITLE
Checking map type before determining value range

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,7 +26,7 @@ env:
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
   MFEM_TOP_DIR: mfem
-  MFEM_BRANCH: master
+  MFEM_BRANCH: l2-integral-support
 
 jobs:
   builds-and-tests:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,7 +26,7 @@ env:
   METIS_ARCHIVE: metis-4.0.3.tar.gz
   METIS_TOP_DIR: metis-4.0.3
   MFEM_TOP_DIR: mfem
-  MFEM_BRANCH: l2-integral-support
+  MFEM_BRANCH: master
 
 jobs:
   builds-and-tests:

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1025,10 +1025,8 @@ void VisualizationSceneSolution3d::FindNewBox(bool prepare)
 
 void VisualizationSceneSolution3d::FindNewValueRange(bool prepare)
 {
-   int dim = mesh->Dimension();
-   const FiniteElement *fe = (dim == 3) ?
-                             GridF->FESpace()->GetFE(0) : GridF->FESpace()->GetBE(0);
-   int map_type = (fe) ? fe->GetMapType() : FiniteElement::VALUE;
+   int map_type = (GridF) ? GridF->FESpace()->FEColl()->GetMapType() :
+                  FiniteElement::VALUE;
 
    if (shading < 2 || map_type != (int)FiniteElement::VALUE)
    {

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1025,7 +1025,12 @@ void VisualizationSceneSolution3d::FindNewBox(bool prepare)
 
 void VisualizationSceneSolution3d::FindNewValueRange(bool prepare)
 {
-   if (shading < 2)
+   int dim = mesh->Dimension();
+   const FiniteElement *fe = (dim == 3) ?
+                             GridF->FESpace()->GetFE(0) : GridF->FESpace()->GetBE(0);
+   int map_type = (fe) ? fe->GetMapType() : FiniteElement::VALUE;
+
+   if (shading < 2 || map_type != (int)FiniteElement::VALUE)
    {
       minv = sol->Min();
       maxv = sol->Max();

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1025,7 +1025,8 @@ void VisualizationSceneSolution3d::FindNewBox(bool prepare)
 
 void VisualizationSceneSolution3d::FindNewValueRange(bool prepare)
 {
-   int map_type = (GridF) ? GridF->FESpace()->FEColl()->GetMapType() :
+   int map_type = (GridF) ?
+                  GridF->FESpace()->FEColl()->GetMapType(mesh->Dimension()) :
                   FiniteElement::VALUE;
 
    if (shading < 2 || map_type != (int)FiniteElement::VALUE)


### PR DESCRIPTION
This PR allows GLVis to determine the range, for use in the color bar, when displaying scalar fields with map type `INTEGRAL`.

This PR partially addresses issue #248 

Note: this branch depends on an MFEM branch of the same name.