### PR TITLE
Tweak library paths in `makefile`

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -134,7 +134,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ env.MFEM_TOP_DIR }}
-        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-${{ matrix.target }}-${{ matrix.build-system}}-v2.2
+        key: ${{ runner.os }}-build-${{ env.MFEM_TOP_DIR }}-${{ env.MFEM_COMMIT }}-${{ matrix.target }}-${{ matrix.build-system}}-v2.4
 
     # We are using the defaults of the MFEM action here, which is to use master
     # branch. There is an implicit assumption here that mfem master hasn't
@@ -143,7 +143,7 @@ jobs:
     # superfluous.
     - name: build mfem
       if: steps.cache-mfem.outputs.cache-hit != 'true'
-      uses: mfem/github-actions/build-mfem@v2.2
+      uses: mfem/github-actions/build-mfem@v2.4
       with:
         os: ${{ matrix.os }}
         target: ${{ matrix.target }}
@@ -153,6 +153,7 @@ jobs:
         mfem-branch: ${{ env.MFEM_BRANCH }}
         build-system: ${{ matrix.build-system }}
         mpi: ${{ matrix.mpi }}
+        library-only: true
 
     # Install GLVis dependencies with package manager
     - name: get deps (Linux)

--- a/tests/glvis_driver.py
+++ b/tests/glvis_driver.py
@@ -61,7 +61,7 @@ def compare_images(baseline_file, output_file, expect_fail=False):
 
     # Compare images with SSIM metrics. For two exactly-equal images, SSIM=1.0.
     # We set a cutoff of 0.999 to account for possible differences in rendering.
-    ssim = structural_similarity(baseline_img, output_img, multichannel=True)
+    ssim = structural_similarity(baseline_img, output_img, channel_axis=2)
     if ssim < cutoff_ssim:
         if expect_fail:
             print("[PASS] Differences were detected in the control case.")


### PR DESCRIPTION
In `makefile`, tweak library paths to exclude system library paths like `/usr/lib` and `/usr/lib64`; also avoid the system include path `/usr/include`.

This fixes warnings on some LLNL systems (TOSS-4).
