### PR TITLE
Added command to plot levellines from stream and script.

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -634,6 +634,17 @@ void ExecuteScriptCommand()
          }
          cout << endl;
       }
+      else if (word == "levellines")
+      {
+         double min, max;
+         int num;
+         scr >> min >> max >> num;
+         cout << "Script: levellines: " << flush;
+         vs->SetLevelLines(min, max, num);
+         vs->UpdateLevelLines();
+         cout << min << ' ' << max << ' ' << num << endl;
+         MyExpose();
+      }
       else if (word == "window")
       {
          scr >> window_x >> window_y >> window_w >> window_h;

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -56,7 +56,8 @@ private:
       WINDOW_GEOMETRY = 17,
       PLOT_CAPTION = 18,
       AXIS_LABELS = 19,
-      PALETTE_REPEAT = 20
+      PALETTE_REPEAT = 20,
+      LEVELLINES = 21
    };
 
    std::atomic<bool> command_ready{false};
@@ -83,6 +84,8 @@ private:
    double        view_center_x, view_center_y;
    std::string   autoscale_mode;
    int           palette, palette_repeat;
+   double        lvl_min, lvl_max;
+   int           lvl_num;
    double        camera[9];
    std::string   autopause_mode;
 
@@ -122,6 +125,7 @@ public:
    int Autoscale(const char *mode);
    int Palette(int pal);
    int PaletteRepeat(int n);
+   int Levellines(double minv, double maxv, int number);
    int Camera(const double cam[]);
    int Autopause(const char *mode);
 


### PR DESCRIPTION
Added the command `levellines` to plot levellines from stream command and script. However, the key m needs to be pressed twice to activate the rendering of the levellines. When `autoscale` is `mesh` the levellines will be ploted for further timesteps, otherwise it has to be used the command again.

This is needed for the new Example 37 of mfem (see PR [#3828](https://github.com/mfem/mfem/pull/3828)).