### PR TITLE
Vector field options in 2D with single colored arrows above

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,9 @@ Version 4.2.1 (development)
 
 - Add support to visualize solutions on 1D elements embedded in 2D and 3D.
 
+- Added two new modes for visualization of vector fields in 2D, placing the
+  arrows above the plotted surface and using a single color.
+
 
 Version 4.2 released on May 23, 2022
 ====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,12 +16,10 @@ Version 4.2.1 (development)
 
 - Add support to visualize solutions on 1D elements embedded in 2D and 3D.
 
-<<<<<<< najlkin/vec-arrows
 - Added two new modes for visualization of vector fields in 2D, placing the
   arrows above the plotted surface and using a single color.
-=======
+
 - Added a compilation parameter for the default font size.
->>>>>>> master
 
 
 Version 4.2 released on May 23, 2022

--- a/README.md
+++ b/README.md
@@ -238,8 +238,7 @@ Key commands
   - show vector field; vectors are uniformly scaled; the color varies with the
     magnitude (or the current *vector-to-scalar function*, see keys <kbd>u</kbd> / <kbd>U</kbd>)
   - show vector field as above, but the vectors are scaled proportionally to their magnitude
-  - show vector field; vectors are uniformly scaled; the color is from the beggining
-    of the colormap; arrows are above the surface
+  - show vector field; vectors are uniformly scaled; the color is gray; arrows are above the surface
   - show vector field as above, but the vectors are scaled proportionally to their magnitude
 - <kbd>V</kbd> – Change the scaling of the vectors relative to the default
 - <kbd>d</kbd> – Toggle the *displaced mesh* state: (see also keys <kbd>n</kbd> / <kbd>b</kbd>). The options are:

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ Key commands
   - show vector field; vectors are uniformly scaled; the color varies with the
     magnitude (or the current *vector-to-scalar function*, see keys <kbd>u</kbd> / <kbd>U</kbd>)
   - show vector field as above, but the vectors are scaled proportionally to their magnitude
+  - show vector field; vectors are uniformly scaled; the color is from the beggining
+    of the colormap; arrows are above the surface
+  - show vector field as above, but the vectors are scaled proportionally to their magnitude
 - <kbd>V</kbd> – Change the scaling of the vectors relative to the default
 - <kbd>d</kbd> – Toggle the *displaced mesh* state: (see also keys <kbd>n</kbd> / <kbd>b</kbd>). The options are:
   - do not show displaced mesh

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -1061,13 +1061,13 @@ void VisualizationSceneVector::glTF_Export()
                      bld,
                      vec_mesh,
                      buf,
-                     (drawvector == 1) ? black_mat : palette_mat,
+                     (drawvector == 1 || drawvector > 3) ? black_mat : palette_mat,
                      vector_buf);
       int nlines = AddLines(
                       bld,
                       vec_mesh,
                       buf,
-                      (drawvector == 1) ? black_mat : pal_lines_mat,
+                      (drawvector == 1 || drawvector > 3) ? black_mat : pal_lines_mat,
                       vector_buf);
       if (ntria == 0 || nlines == 0)
       {

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -242,7 +242,7 @@ void VisualizationSceneVector::ToggleDrawElems()
 
 void VisualizationSceneVector::ToggleVectorField()
 {
-   drawvector = (drawvector+1)%4;
+   drawvector = (drawvector+1)%6;
    PrepareVectorField();
 }
 
@@ -844,7 +844,7 @@ thread_local double new_maxlen;
 void VisualizationSceneVector::DrawVector(double px, double py, double vx,
                                           double vy, double cval)
 {
-   double zc = 0.5*(bb.z[0]+bb.z[1]);
+   double zc = (drawvector > 3)?(bb.z[1]):(0.5*(bb.z[0]+bb.z[1]));
 
    if (drawvector == 1)
    {
@@ -860,7 +860,9 @@ void VisualizationSceneVector::DrawVector(double px, double py, double vx,
       arrow_type = 1;
       arrow_scaling_type = 1;
 
-      if (drawvector == 2)
+      if (drawvector > 3) { cval = 0.; }
+
+      if (drawvector == 2 || drawvector == 4)
       {
          Arrow(vector_buf, px, py, zc, vx, vy, 0.0, h, 0.125, cval);
       }
@@ -892,7 +894,7 @@ void VisualizationSceneVector::PrepareVectorField()
          int i;
 
          palette.SetUseLogscale(logscale);
-         if (drawvector == 3)
+         if (drawvector == 3 || drawvector == 5)
          {
             new_maxlen = 0.0;
          }
@@ -939,7 +941,7 @@ void VisualizationSceneVector::PrepareVectorField()
             }
          }
 
-         if (drawvector == 3 && new_maxlen != maxlen)
+         if ((drawvector == 3 || drawvector == 5) && new_maxlen != maxlen)
          {
             maxlen = new_maxlen;
             rerun = 1;

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -860,7 +860,7 @@ void VisualizationSceneVector::DrawVector(double px, double py, double vx,
       arrow_type = 1;
       arrow_scaling_type = 1;
 
-      if (drawvector > 3) { cval = 0.; }
+      if (drawvector > 3) { cval = HUGE_VAL; }
 
       if (drawvector == 2 || drawvector == 4)
       {
@@ -968,7 +968,7 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
    double* cp_eqn = CuttingPlane->Equation();
    params.clip_plane_eqn = {cp_eqn[0], cp_eqn[1], cp_eqn[2], cp_eqn[3]};
    params.contains_translucent = false;
-   if (drawvector > 1)
+   if (drawvector == 2 || drawvector == 3)
    {
       scene.queue.emplace_back(params, &vector_buf);
    }
@@ -1015,8 +1015,12 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
       scene.queue.emplace_back(params, &v_nums_buf);
    }
 
-   if (drawvector == 1)
+   if (drawvector == 1 || drawvector > 3)
    {
+      if (drawvector > 3)
+      {
+         params.static_color = {.3f, .3f, .3f, 1.f};
+      }
       scene.queue.emplace_back(params, &vector_buf);
    }
 
@@ -1025,6 +1029,10 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
       if (drawmesh == 1)
       {
          params.static_color = {1.f, 0.f, 0.f, 1.f};
+      }
+      else
+      {
+         params.static_color = GetLineColor();
       }
       scene.queue.emplace_back(params, &displine_buf);
    }


### PR DESCRIPTION
This PR adds two options for visualization of vector fields. They are similar to the options 2 and 3, but the arrows are drawn above the function surface and in a single color (gray as the options 4 and 5 in 3D) instead of the placement on the mid-plane with colors encoding the values. The main purpose is visualization of 2D data, where the current options for visualization of vector fields draw arrows, which are partially hidden behind the surface and the arrows blend with the background when looking from top.

example 5:
option 4:
![image](https://github.com/GLVis/glvis/assets/4259064/ba11499a-7e81-4e54-bdc0-d54693e97de3)
option 5:
![image](https://github.com/GLVis/glvis/assets/4259064/8fac3b52-5221-40c0-8d5a-1bcdb58b8398)
