### PR TITLE
A compilation parameter for font size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@ Version 4.2.1 (development)
 
 - Add support to visualize solutions on 1D elements embedded in 2D and 3D.
 
+- Added a compilation parameter for the default font size.
+
 
 Version 4.2 released on May 23, 2022
 ====================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ if (NOT GLVIS_MS_LINEWIDTH)
   endif()
 endif (NOT GLVIS_MS_LINEWIDTH)
 
+# Default font size
+if (NOT GLVIS_FONT_SIZE)
+  set(GLVIS_FONT_SIZE 12)
+endif (NOT GLVIS_FONT_SIZE)
+
 #
 # Start finding everything
 #
@@ -88,6 +93,7 @@ set(_glvis_libraries)
 
 list(APPEND _glvis_compile_defs "GLVIS_MULTISAMPLE=${GLVIS_MULTISAMPLE}")
 list(APPEND _glvis_compile_defs "GLVIS_MS_LINEWIDTH=${GLVIS_MS_LINEWIDTH}")
+list(APPEND _glvis_compile_defs "GLVIS_FONT_SIZE=${GLVIS_FONT_SIZE}")
 if (NOT WIN32)
   list(APPEND _glvis_compile_defs "GLVIS_USE_LOGO")
 else()

--- a/INSTALL
+++ b/INSTALL
@@ -114,6 +114,8 @@ Some important variables for CMake are:
 - GLVIS_MULTISAMPLE and GLVIS_MS_LINEWIDTH: See building considerations below
      for more information on these variables.
 
+- GLVIS_FONT_SIZE: Default font size for text. Default is "12".
+
 
 Some building considerations
 ============================

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -1637,7 +1637,11 @@ vector<string> fc_font_patterns =
    "Arial:style=Regular:weight=80"
 };
 
+#ifdef GLVIS_FONT_SIZE
+constexpr int default_font_size = GLVIS_FONT_SIZE;
+#else
 constexpr int default_font_size = 12;
+#endif
 int font_size = default_font_size;
 
 thread_local GlVisFont glvis_font;

--- a/makefile
+++ b/makefile
@@ -132,8 +132,10 @@ NOTMAC := $(subst Darwin,,$(shell uname -s))
 # Default multisampling mode and multisampling line-width
 GLVIS_MULTISAMPLE  ?= 4
 GLVIS_MS_LINEWIDTH ?= $(if $(NOTMAC),1.4,1.0)
+GLVIS_FONT_SIZE ?= 12
 DEFINES = -DGLVIS_MULTISAMPLE=$(GLVIS_MULTISAMPLE)\
  -DGLVIS_MS_LINEWIDTH=$(GLVIS_MS_LINEWIDTH)\
+ -DGLVIS_FONT_SIZE=$(GLVIS_FONT_SIZE)\
  -DGLVIS_OGL3
 
 # Enable logo setting via SDL (disabled on Windows/CMake build)


### PR DESCRIPTION
This PR adds a compilation parameter for the default font size (afterwards can be adjusted at runtime), which might be useful to adjust for different machines.