### PR TITLE
Support for integral finite elements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,7 @@ Version 4.2.1 (development)
 
 - Added support for scalar integral finite elements, where calculation of the
   surface normals was not implemented and was crashing GLVis. The normals are
-  approximately calculated from the point-wise projected value-based FEs.
+  approximately calculated from the point-wise projected value-based elements.
 
 - Added two new modes for visualization of vector fields in 2D, placing the
   arrows above the plotted surface and using a single color.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,10 @@ Version 4.2.1 (development)
 
 - Add support to visualize solutions on 1D elements embedded in 2D and 3D.
 
+- Added support for scalar integral finite elements, where calculation of the
+  surface normals was not implemented and was crashing GLVis. The normals are
+  approximately calculated from the point-wise projected value-based FEs.
+
 
 Version 4.2 released on May 23, 2022
 ====================================

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -749,7 +749,7 @@ int VisualizationSceneSolution::GetRefinedValuesAndNormals(
             {
                const IntegrationPoint &ip = nodes.IntPoint(n);
                Trans->SetIntPoint(&ip);
-               lval(n) /= Trans->Weight();
+               lval(n) /= Trans->Weight();//value = dof / |J|
             }
 
             // Gradient calculation

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -725,7 +725,7 @@ int VisualizationSceneSolution::GetRefinedValuesAndNormals(
    if (drawelems < 2)
    {
       // In 1D we do not have well-defined normals.
-      if (dim > 1)
+      if (dim > 1 && rsol->FESpace()->GetFE(i)->GetMapType() == FiniteElement::VALUE)
       {
          rsol->GetGradients(i, ir, tr);
          normals.SetSize(3, tr.Width());

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -727,11 +727,12 @@ int VisualizationSceneSolution::GetRefinedValuesAndNormals(
       // In 1D we do not have well-defined normals.
       if (dim > 1)
       {
-         if (rsol->FESpace()->GetFE(i)->GetMapType() == FiniteElement::VALUE)
+         const int map_type = rsol->FESpace()->GetFE(i)->GetMapType();
+         if (map_type == FiniteElement::MapType::VALUE)
          {
             rsol->GetGradients(i, ir, tr);
          }
-         else
+         else (map_type == FiniteElement::MapType::INTEGRAL)
          {
             FiniteElementSpace *fes = rsol->FESpace();
             const FiniteElement *fe = fes->GetFE(i);
@@ -765,6 +766,11 @@ int VisualizationSceneSolution::GetRefinedValuesAndNormals(
                Jinv.MultTranspose(gh, gcol);
             }
          }
+         else
+         {
+            MFEM_ABORT("Unknown mapping type");
+         }
+
          normals.SetSize(3, tr.Width());
          for (int j = 0; j < tr.Width(); j++)
          {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -732,7 +732,7 @@ int VisualizationSceneSolution::GetRefinedValuesAndNormals(
          {
             rsol->GetGradients(i, ir, tr);
          }
-         else (map_type == FiniteElement::MapType::INTEGRAL)
+         else if (map_type == FiniteElement::MapType::INTEGRAL)
          {
             FiniteElementSpace *fes = rsol->FESpace();
             const FiniteElement *fe = fes->GetFE(i);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3924,12 +3924,13 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
          RefG = GLVisGeometryRefiner.Refine(geom, TimesToRefine);
          GridF->GetValues(ie, RefG->RefPts, vals, pointmat);
 #ifdef GLVIS_SMOOTH_LEVELSURF_NORMALS
-         if (GridF->FESpace()->GetFE(ie)->GetMapType() == FiniteElement::VALUE)
+         const int map_type = GridF->FESpace()->GetFE(ie)->GetMapType();
+         if (map_type == FiniteElement::MapType::VALUE)
          {
             GridF->GetGradients(ie, RefG->RefPts, grad);
             gp = &grad;
          }
-         else
+         else if (map_type == FiniteElement::MapType::INTEGRAL)
          {
             FiniteElementSpace *fes = GridF->FESpace();
             const FiniteElement *fe = fes->GetFE(ie);
@@ -3964,6 +3965,10 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
                Jinv.MultTranspose(gh, gcol);
             }
             gp = &grad;
+         }
+         else
+         {
+            MFEM_ABORT("Unknown mapping type");
          }
 #endif
 

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3948,7 +3948,7 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
             {
                const IntegrationPoint &ip = nodes.IntPoint(n);
                Trans->SetIntPoint(&ip);
-               lval(n) /= Trans->Weight();
+               lval(n) /= Trans->Weight();//value = dof / |J|
             }
 
             // Gradient calculation

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3915,11 +3915,7 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
    {
       RefinedGeometry *RefG;
 #define GLVIS_SMOOTH_LEVELSURF_NORMALS
-#ifdef GLVIS_SMOOTH_LEVELSURF_NORMALS
-      const DenseMatrix *gp = &grad;
-#else
       const DenseMatrix *gp = NULL;
-#endif
 
       for (int ie = 0; ie < mesh->GetNE(); ie++)
       {
@@ -3928,7 +3924,15 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
          RefG = GLVisGeometryRefiner.Refine(geom, TimesToRefine);
          GridF->GetValues(ie, RefG->RefPts, vals, pointmat);
 #ifdef GLVIS_SMOOTH_LEVELSURF_NORMALS
-         GridF->GetGradients(ie, RefG->RefPts, grad);
+         if (GridF->FESpace()->GetFE(ie)->GetMapType() == FiniteElement::VALUE)
+         {
+            GridF->GetGradients(ie, RefG->RefPts, grad);
+            gp = &grad;
+         }
+         else
+         {
+            gp = NULL;
+         }
 #endif
 
          Array<int> &RG = RefG->RefGeoms;

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3931,7 +3931,27 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
          }
          else
          {
-            gp = NULL;
+            FiniteElementSpace *fes = GridF->FESpace();
+            const FiniteElement *fe = fes->GetFE(ie);
+            ElementTransformation *Trans = fes->GetElementTransformation(ie);
+            const IntegrationRule &ir = RefG->RefPts;
+            DenseMatrix dshape(fe->GetDof(), fe->GetDim());
+            Vector lval, gh(fe->GetDim()), gcol;
+
+            GridF->GetElementDofValues(ie, lval);
+            grad.SetSize(fe->GetDim(), ir.GetNPoints());
+            for (int q = 0; q < ir.GetNPoints(); q++)
+            {
+               const IntegrationPoint &ip = ir.IntPoint(q);
+               fe->CalcDShape(ip, dshape);
+               dshape.MultTranspose(lval, gh);
+               Trans->SetIntPoint(&ip);
+               gh /= Trans->Weight();
+               grad.GetColumnReference(q, gcol);
+               const DenseMatrix &Jinv = Trans->InverseJacobian();
+               Jinv.MultTranspose(gh, gcol);
+            }
+            gp = &grad;
          }
 #endif
 


### PR DESCRIPTION
This PR adds support for integral finite elements, which were loaded, but crashed GLVis 💣 .

Status:

- [x] Fixed the crash for scalar grid functions (by turning off normals)
- [x] Compute normals for smooth surface visualization (approximated by value-based FEs)
- [ ] Adjust the refinement to respect mesh curvature -> #285 
- [ ] ~Vector grid functions in 2D~ (No smooth visualization of vector fields in 2D 😞 )
- [ ] ~Vector grid functions in 3D~ (No smooth visualization with value-based displacement 😞 )