### PR TITLE
Fixed mesh color with vector field options 4 and 5 in 3D

### DIFF
--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -1632,6 +1632,7 @@ gl3::SceneInfo VisualizationSceneVector3d::GetSceneObjs()
    {
       params.static_color = {0.3,0.3,0.3,1.0};
       scene.queue.emplace_back(params, &vector_buf);
+      params.static_color = GetLineColor();
    }
 
    // draw lines


### PR DESCRIPTION
This PR fixes the bug introduced in #237 , which causes that the mesh lines become gray after switching to the vector field visualization options 4 and 5, which use gray color for the arrows.