### PR TITLE
Higher auto-refinement limits

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,9 +12,11 @@
 Version 4.2.1 (development)
 ===========================
 
-- Increased the default auto-refinement limits to maximum of 32 refinement
-  levels or 5M elements. Note that you may still need to press 'o' if the mesh
-  is larger and/or appears not as curved as it should be.
+- Changed the auto refinement algorithm, which is now based on the order of
+  the grid function and mesh. The total number of elements is limited to the
+  range between 100k and 2M. If the upper limit is reached a warning is shown
+  and you may still need to press 'o' if you want to increase the refinement
+  even further.
 
 - Significantly improved memory usage.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,13 +12,11 @@
 Version 4.2.1 (development)
 ===========================
 
-- Changed the auto refinement algorithm, which is now based on the order of
-  the grid function and mesh. The total number of drawn elements (with the
-  non-conforming refinement shading) is limited to the range between 100k and
-  2M, while the maximum refiment is still limited to 16. If one of the upper
-  limits is reached a warning is shown that the data are potentially not resolved
-  and you may still need to press 'o' if you want to increase the refinement even
-  further.
+- The GLVis auto refinement algorithm now takes into account the order of the
+  data (mesh and grid function). The new refinement is chosen to be sufficient
+  for resolving the curvature of the data, but only if we can do that with less
+  than 2M vertices and 16 refinements. Otherwise, we print a warning and the
+  user may still needs to press 'o' to fully resolve the data.
 
 - Significantly improved memory usage.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,7 +16,8 @@ Version 4.2.1 (development)
   data (mesh and grid function). The new refinement is chosen to be sufficient
   for resolving the curvature of the data, but only if we can do that with less
   than 2M vertices and 16 refinements. Otherwise, we print a warning and the
-  user may still needs to press 'o' to fully resolve the data.
+  user may still need to press 'o' to fully resolve the data. For more details,
+  see the section Auto-refinement in README.md.
 
 - Significantly improved memory usage.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,10 +13,12 @@ Version 4.2.1 (development)
 ===========================
 
 - Changed the auto refinement algorithm, which is now based on the order of
-  the grid function and mesh. The total number of elements is limited to the
-  range between 100k and 2M. If the upper limit is reached a warning is shown
-  and you may still need to press 'o' if you want to increase the refinement
-  even further.
+  the grid function and mesh. The total number of drawn elements (with the
+  non-conforming refinement shading) is limited to the range between 100k and
+  2M, while the maximum refiment is still limited to 16. If one of the upper
+  limits is reached a warning is shown that the data are potentially not resolved
+  and you may still need to press 'o' if you want to increase the refinement even
+  further.
 
 - Significantly improved memory usage.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@
 Version 4.2.1 (development)
 ===========================
 
+- Increased the default auto-refinement limits to maximum of 32 refinement
+  levels or 5M elements. Note that you may still need to press 'o' if the mesh
+  is larger and/or appears not as curved as it should be.
+
 - Significantly improved memory usage.
 
 - Add support to visualize solutions on 1D elements embedded in 2D and 3D.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ is a partial list of the available functionality. Some of these keys can also be
 provided as input, using the `-k` command-line option and the `keys` script
 command.
 
+For high-order meshes and/or solution data, GLVis performs element subdivision
+to try to represent the data more accurately. However, for highly-varying data
+or large meshes, the auto-selected subdivision factor (see the
+[Auto-refinement](#auto-refinement) section below) may not be sufficient -- use
+the keys <kbd>o</kbd> / <kbd>O</kbd>, described below, to manually adjust the
+subdivision factor.
 
 SPDX-License-Identifier: BSD-3-Clause <br>
 LLNL Release Number: LLNL-CODE-443271 <br>
@@ -298,3 +304,46 @@ Key commands
   - `x`-component: `v_x`
   - `y`-component: `v_y`
   - `z`-component: `v_z`
+
+## Auto-refinement
+
+The GLVis auto-refinement algorithm selects a subdivision factor trying to
+achieve an accurate representation of high-order meshes and solution data while
+keeping the initial time to visualize the data reasonable. The algorithm can be
+summarized as follows:
+- GLVis draws surface elements; the number of drawn elements, `ne`, is either:
+  - the number of elements in the mesh for 2D meshes (including surface meshes,
+    i.e. 2D meshes embedded in 3D space), or
+  - the number of boundary mesh elements described by the mesh in 3D.
+- A tentative upper limit on the number of vertices to be drawn is defined based
+  on the maximum order of the mesh and the solution, `max_order`:
+  ```
+  max_vert = ne * (max_order + 1) * (max_order + 1)
+  ```
+- To allow more accurate representation for small meshes, this number is
+  potentially increased:
+  ```
+  max_vert = max(max_vert, 100 000)
+  ```
+- To keep the time to initially visualize the data reasonable, this number is
+  potentially reduced:
+  ```
+  max_vert = min(max_vert, 2 000 000)
+  ```
+- Finally, the subdivision factor `ref` is chosen to be the largest number such
+  that:
+  - the number of vertices needed to draw the `ne` surface elements with `ref`
+    subdivisions does not exceed `max_vert`:
+    ```
+    ne * (ref + 1) * (ref + 1) <= max_vert
+    ```
+  - for large meshes where the above limit cannot be satisfied, set `ref = 1`
+  - for small meshes, avoid excessive refinements:
+    ```
+    ref <= 16
+    ```
+
+Note that, for highly-varying data or large meshes, this auto-selected
+subdivision factor may not be sufficient for accurate representation. In such
+cases the sudivision can be manually adjusted using the keys <kbd>o</kbd> /
+<kbd>O</kbd>, described above.

--- a/README.md
+++ b/README.md
@@ -345,5 +345,5 @@ summarized as follows:
 
 Note that, for highly-varying data or large meshes, this auto-selected
 subdivision factor may not be sufficient for accurate representation. In such
-cases the sudivision can be manually adjusted using the keys <kbd>o</kbd> /
+cases the subdivision can be manually adjusted using the keys <kbd>o</kbd> /
 <kbd>O</kbd>, described above.

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -50,8 +50,17 @@ void VisualizationSceneScalarData::FixValueRange()
 int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
 {
    Mesh *mesh = gf.FESpace()->GetMesh();
-   const int dim = mesh->Dimension();
    const int order = gf.FESpace()->GetMaxElementOrder();
+
+   //check for integral elements
+   const int dim = mesh->Dimension();
+   const FiniteElementCollection *fec = gf.FESpace()->FEColl();
+   if (fec && fec->GetMapType(dim) == FiniteElement::INTEGRAL)
+   {
+      cout << "Warning: integral elements are non-polynomial in the physical space,\n"
+           << "         consider increasing the refinement by the key 'o'."
+           << endl;
+   }
 
    return order;
 }

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -82,13 +82,13 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
    }
 
    // limit the total number of elements
-   int auto_ref_surf_elem = ne * order_ref * order_ref;
-   auto_ref_surf_elem = std::min(std::max(auto_ref_surf_elem,
-                                          auto_ref_min_surf_elem), auto_ref_max_surf_elem);
+   int auto_ref_surf_vert = ne * (order_ref+1) * (order_ref+1);
+   auto_ref_surf_vert = std::min(std::max(auto_ref_surf_vert,
+                                          auto_ref_min_surf_vert), auto_ref_max_surf_vert);
 
    // approach the given number of elements
    int ref = 1;
-   while (ref < auto_ref_max && ne*(ref+1)*(ref+1) <= auto_ref_surf_elem)
+   while (ref < auto_ref_max && ne*(ref+2)*(ref+2) <= auto_ref_surf_vert)
    { ref++; }
 
    if (ref < order_ref)
@@ -1375,8 +1375,8 @@ void VisualizationSceneScalarData::Init()
    scaling = 0;
    drawaxes = colorbar = 0;
    auto_ref_max = 16;
-   auto_ref_min_surf_elem = 100000;
-   auto_ref_max_surf_elem = 2000000;
+   auto_ref_min_surf_vert = 100000;
+   auto_ref_max_surf_vert = 2000000;
    minv = 0.0;
    maxv = 1.0;
    logscale = false;

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -115,6 +115,12 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
    while (ref < auto_ref_max && ne*(ref+1)*(ref+1) <= auto_ref_surf_elem)
    { ref++; }
 
+   if (ref < order_ref)
+   {
+      cout << "Warning: the automatic refinement does not resolve the function fully"
+           << endl;
+   }
+
    return ref;
 }
 

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -56,11 +56,27 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
    {
       for (int i = 0; i < mesh->GetNBE(); i++)
       {
-         const FiniteElement &fe = *gf.FESpace()->GetBE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+         const int f = mesh->GetBdrElementFaceIndex(i);
+         const FiniteElement *fe = gf.FESpace()->GetFaceElement(f);
+         int order;
+         if (fe)
          {
-            order += mesh->GetBdrElementTransformation(i)->OrderW();
+            order = fe->GetOrder();
+            if (fe->GetMapType() == FiniteElement::MapType::INTEGRAL)
+            {
+               order += mesh->GetBdrElementTransformation(i)->OrderW();
+            }
+         }
+         else
+         {
+            int ivol, info;
+            mesh->GetBdrElementAdjacentElement(i, ivol, info);
+            const FiniteElement *fevol = gf.FESpace()->GetFE(ivol);
+            order = fevol->GetOrder() - 1;
+            if (fevol->GetMapType() == FiniteElement::MapType::INTEGRAL)
+            {
+               order += mesh->GetElementTransformation(ivol)->OrderW();
+            }
          }
          ref = std::max(ref, 2 * order);
       }

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -81,12 +81,12 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
       order_ref = std::max(order_ref, order);
    }
 
-   // limit the total number of elements
+   // limit the total number of vertices
    int auto_ref_surf_vert = ne * (order_ref+1) * (order_ref+1);
    auto_ref_surf_vert = std::min(std::max(auto_ref_surf_vert,
                                           auto_ref_min_surf_vert), auto_ref_max_surf_vert);
 
-   // approach the given number of elements
+   // approach the given number of vertices
    int ref = 1;
    while (ref < auto_ref_max && ne*(ref+2)*(ref+2) <= auto_ref_surf_vert)
    { ref++; }

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1271,8 +1271,9 @@ void VisualizationSceneScalarData::Init()
    arrow_type = arrow_scaling_type = 0;
    scaling = 0;
    drawaxes = colorbar = 0;
-   auto_ref_max = 32;
-   auto_ref_max_surf_elem = 5000000;
+   auto_ref_max = 16;
+   auto_ref_min_surf_elem = 100000;
+   auto_ref_max_surf_elem = 2000000;
    minv = 0.0;
    maxv = 1.0;
    logscale = false;

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -52,7 +52,7 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
    Mesh *mesh = gf.FESpace()->GetMesh();
    const int order = gf.FESpace()->GetMaxElementOrder();
 
-   //check for integral elements
+   // check for integral elements
    const int dim = mesh->Dimension();
    const FiniteElementCollection *fec = gf.FESpace()->FEColl();
    if (fec && fec->GetMapType(dim) == FiniteElement::INTEGRAL)
@@ -70,10 +70,10 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
    const int dim = mesh->Dimension();
    const int ne = (dim == 3)?(mesh->GetNBE()):(mesh->GetNE());
 
-   //determine the refinement based on the order of the mesh and grid function
+   // determine the refinement based on the order of the mesh and grid function
    int order_ref = GetFunctionAutoRefineFactor();
 
-   //mesh
+   // mesh
    const FiniteElementSpace *nfes = mesh->GetNodalFESpace();
    if (nfes)
    {
@@ -81,12 +81,12 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
       order_ref = std::max(order_ref, order);
    }
 
-   //limit the total number of elements
+   // limit the total number of elements
    int auto_ref_surf_elem = ne*(order_ref+1)*(order_ref+1);
    auto_ref_surf_elem = std::min(std::max(auto_ref_surf_elem,
                                           auto_ref_min_surf_elem), auto_ref_max_surf_elem);
 
-   //approach the given number of elements
+   // approach the given number of elements
    int ref = 1;
    while (ref < auto_ref_max && ne*(ref+1)*(ref+1) <= auto_ref_surf_elem)
    { ref++; }

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -47,6 +47,41 @@ void VisualizationSceneScalarData::FixValueRange()
    }
 }
 
+int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
+{
+   Mesh *mesh = gf.FESpace()->GetMesh();
+   const int dim = mesh->Dimension();
+   int ref = 1;
+   if (dim == 3)
+   {
+      for (int i = 0; i < mesh->GetNBE(); i++)
+      {
+         const FiniteElement &fe = *gf.FESpace()->GetBE(i);
+         int order = fe.GetOrder();
+         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+         {
+            order += mesh->GetBdrElementTransformation(i)->OrderW();
+         }
+         ref = std::max(ref, 2 * order);
+      }
+   }
+   else
+   {
+      for (int i = 0; i < mesh->GetNE(); i++)
+      {
+         const FiniteElement &fe = *gf.FESpace()->GetFE(i);
+         int order = fe.GetOrder();
+         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+         {
+            order += mesh->GetElementTransformation(i)->OrderW();
+         }
+         ref = std::max(ref, 2 * order);
+      }
+   }
+
+   return ref;
+}
+
 int VisualizationSceneScalarData::GetFunctionAutoRefineFactor()
 {
    if (!sol) { return 1; }

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -77,7 +77,7 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
             int ivol, info;
             mesh->GetBdrElementAdjacentElement(i, ivol, info);
             const FiniteElement *fevol = gf.FESpace()->GetFE(ivol);
-            order = fevol->GetOrder() - 1;
+            order = fevol->GetOrder();
             if (fevol->GetMapType() == FiniteElement::MapType::INTEGRAL)
             {
                order += mesh->GetElementTransformation(ivol)->OrderW();

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -82,7 +82,7 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
    }
 
    // limit the total number of elements
-   int auto_ref_surf_elem = ne*(order_ref+1)*(order_ref+1);
+   int auto_ref_surf_elem = ne * order_ref * order_ref;
    auto_ref_surf_elem = std::min(std::max(auto_ref_surf_elem,
                                           auto_ref_min_surf_elem), auto_ref_max_surf_elem);
 

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -83,7 +83,7 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
                order += mesh->GetElementTransformation(ivol)->OrderW();
             }
          }
-         ref = std::max(ref, 2 * order);
+         ref = std::max(ref, 2 * order - 1);
       }
    }
    else
@@ -96,18 +96,11 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
          {
             order += mesh->GetElementTransformation(i)->OrderW();
          }
-         ref = std::max(ref, 2 * order);
+         ref = std::max(ref, 2 * order - 1);
       }
    }
 
    return ref;
-}
-
-int VisualizationSceneScalarData::GetFunctionAutoRefineFactor()
-{
-   if (!sol) { return 1; }
-
-   return (sol->Size() == mesh->GetNV())?(2):(1);
 }
 
 int VisualizationSceneScalarData::GetAutoRefineFactor()
@@ -123,7 +116,7 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
    if (nfes)
    {
       const int order = nfes->GetMaxElementOrder();
-      order_ref = std::max(order_ref, 2 * order);
+      order_ref = std::max(order_ref, 2 * order - 1);
    }
 
    //limit the total number of elements

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -62,7 +62,7 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
            << endl;
    }
 
-   return order;
+   return std::max(order, 1);
 }
 
 int VisualizationSceneScalarData::GetAutoRefineFactor()

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -57,7 +57,12 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
       for (int i = 0; i < mesh->GetNBE(); i++)
       {
          const int f = mesh->GetBdrElementFaceIndex(i);
-         const FiniteElement *fe = gf.FESpace()->GetFaceElement(f);
+         const FiniteElementCollection *fec = gf.FESpace()->FEColl();
+         const FiniteElement *fe = NULL;
+         if (fec && fec->GetContType() != FiniteElementCollection::DISCONTINUOUS)
+         {
+            fe = gf.FESpace()->GetFaceElement(f);//might abort instead of returning NULL!
+         }
          int order;
          if (fe)
          {

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -93,7 +93,8 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
 
    if (ref < order_ref)
    {
-      cout << "Warning: the automatic refinement does not resolve the function fully"
+      cout << "Warning: the automatic refinement does not resolve the data fully,\n"
+           << "         consider increasing the refinement by the key 'o'."
            << endl;
    }
 

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -116,7 +116,7 @@ int VisualizationSceneScalarData::GetAutoRefineFactor()
    if (nfes)
    {
       const int order = nfes->GetMaxElementOrder();
-      order_ref = std::max(order_ref, 2 * order - 1);
+      order_ref = std::max(order_ref, order);
    }
 
    //limit the total number of elements

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -51,56 +51,9 @@ int VisualizationSceneScalarData::GetFunctionAutoRefineFactor(GridFunction &gf)
 {
    Mesh *mesh = gf.FESpace()->GetMesh();
    const int dim = mesh->Dimension();
-   int ref = 1;
-   if (dim == 3)
-   {
-      for (int i = 0; i < mesh->GetNBE(); i++)
-      {
-         const int f = mesh->GetBdrElementFaceIndex(i);
-         const FiniteElementCollection *fec = gf.FESpace()->FEColl();
-         const FiniteElement *fe = NULL;
-         if (fec && fec->GetContType() != FiniteElementCollection::DISCONTINUOUS)
-         {
-            fe = gf.FESpace()->GetFaceElement(f);//might abort instead of returning NULL!
-         }
-         int order;
-         if (fe)
-         {
-            order = fe->GetOrder();
-            if (fe->GetMapType() == FiniteElement::MapType::INTEGRAL)
-            {
-               order += mesh->GetBdrElementTransformation(i)->OrderW();
-            }
-         }
-         else
-         {
-            int ivol, info;
-            mesh->GetBdrElementAdjacentElement(i, ivol, info);
-            const FiniteElement *fevol = gf.FESpace()->GetFE(ivol);
-            order = fevol->GetOrder();
-            if (fevol->GetMapType() == FiniteElement::MapType::INTEGRAL)
-            {
-               order += mesh->GetElementTransformation(ivol)->OrderW();
-            }
-         }
-         ref = std::max(ref, 2 * order - 1);
-      }
-   }
-   else
-   {
-      for (int i = 0; i < mesh->GetNE(); i++)
-      {
-         const FiniteElement &fe = *gf.FESpace()->GetFE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-         {
-            order += mesh->GetElementTransformation(i)->OrderW();
-         }
-         ref = std::max(ref, 2 * order - 1);
-      }
-   }
+   const int order = gf.FESpace()->GetMaxElementOrder();
 
-   return ref;
+   return order;
 }
 
 int VisualizationSceneScalarData::GetAutoRefineFactor()

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1270,8 +1270,8 @@ void VisualizationSceneScalarData::Init()
    arrow_type = arrow_scaling_type = 0;
    scaling = 0;
    drawaxes = colorbar = 0;
-   auto_ref_max = 16;
-   auto_ref_max_surf_elem = 20000;
+   auto_ref_max = 32;
+   auto_ref_max_surf_elem = 5000000;
    minv = 0.0;
    maxv = 1.0;
    logscale = false;

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -77,7 +77,7 @@ protected:
 
    int scaling, colorbar, drawaxes;
    Shading shading;
-   int auto_ref_max, auto_ref_max_surf_elem;
+   int auto_ref_max, auto_ref_min_surf_elem, auto_ref_max_surf_elem;
 
    vector<gl3::GlDrawable*> updated_bufs;
    gl3::GlDrawable axes_buf;

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -206,7 +206,7 @@ public:
    void SetValueRange(double, double);
 
    virtual void SetShading(Shading, bool) = 0;
-   virtual void ToogleShading() { SetShading((Shading)(((int)shading + 1) % (int)Shading::Max), true); }
+   virtual void ToggleShading() { SetShading((Shading)(((int)shading + 1) % (int)Shading::Max), true); }
    virtual Shading GetShading() { return shading; }
    virtual void SetRefineFactors(int, int) = 0;
    void SetAutoRefineLimits(int max_ref, int max_surf_elem)

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -138,6 +138,9 @@ protected:
 
    void FixValueRange();
 
+   virtual int GetFunctionAutoRefineFactor();
+   virtual int GetAutoRefineFactor();
+
    void Cone(gl3::GlDrawable& buf, glm::mat4 transform, double cval);
 
 public:

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -138,6 +138,7 @@ protected:
 
    void FixValueRange();
 
+   static int GetFunctionAutoRefineFactor(GridFunction &gf);
    virtual int GetFunctionAutoRefineFactor();
    virtual int GetAutoRefineFactor();
 

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -78,7 +78,7 @@ protected:
 
    int scaling, colorbar, drawaxes;
    Shading shading;
-   int auto_ref_max, auto_ref_min_surf_elem, auto_ref_max_surf_elem;
+   int auto_ref_max, auto_ref_min_surf_vert, auto_ref_max_surf_vert;
 
    // Formatter for axes & colorbar numbers. Set defaults.
    function<string(double)> axis_formatter = NumberFormatter(4, 'd', false);
@@ -209,10 +209,10 @@ public:
    virtual void ToggleShading() { SetShading((Shading)(((int)shading + 1) % (int)Shading::Max), true); }
    virtual Shading GetShading() { return shading; }
    virtual void SetRefineFactors(int, int) = 0;
-   void SetAutoRefineLimits(int max_ref, int max_surf_elem)
+   void SetAutoRefineLimits(int max_ref, int max_surf_vert)
    {
       auto_ref_max = max_ref;
-      auto_ref_max_surf_elem = max_surf_elem;
+      auto_ref_max_surf_vert = max_surf_vert;
    }
    virtual void AutoRefine() = 0;
    virtual void ToggleAttributes(Array<int> &attr_list) = 0;

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -139,7 +139,7 @@ protected:
    void FixValueRange();
 
    static int GetFunctionAutoRefineFactor(GridFunction &gf);
-   virtual int GetFunctionAutoRefineFactor();
+   virtual int GetFunctionAutoRefineFactor() = 0;
    virtual int GetAutoRefineFactor();
 
    void Cone(gl3::GlDrawable& buf, glm::mat4 transform, double cval);

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -589,10 +589,15 @@ void VisualizationSceneSolution::ToggleDrawElems()
 void VisualizationSceneSolution::NewMeshAndSolution(
    Mesh *new_m, Mesh *new_mc, Vector *new_sol, GridFunction *new_u)
 {
+   Mesh *old_m = mesh;
+   mesh = new_m;
+   mesh_coarse = new_mc;
+   sol = new_sol;
+   rsol = new_u;
+
    // If the number of elements changes, recompute the refinement factor
-   if (mesh->GetNE() != new_m->GetNE())
+   if (mesh->GetNE() != old_m->GetNE())
    {
-      mesh = new_m;
       int ref = GetAutoRefineFactor();
       if (TimesToRefine != ref || EdgeRefineFactor != 1)
       {
@@ -601,10 +606,6 @@ void VisualizationSceneSolution::NewMeshAndSolution(
          cout << "Subdivision factors = " << TimesToRefine << ", 1" << endl;
       }
    }
-   mesh = new_m;
-   mesh_coarse = new_mc;
-   sol = new_sol;
-   rsol = new_u;
 
    have_sol_range = false;
    DoAutoscale(false);

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -881,7 +881,7 @@ void VisualizationSceneSolution::ToggleShading()
 {
    if (rsol)
    {
-      VisualizationSceneScalarData::ToogleShading();
+      VisualizationSceneScalarData::ToggleShading();
    }
    else
    {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -988,12 +988,47 @@ void VisualizationSceneSolution::SetRefineFactors(int tot, int bdr)
 
 int VisualizationSceneSolution::GetAutoRefineFactor()
 {
-   int ne = mesh->GetNE(), ref = 1;
+   const int ne = mesh->GetNE();
 
-   while (ref < auto_ref_max && ne*(ref+1)*(ref+1) <= auto_ref_max_surf_elem)
+   //determine the refinement based on the order of the mesh and grid function
+   int order_ref = 1;
+
+   //grid function
+   if (rsol)
    {
-      ref++;
+      for (int i = 0; i < ne; i++)
+      {
+         const FiniteElement &fe = *rsol->FESpace()->GetFE(i);
+         int order = fe.GetOrder();
+         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+         {
+            order += mesh->GetElementTransformation(i)->OrderW();
+         }
+         order_ref = std::max(order_ref, 2 * order);
+      }
    }
+   else
+   {
+      order_ref = (sol->Size() == mesh->GetNV())?(2):(1);
+   }
+
+   //mesh
+   const FiniteElementSpace *nfes = mesh->GetNodalFESpace();
+   if (nfes)
+   {
+      const int order = nfes->GetMaxElementOrder();
+      order_ref = std::max(order_ref, 2 * order);
+   }
+
+   //limit the total number of elements
+   int auto_ref_surf_elem = ne*(order_ref+1)*(order_ref+1);
+   auto_ref_surf_elem = std::min(std::max(auto_ref_surf_elem,
+                                          auto_ref_min_surf_elem), auto_ref_max_surf_elem);
+
+   //approach the given number of elements
+   int ref = 1;
+   while (ref < auto_ref_max && ne*(ref+1)*(ref+1) <= auto_ref_surf_elem)
+   { ref++; }
 
    return ref;
 }

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -990,22 +990,7 @@ int VisualizationSceneSolution::GetFunctionAutoRefineFactor()
 {
    if (!rsol) { return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(); }
 
-   //grid function
-
-   const int ne = mesh->GetNE();
-   int ref = 1;
-   for (int i = 0; i < ne; i++)
-   {
-      const FiniteElement &fe = *rsol->FESpace()->GetFE(i);
-      int order = fe.GetOrder();
-      if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-      {
-         order += mesh->GetElementTransformation(i)->OrderW();
-      }
-      ref = std::max(ref, 2 * order);
-   }
-
-   return ref;
+   return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*rsol);
 }
 
 void VisualizationSceneSolution::AutoRefine()

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -986,49 +986,24 @@ void VisualizationSceneSolution::SetRefineFactors(int tot, int bdr)
    }
 }
 
-int VisualizationSceneSolution::GetAutoRefineFactor()
+int VisualizationSceneSolution::GetFunctionAutoRefineFactor()
 {
-   const int ne = mesh->GetNE();
-
-   //determine the refinement based on the order of the mesh and grid function
-   int order_ref = 1;
+   if (!rsol) { return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(); }
 
    //grid function
-   if (rsol)
-   {
-      for (int i = 0; i < ne; i++)
-      {
-         const FiniteElement &fe = *rsol->FESpace()->GetFE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-         {
-            order += mesh->GetElementTransformation(i)->OrderW();
-         }
-         order_ref = std::max(order_ref, 2 * order);
-      }
-   }
-   else
-   {
-      order_ref = (sol->Size() == mesh->GetNV())?(2):(1);
-   }
 
-   //mesh
-   const FiniteElementSpace *nfes = mesh->GetNodalFESpace();
-   if (nfes)
-   {
-      const int order = nfes->GetMaxElementOrder();
-      order_ref = std::max(order_ref, 2 * order);
-   }
-
-   //limit the total number of elements
-   int auto_ref_surf_elem = ne*(order_ref+1)*(order_ref+1);
-   auto_ref_surf_elem = std::min(std::max(auto_ref_surf_elem,
-                                          auto_ref_min_surf_elem), auto_ref_max_surf_elem);
-
-   //approach the given number of elements
+   const int ne = mesh->GetNE();
    int ref = 1;
-   while (ref < auto_ref_max && ne*(ref+1)*(ref+1) <= auto_ref_surf_elem)
-   { ref++; }
+   for (int i = 0; i < ne; i++)
+   {
+      const FiniteElement &fe = *rsol->FESpace()->GetFE(i);
+      int order = fe.GetOrder();
+      if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+      {
+         order += mesh->GetElementTransformation(i)->OrderW();
+      }
+      ref = std::max(ref, 2 * order);
+   }
 
    return ref;
 }

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -988,7 +988,7 @@ void VisualizationSceneSolution::SetRefineFactors(int tot, int bdr)
 
 int VisualizationSceneSolution::GetFunctionAutoRefineFactor()
 {
-   if (!rsol) { return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(); }
+   if (!rsol) { return 1; }
 
    return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*rsol);
 }

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -77,7 +77,7 @@ protected:
                         Vector &values, int sides, Array<double> &lvl,
                         int flat = 0);
 
-   int GetAutoRefineFactor();
+   virtual int GetFunctionAutoRefineFactor() override;
 
    // Used for drawing markers for element and vertex numbering
    double GetElementLengthScale(int k);

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -77,7 +77,7 @@ protected:
                         Vector &values, int sides, Array<double> &lvl,
                         int flat = 0);
 
-   virtual int GetFunctionAutoRefineFactor() override;
+   virtual int GetFunctionAutoRefineFactor();
 
    // Used for drawing markers for element and vertex numbering
    double GetElementLengthScale(int k);

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -77,7 +77,7 @@ protected:
                         Vector &values, int sides, Array<double> &lvl,
                         int flat = 0);
 
-   virtual int GetFunctionAutoRefineFactor();
+   int GetFunctionAutoRefineFactor() override;
 
    // Used for drawing markers for element and vertex numbering
    double GetElementLengthScale(int k);
@@ -92,35 +92,35 @@ public:
 
    virtual ~VisualizationSceneSolution();
 
-   virtual std::string GetHelpString() const;
+   std::string GetHelpString() const override;
 
    void SetGridFunction(GridFunction & u) { rsol = &u; }
 
    void NewMeshAndSolution(Mesh *new_m, Mesh *new_mc, Vector *new_sol,
                            GridFunction *new_u = NULL);
 
-   virtual void SetNewScalingFromBox();
-   virtual void FindNewBox(bool prepare);
-   virtual void FindNewValueRange(bool prepare);
-   virtual void FindNewBoxAndValueRange(bool prepare)
+   void SetNewScalingFromBox() override;
+   void FindNewBox(bool prepare) override;
+   void FindNewValueRange(bool prepare) override;
+   void FindNewBoxAndValueRange(bool prepare) override
    { FindNewBox(prepare); }
-   virtual void FindMeshBox(bool prepare);
+   void FindMeshBox(bool prepare) override;
 
-   virtual void ToggleLogscale(bool print);
-   virtual void EventUpdateBackground();
-   virtual void EventUpdateColors();
-   virtual void UpdateLevelLines() { PrepareLevelCurves(); }
-   virtual void UpdateValueRange(bool prepare);
+   void ToggleLogscale(bool print) override;
+   void EventUpdateBackground() override;
+   void EventUpdateColors() override;
+   void UpdateLevelLines()  override { PrepareLevelCurves(); }
+   void UpdateValueRange(bool prepare) override;
 
    void PrepareWithNormals();
    void PrepareFlat();
    void PrepareFlat2();
 
-   virtual void PrepareLines();
+   void PrepareLines() override;
    void PrepareLines2();
    void PrepareLines3();
 
-   virtual void Prepare();
+   void Prepare() override;
    void PrepareLevelCurves();
    void PrepareLevelCurves2();
 
@@ -140,12 +140,12 @@ public:
 
    void PrepareCP();
 
-   virtual gl3::SceneInfo GetSceneObjs();
+   gl3::SceneInfo GetSceneObjs() override;
 
    void glTF_ExportBoundary(glTF_Builder &bld,
                             glTF_Builder::buffer_id buffer,
                             glTF_Builder::material_id black_mat);
-   virtual void glTF_Export();
+   void glTF_Export() override;
 
    void ToggleDrawBdr();
 
@@ -164,17 +164,17 @@ public:
       PrepareNumbering(false);
    }
 
-   virtual void SetShading(Shading, bool);
-   virtual void ToggleShading();
+   void SetShading(Shading, bool) override;
+   void ToggleShading() override;
 
    void ToggleDrawCP() { draw_cp = !draw_cp; PrepareCP(); }
 
    void ToggleRefinements();
    void ToggleRefinementFunction();
 
-   virtual void SetRefineFactors(int, int);
-   virtual void AutoRefine();
-   virtual void ToggleAttributes(Array<int> &attr_list);
+   void SetRefineFactors(int, int) override;
+   void AutoRefine() override;
+   void ToggleAttributes(Array<int> &attr_list) override;
 
    virtual void SetDrawMesh(int i) { drawmesh = i % 3; }
    virtual int GetDrawMesh() { return drawmesh; }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -919,7 +919,7 @@ void VisualizationSceneSolution3d::SetRefineFactors(int f, int ignored)
 
 int VisualizationSceneSolution3d::GetFunctionAutoRefineFactor()
 {
-   if (!GridF) { return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(); }
+   if (!GridF) { return 1; }
 
    return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*GridF);
 }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -829,12 +829,18 @@ void VisualizationSceneSolution3d::NewMeshAndSolution(
       delete [] node_pos;
       node_pos = new double[new_m->GetNV()];
    }
+
+   Mesh *old_m = mesh;
+   mesh = new_m;
+   mesh_coarse = new_mc;
+   sol = new_sol;
+   GridF = new_u;
+
    // If the number of surface elements changes, recompute the refinement factor
-   if (mesh->Dimension() != new_m->Dimension() ||
-       (mesh->Dimension() == 2 && mesh->GetNE() != new_m->GetNE()) ||
-       (mesh->Dimension() == 3 && mesh->GetNBE() != new_m->GetNBE()))
+   if (mesh->Dimension() != old_m->Dimension() ||
+       (mesh->Dimension() == 2 && mesh->GetNE() != old_m->GetNE()) ||
+       (mesh->Dimension() == 3 && mesh->GetNBE() != old_m->GetNBE()))
    {
-      mesh = new_m;
       int ref = GetAutoRefineFactor();
       if (TimesToRefine != ref)
       {
@@ -842,10 +848,6 @@ void VisualizationSceneSolution3d::NewMeshAndSolution(
          cout << "Subdivision factor = " << TimesToRefine << endl;
       }
    }
-   mesh = new_m;
-   mesh_coarse = new_mc;
-   sol = new_sol;
-   GridF = new_u;
    FindNodePos();
 
    DoAutoscale(false);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -921,38 +921,7 @@ int VisualizationSceneSolution3d::GetFunctionAutoRefineFactor()
 {
    if (!GridF) { return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(); }
 
-   //grid function
-
-   const int dim = mesh->Dimension();
-   int ref = 1;
-   if (dim == 3)
-   {
-      for (int i = 0; i < mesh->GetNBE(); i++)
-      {
-         const FiniteElement &fe = *GridF->FESpace()->GetBE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-         {
-            order += mesh->GetBdrElementTransformation(i)->OrderW();
-         }
-         ref = std::max(ref, 2 * order);
-      }
-   }
-   else
-   {
-      for (int i = 0; i < mesh->GetNE(); i++)
-      {
-         const FiniteElement &fe = *GridF->FESpace()->GetFE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-         {
-            order += mesh->GetElementTransformation(i)->OrderW();
-         }
-         ref = std::max(ref, 2 * order);
-      }
-   }
-
-   return ref;
+   return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*GridF);
 }
 
 void VisualizationSceneSolution3d::AutoRefine()

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -892,7 +892,7 @@ void VisualizationSceneSolution3d::ToggleShading()
 {
    if (GridF)
    {
-      VisualizationSceneScalarData::ToogleShading();
+      VisualizationSceneScalarData::ToggleShading();
    }
    else
    {

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -101,7 +101,7 @@ protected:
                                 const int nh, const int face_splits,
                                 const DenseMatrix *grad = NULL);
 
-   virtual int GetFunctionAutoRefineFactor() override;
+   virtual int GetFunctionAutoRefineFactor();
 
    bool CheckPositions(Array<int> &vertices) const
    {

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -101,7 +101,7 @@ protected:
                                 const int nh, const int face_splits,
                                 const DenseMatrix *grad = NULL);
 
-   virtual int GetFunctionAutoRefineFactor();
+   int GetFunctionAutoRefineFactor() override;
 
    bool CheckPositions(Array<int> &vertices) const
    {
@@ -129,22 +129,22 @@ public:
 
    virtual ~VisualizationSceneSolution3d();
 
-   virtual std::string GetHelpString() const;
+   std::string GetHelpString() const override;
 
-   virtual void FindNewBox(bool prepare);
-   virtual void FindNewValueRange(bool prepare);
+   void FindNewBox(bool prepare) override;
+   void FindNewValueRange(bool prepare) override;
 
-   virtual void PrepareRuler()
+   void PrepareRuler() override
    { VisualizationSceneScalarData::PrepareRuler(false); }
    virtual void PrepareFlat();
-   virtual void PrepareLines();
-   virtual void Prepare();
+   void PrepareLines() override;
+   void Prepare() override;
    virtual void PrepareOrderingCurve();
    virtual void PrepareOrderingCurve1(gl3::GlDrawable& buf, bool arrows,
                                       bool color);
-   virtual gl3::SceneInfo GetSceneObjs();
+   gl3::SceneInfo GetSceneObjs() override;
 
-   virtual void glTF_Export();
+   void glTF_Export() override;
 
    void ToggleDrawElems()
    { drawelems = !drawelems; Prepare(); }
@@ -155,11 +155,11 @@ public:
    //           3 - no arrows (black), 4 - with arrows (black)
    void ToggleDrawOrdering() { draworder = (draworder+1)%5; }
 
-   virtual void SetShading(Shading, bool);
-   virtual void ToggleShading();
-   virtual void SetRefineFactors(int, int);
-   virtual void AutoRefine();
-   virtual void ToggleAttributes(Array<int> &attr_list);
+   void SetShading(Shading, bool) override;
+   void ToggleShading() override;
+   void SetRefineFactors(int, int) override;
+   void AutoRefine() override;
+   void ToggleAttributes(Array<int> &attr_list) override;
 
    void FindNodePos();
 
@@ -188,10 +188,10 @@ public:
    void ToggleCPAlgorithm();
    void MoveLevelSurf(int);
    void NumberOfLevelSurf(int);
-   virtual void EventUpdateColors();
-   virtual void UpdateLevelLines()
+   void EventUpdateColors() override;
+   void UpdateLevelLines() override
    { PrepareLines(); PrepareCuttingPlaneLines(); }
-   virtual void UpdateValueRange(bool prepare);
+   void UpdateValueRange(bool prepare) override;
 
    virtual void SetDrawMesh(int i)
    {

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -101,7 +101,7 @@ protected:
                                 const int nh, const int face_splits,
                                 const DenseMatrix *grad = NULL);
 
-   int GetAutoRefineFactor();
+   virtual int GetFunctionAutoRefineFactor() override;
 
    bool CheckPositions(Array<int> &vertices) const
    {

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -418,13 +418,15 @@ void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf, Mesh *mc)
       delete solx;
    }
 
+   Mesh *old_m = mesh;
+   Mesh *new_mesh = vgf.FESpace()->GetMesh();
+   mesh = new_mesh;
+   mesh_coarse = mc;
    VecGridF = &vgf;
 
    // If the number of elements changes, recompute the refinement factor
-   Mesh *new_mesh = vgf.FESpace()->GetMesh();
-   if (mesh->GetNE() != new_mesh->GetNE())
+   if (mesh->GetNE() != old_m->GetNE())
    {
-      mesh = new_mesh;
       int ref = GetAutoRefineFactor();
       if (TimesToRefine != ref || EdgeRefineFactor != 1)
       {
@@ -438,8 +440,6 @@ void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf, Mesh *mc)
          cout << "Vector subdivision factor = 1" << endl;
       }
    }
-   mesh = new_mesh;
-   mesh_coarse = mc;
 
    solx = new Vector(mesh->GetNV());
    soly = new Vector(mesh->GetNV());

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -883,6 +883,31 @@ void VisualizationSceneVector::DrawVector(double px, double py, double vx,
    }
 }
 
+int VisualizationSceneVector::GetFunctionAutoRefineFactor()
+{
+   if (!VecGridF)
+   {
+      return (solx->Size() == mesh->GetNV() || soly->Size() == mesh->GetNV())?(2):(1);
+   }
+
+   //grid function
+
+   const int ne = mesh->GetNE();
+   int ref = 1;
+   for (int i = 0; i < ne; i++)
+   {
+      const FiniteElement &fe = *VecGridF->FESpace()->GetFE(i);
+      int order = fe.GetOrder();
+      if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+      {
+         order += mesh->GetElementTransformation(i)->OrderW();
+      }
+      ref = std::max(ref, 2 * order);
+   }
+
+   return ref;
+}
+
 void VisualizationSceneVector::PrepareVectorField()
 {
    int rerun;

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -885,10 +885,7 @@ void VisualizationSceneVector::DrawVector(double px, double py, double vx,
 
 int VisualizationSceneVector::GetFunctionAutoRefineFactor()
 {
-   if (!VecGridF)
-   {
-      return (solx->Size() == mesh->GetNV() || soly->Size() == mesh->GetNV())?(2):(1);
-   }
+   if (!VecGridF) { return 1;}
 
    return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*VecGridF);
 }

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -890,22 +890,7 @@ int VisualizationSceneVector::GetFunctionAutoRefineFactor()
       return (solx->Size() == mesh->GetNV() || soly->Size() == mesh->GetNV())?(2):(1);
    }
 
-   //grid function
-
-   const int ne = mesh->GetNE();
-   int ref = 1;
-   for (int i = 0; i < ne; i++)
-   {
-      const FiniteElement &fe = *VecGridF->FESpace()->GetFE(i);
-      int order = fe.GetOrder();
-      if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-      {
-         order += mesh->GetElementTransformation(i)->OrderW();
-      }
-      ref = std::max(ref, 2 * order);
-   }
-
-   return ref;
+   return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*VecGridF);
 }
 
 void VisualizationSceneVector::PrepareVectorField()

--- a/lib/vsvector.hpp
+++ b/lib/vsvector.hpp
@@ -45,6 +45,8 @@ protected:
    Vector vc0;
    IsoparametricTransformation T0;
 
+   virtual int GetFunctionAutoRefineFactor() override;
+
 public:
    VisualizationSceneVector(Mesh &m, Vector &sx, Vector &sy, Mesh *mc = NULL);
    VisualizationSceneVector(GridFunction &vgf);

--- a/lib/vsvector.hpp
+++ b/lib/vsvector.hpp
@@ -30,11 +30,11 @@ protected:
 
    void Init();
 
-   virtual void GetRefinedValues(int i, const IntegrationRule &ir,
-                                 Vector &vals, DenseMatrix &tr);
-   virtual int GetRefinedValuesAndNormals(int i, const IntegrationRule &ir,
-                                          Vector &vals, DenseMatrix &tr,
-                                          DenseMatrix &normals);
+   void GetRefinedValues(int i, const IntegrationRule &ir,
+                         Vector &vals, DenseMatrix &tr) override;
+   int GetRefinedValuesAndNormals(int i, const IntegrationRule &ir,
+                                  Vector &vals, DenseMatrix &tr,
+                                  DenseMatrix &normals) override;
 
    double (*Vec2Scalar)(double, double);
 
@@ -45,7 +45,7 @@ protected:
    Vector vc0;
    IsoparametricTransformation T0;
 
-   virtual int GetFunctionAutoRefineFactor();
+   int GetFunctionAutoRefineFactor() override;
 
 public:
    VisualizationSceneVector(Mesh &m, Vector &sx, Vector &sy, Mesh *mc = NULL);
@@ -55,14 +55,14 @@ public:
 
    virtual ~VisualizationSceneVector();
 
-   virtual std::string GetHelpString() const;
+   std::string GetHelpString() const override;
 
    void NPressed();
    void PrepareDisplacedMesh();
-   virtual void PrepareLines()
+   void PrepareLines() override
    { VisualizationSceneSolution::PrepareLines(); PrepareDisplacedMesh(); }
 
-   virtual void ToggleDrawElems();
+   void ToggleDrawElems() override;
 
    virtual void PrepareVectorField();
    void ToggleVectorField();
@@ -76,11 +76,11 @@ public:
       }
    }
 
-   virtual gl3::SceneInfo GetSceneObjs();
+   gl3::SceneInfo GetSceneObjs() override;
 
-   virtual void glTF_Export();
+   void glTF_Export() override;
 
-   virtual void EventUpdateColors() { Prepare(); PrepareVectorField(); }
+   void EventUpdateColors() override { Prepare(); PrepareVectorField(); }
 
    // refinement factor for the vectors
    int RefineFactor;

--- a/lib/vsvector.hpp
+++ b/lib/vsvector.hpp
@@ -45,7 +45,7 @@ protected:
    Vector vc0;
    IsoparametricTransformation T0;
 
-   virtual int GetFunctionAutoRefineFactor() override;
+   virtual int GetFunctionAutoRefineFactor();
 
 public:
    VisualizationSceneVector(Mesh &m, Vector &sx, Vector &sy, Mesh *mc = NULL);

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -442,13 +442,7 @@ void VisualizationSceneVector3d::Init()
 
 int VisualizationSceneVector3d::GetFunctionAutoRefineFactor()
 {
-   if (!VecGridF)
-   {
-      return (solx->Size() == mesh->GetNV()
-              || soly->Size() == mesh->GetNV()
-              || solz->Size() == mesh->GetNV())
-             ?(2):(1);
-   }
+   if (!VecGridF) { return 1; }
 
    return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*VecGridF);
 }

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -440,6 +440,50 @@ void VisualizationSceneVector3d::Init()
    }
 }
 
+int VisualizationSceneVector3d::GetFunctionAutoRefineFactor()
+{
+   if (!VecGridF)
+   {
+      return (solx->Size() == mesh->GetNV()
+              || soly->Size() == mesh->GetNV()
+              || solz->Size() == mesh->GetNV())
+             ?(2):(1);
+   }
+
+   //grid function
+
+   const int dim = mesh->Dimension();
+   int ref = 1;
+   if (dim == 3)
+   {
+      for (int i = 0; i < mesh->GetNBE(); i++)
+      {
+         const FiniteElement &fe = *VecGridF->FESpace()->GetBE(i);
+         int order = fe.GetOrder();
+         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+         {
+            order += mesh->GetBdrElementTransformation(i)->OrderW();
+         }
+         ref = std::max(ref, 2 * order);
+      }
+   }
+   else
+   {
+      for (int i = 0; i < mesh->GetNE(); i++)
+      {
+         const FiniteElement &fe = *VecGridF->FESpace()->GetFE(i);
+         int order = fe.GetOrder();
+         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
+         {
+            order += mesh->GetElementTransformation(i)->OrderW();
+         }
+         ref = std::max(ref, 2 * order);
+      }
+   }
+
+   return ref;
+}
+
 VisualizationSceneVector3d::~VisualizationSceneVector3d()
 {
    delete sol;

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -481,12 +481,16 @@ void VisualizationSceneVector3d::NewMeshAndSolution(
       node_pos = new double[new_m->GetNV()];
    }
 
+   Mesh *old_m = mesh;
+   VecGridF = new_v;
+   mesh = new_m;
+   mesh_coarse = new_mc;
+
    // If the number of surface elements changes, recompute the refinement factor
-   if (mesh->Dimension() != new_m->Dimension() ||
-       (mesh->Dimension() == 2 && mesh->GetNE() != new_m->GetNE()) ||
-       (mesh->Dimension() == 3 && mesh->GetNBE() != new_m->GetNBE()))
+   if (mesh->Dimension() != old_m->Dimension() ||
+       (mesh->Dimension() == 2 && mesh->GetNE() != old_m->GetNE()) ||
+       (mesh->Dimension() == 3 && mesh->GetNBE() != old_m->GetNBE()))
    {
-      mesh = new_m;
       int ref = GetAutoRefineFactor();
       if (TimesToRefine != ref)
       {
@@ -497,9 +501,6 @@ void VisualizationSceneVector3d::NewMeshAndSolution(
 
    FiniteElementSpace *new_fes = new_v->FESpace();
 
-   VecGridF = new_v;
-   mesh = new_m;
-   mesh_coarse = new_mc;
    FindNodePos();
 
    sfes = new FiniteElementSpace(mesh, new_fes->FEColl(), 1,

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -450,38 +450,7 @@ int VisualizationSceneVector3d::GetFunctionAutoRefineFactor()
              ?(2):(1);
    }
 
-   //grid function
-
-   const int dim = mesh->Dimension();
-   int ref = 1;
-   if (dim == 3)
-   {
-      for (int i = 0; i < mesh->GetNBE(); i++)
-      {
-         const FiniteElement &fe = *VecGridF->FESpace()->GetBE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-         {
-            order += mesh->GetBdrElementTransformation(i)->OrderW();
-         }
-         ref = std::max(ref, 2 * order);
-      }
-   }
-   else
-   {
-      for (int i = 0; i < mesh->GetNE(); i++)
-      {
-         const FiniteElement &fe = *VecGridF->FESpace()->GetFE(i);
-         int order = fe.GetOrder();
-         if (fe.GetMapType() == FiniteElement::MapType::INTEGRAL)
-         {
-            order += mesh->GetElementTransformation(i)->OrderW();
-         }
-         ref = std::max(ref, 2 * order);
-      }
-   }
-
-   return ref;
+   return VisualizationSceneScalarData::GetFunctionAutoRefineFactor(*VecGridF);
 }
 
 VisualizationSceneVector3d::~VisualizationSceneVector3d()

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -33,6 +33,8 @@ protected:
    Array<int> vflevel;
    Array<double> dvflevel;
 
+   virtual int GetFunctionAutoRefineFactor() override;
+
 public:
    int ianim, ianimd, ianimmax, drawdisp;
 

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -33,7 +33,7 @@ protected:
    Array<int> vflevel;
    Array<double> dvflevel;
 
-   virtual int GetFunctionAutoRefineFactor();
+   int GetFunctionAutoRefineFactor() override;
 
 public:
    int ianim, ianimd, ianimmax, drawdisp;
@@ -46,12 +46,12 @@ public:
 
    virtual ~VisualizationSceneVector3d();
 
-   virtual std::string GetHelpString() const;
+   std::string GetHelpString() const override;
 
    void NPressed();
-   virtual void PrepareFlat();
-   virtual void Prepare();
-   virtual void PrepareLines();
+   void PrepareFlat() override;
+   void Prepare() override;
+   void PrepareLines() override;
 
    void PrepareFlat2();
    void PrepareLines2();
@@ -66,13 +66,13 @@ public:
    void SetScalarFunction();
    void ToggleScalarFunction();
 
-   virtual void PrepareCuttingPlane();
+   void PrepareCuttingPlane() override;
 
    void ToggleDisplacements() {drawdisp = (drawdisp+1)%2;};
 
-   virtual gl3::SceneInfo GetSceneObjs();
+   gl3::SceneInfo GetSceneObjs() override;
 
-   virtual void EventUpdateColors()
+   void EventUpdateColors() override
    { Prepare(); PrepareVectorField(); PrepareCuttingPlane(); };
 
    void ToggleVectorFieldLevel(int v);

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -33,7 +33,7 @@ protected:
    Array<int> vflevel;
    Array<double> dvflevel;
 
-   virtual int GetFunctionAutoRefineFactor() override;
+   virtual int GetFunctionAutoRefineFactor();
 
 public:
    int ianim, ianimd, ianimmax, drawdisp;


### PR DESCRIPTION
This is meant to address the issue where small meshes are curved but refined versions of them appear to lose the curvature in GLVis. See also this task in https://github.com/GLVis/glvis/pull/284

> Command-line option to ensure minimal level of refinement to large meshes don't show as linear by default (ping: @dylan-copeland, @psocratis)?

The reasons for that behavior are the auto-refinement limits, which previously were:

- at most 16 refinement levels (`auto_ref_max = 16`)
- at most 20K "refined" elements to be visualized (`auto_ref_max_surf_elem = 20000`)

Both of these variables are set in `lib/vsdata.cpp`

After considering several options, I suggest that we just increase those variables to 32 and 5M respectively.

These limits seems to work fine on modern hardware and the waiting time for large meshes is a few seconds on my Mac. 

@psocratis and @dylan-copeland -- do you mind trying this on your use cases and reporting if it works well?
