### PR TITLE
Visualization of quadrature functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,11 +23,12 @@ Version 4.2.1 (development)
 
 - Added visualization of quadratures. They can be loaded from a file through the
   new command line argument '-q' or in a socket stream with the keyword 'quadrature'
-  (instead of solution). Two options of visualization are offered (which can be
+  (instead of solution). Three options of visualization are offered (which can be
   switched by 'Q' key): piece-wise constant function on a refined mesh (closed
-  Gauss-Legendre refinement), or discontinuous elements with DOFs collocated with
-  the quadrature on the original mesh. High-order quadratures are supported only
-  for tensor finite elements.
+  Gauss-Legendre refinement), discontinuous elements with DOFs collocated with
+  the quadrature on the original mesh, or projection to discontinuous elements.
+  High-order quadratures are supported only for tensor finite elements with the
+  first two options.
 
 
 Version 4.2 released on May 23, 2022

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ Version 4.2.1 (development)
   (instead of solution). Two options of visualization are offered (which can be
   switched by 'Q' key): piece-wise constant function on a refined mesh (closed
   Gauss-Legendre refinement), or discontinuous elements with DOFs collocated with
-  the quadrature on the original mesh.
+  the quadrature on the original mesh (available for tensor basis only).
 
 
 Version 4.2 released on May 23, 2022

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,8 @@ Version 4.2.1 (development)
   (instead of solution). Two options of visualization are offered (which can be
   switched by 'Q' key): piece-wise constant function on a refined mesh (closed
   Gauss-Legendre refinement), or discontinuous elements with DOFs collocated with
-  the quadrature on the original mesh (available for tensor basis only).
+  the quadrature on the original mesh. High-order quadratures are supported only
+  for tensor finite elements.
 
 
 Version 4.2 released on May 23, 2022

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,14 +25,13 @@ Version 4.2.1 (development)
 
 - Added a compilation parameter for the default font size.
 
-- Added visualization of quadrature data (QuadratureFunction in MFEM). They can
-  be loaded from a file through the new command line argument '-q' or in a socket
-  stream with the keyword 'quadrature' (instead of 'solution'). Three options of
-  visualization are offered (which can be switched by 'Q' key): piece-wise constant
-  function on a refined mesh (closed Gauss-Legendre refinement), discontinuous
-  elements with DOFs collocated with the quadrature on the original mesh, or
-  projection to discontinuous elements. High-order quadrature functions are supported
-  only for tensor finite elements with the first two options.
+- Added visualization of quadrature data (QuadratureFunction in MFEM). Both
+  loading from file, with the new command line argument '-q', or from a socket
+  stream, with the keyword 'quadrature', are supported. Three visualization
+  options are provided: piece-wise constants on a refined mesh (LOR), L2 field
+  with DOFs collocated (interpolation), or projection to discontinuous elements
+  (L2 projection). Use 'Q' to switch between them. High-order quadrature data is
+  supported only for tensor finite elements with the first two options.
 
 
 Version 4.2 released on May 23, 2022

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,13 @@ Version 4.2.1 (development)
 
 - Added a compilation parameter for the default font size.
 
+- Added visualization of quadratures. They can be loaded from a file through the
+  new command line argument '-q' or in a socket stream with the keyword 'quadrature'
+  (instead of solution). Two options of visualization are offered (which can be
+  switched by 'Q' key): piece-wise constant function on a refined mesh (closed
+  Gauss-Legendre refinement), or discontinuous elements with DOFs collocated with
+  the quadrature on the original mesh.
+
 
 Version 4.2 released on May 23, 2022
 ====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,7 +31,9 @@ Version 4.2.1 (development)
   options are provided: piece-wise constants on a refined mesh (LOR), L2 field
   with DOFs collocated (interpolation), or projection to discontinuous elements
   (L2 projection). Use 'Q' to switch between them. High-order quadrature data is
-  supported only for tensor finite elements with the first two options.
+  supported only for tensor finite elements with the first two options. With the
+  first option, only the mesh lines of the original mesh are visualized. This
+  feature is also supported for the element-wise cutting plane (cplane=2).
 
 
 Version 4.2 released on May 23, 2022

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ Key commands
   vector formats (SVG, EPS) are also possible, but keep in mind that the
   printing takes a while and the generated files are big.
 - <kbd>Q</kbd> – Cycle between representations of the visualized *quadrature data*. The options are:
-  - piece-wise constant refined
-  - L2 element dof collocation
-  - L2 element projection
+  - piece-wise constant refined (LOR)
+  - L2 element dof collocation (interpolation)
+  - L2 element projection (L2 projection)
 - <kbd>q</kbd> – Exit
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Key commands
 - <kbd>Ctrl</kbd> + <kbd>p</kbd> – Print to a PDF file using `gl2ps`. Other
   vector formats (SVG, EPS) are also possible, but keep in mind that the
   printing takes a while and the generated files are big.
+- <kbd>Q</kbd> – Cycle between representations of the quadrature (piece-wise constant refined/L2 element dof collocation) 
 - <kbd>q</kbd> – Exit
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ Key commands
 - <kbd>Ctrl</kbd> + <kbd>p</kbd> – Print to a PDF file using `gl2ps`. Other
   vector formats (SVG, EPS) are also possible, but keep in mind that the
   printing takes a while and the generated files are big.
-- <kbd>Q</kbd> – Cycle between representations of the quadrature (piece-wise constant refined/L2 element dof collocation) 
+- <kbd>Q</kbd> – Cycle between representations of the quadrature (piece-wise constant refined
+  / L2 element dof collocation / L2 element projection) 
 - <kbd>q</kbd> – Exit
 
 ## Advanced

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1376,18 +1376,21 @@ int main (int argc, char *argv[])
       return 0;
    }
 
+   //turn off the server mode if other options are present
+   if (input & ~INPUT_SERVER_MODE) { input &= ~INPUT_SERVER_MODE; }
+
    // print help for wrong input
    if (!(input == INPUT_SERVER_MODE
-         || input == (INPUT_SERVER_MODE | INPUT_MESH)
-         || input == (INPUT_SERVER_MODE | INPUT_MESH | INPUT_SCALAR_SOL)
-         || input == (INPUT_SERVER_MODE | INPUT_MESH | INPUT_VECTOR_SOL)
-         || input == (INPUT_SERVER_MODE | INPUT_MESH | INPUT_PARALLEL)
+         || input == (INPUT_MESH)
+         || input == (INPUT_MESH | INPUT_SCALAR_SOL)
+         || input == (INPUT_MESH | INPUT_VECTOR_SOL)
+         || input == (INPUT_MESH | INPUT_PARALLEL)
          || (stream_state.is_gf
-             && (input == (INPUT_SERVER_MODE | INPUT_MESH)
-                 || input == (INPUT_SERVER_MODE | INPUT_MESH | INPUT_PARALLEL)))
+             && (input == (INPUT_MESH)
+                 || input == (INPUT_MESH | INPUT_PARALLEL)))
          || (stream_state.is_qf
-             && (input == (INPUT_SERVER_MODE | INPUT_MESH)
-                 || input == (INPUT_SERVER_MODE | INPUT_MESH | INPUT_PARALLEL)))))
+             && (input == (INPUT_MESH)
+                 || input == (INPUT_MESH | INPUT_PARALLEL)))))
    {
       cout << "Invalid combination of mesh/solution options!\n\n";
       PrintSampleUsage(cout);

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -337,6 +337,7 @@ int ScriptReadQuadrature(istream &scr, StreamState& state)
       return 1;
    }
    state.mesh.reset(new Mesh(imesh, 1, 0, state.fix_elem_orient));
+   state.mesh_quad.reset();
 
    // read the quadrature (QuadratureFunction)
    scr >> ws >> sword;
@@ -1590,6 +1591,7 @@ void ReadSerial(StreamState& state)
    }
 
    state.mesh.reset(new Mesh(meshin, 1, 0, state.fix_elem_orient));
+   state.mesh_quad.reset();
 
    if (state.is_gf || state.is_qf || (input & INPUT_SCALAR_SOL) ||
        (input & INPUT_VECTOR_SOL))
@@ -1923,6 +1925,7 @@ int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
    {
       // create the combined mesh and gf
       state.mesh.reset(new Mesh(mesh_array, np));
+      state.mesh_quad.reset();
       if (sol_prefix)
       {
          state.CollectQuadratures(qf_array, np);

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1138,19 +1138,7 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
          else
          {
             new_session.state.ReadStreams(input_streams);
-            ofs.precision(8);
-            if (new_session.state.quad_f)
-            {
-               ofs << "quadrature\n";
-               new_session.state.mesh->Print(ofs);
-               new_session.state.quad_f->Save(ofs);
-            }
-            else if (new_session.state.grid_f)
-            {
-               ofs << "solution\n";
-               new_session.state.mesh->Print(ofs);
-               new_session.state.grid_f->Save(ofs);
-            }
+            new_session.state.WriteStream(ofs);
          }
          ofs.close();
          cout << "Data saved in " << tmp_file << endl;

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -364,6 +364,7 @@ int ScriptReadQuadrature(istream &scr, StreamState& state)
       state.SetQuadFunction(new QuadratureFunction(state.mesh.get(), isol));
    }
 
+   state.SetQuadSolution();
    state.Extrude1DMeshAndSolution();
 
    return 0;
@@ -432,6 +433,7 @@ int ScriptReadParQuadrature(istream &scr, StreamState& state)
                                          quad_prefix.c_str(), state);
    if (!err_read)
    {
+      state.SetQuadSolution();
       state.Extrude1DMeshAndSolution();
    }
    return err_read;

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1471,7 +1471,11 @@ void PrintSampleUsage(ostream &os)
       "Visualize mesh and solution (grid function):\n"
       "   glvis -m <mesh_file> -g <grid_function_file> [-gc <component>]\n"
       "Visualize parallel mesh and solution (grid function):\n"
-      "   glvis -np <#proc> -m <mesh_prefix> [-g <grid_function_prefix>]\n\n"
+      "   glvis -np <#proc> -m <mesh_prefix> [-g <grid_function_prefix>]\n"
+      "Visualize mesh and quadrature function:\n"
+      "   glvis -m <mesh_file> -q <quadrature_function_file> [-qc <component>]\n"
+      "Visualize parallel mesh and quadrature function:\n"
+      "   glvis -np <#proc> -m <mesh_prefix> [-q <quadrature_function_prefix>]\n\n"
       "All Options:\n";
 }
 

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -240,12 +240,14 @@ bool GLVisInitVis(StreamState::FieldType field_type,
          if (stream_state.grid_f)
          {
             stream_state.ProjectVectorFEGridFunction();
-            vs = new VisualizationSceneVector3d(*stream_state.grid_f);
+            vs = new VisualizationSceneVector3d(*stream_state.grid_f,
+                                                stream_state.mesh_quad.get());
          }
          else
          {
             vs = new VisualizationSceneVector3d(*stream_state.mesh, stream_state.solu,
-                                                stream_state.solv, stream_state.solw);
+                                                stream_state.solv, stream_state.solw,
+                                                stream_state.mesh_quad.get());
          }
       }
    }

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1609,6 +1609,8 @@ void SetQuadFunction(StreamState& state)
    {
       input |= INPUT_VECTOR_SOL;
    }
+
+   state.SetQuadSolution();
 }
 
 void ReadParallel(int np, StreamState& state)

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -113,6 +113,9 @@ int ReadParMeshAndGridFunction(int np, const char *mesh_prefix,
 int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
                                const char *sol_prefix, StreamState& state);
 
+// switch representation of the quadrature function
+void SwitchQuadSolution();
+
 // Visualize the data in the global variables mesh, sol/grid_f, etc
 bool GLVisInitVis(StreamState::FieldType field_type,
                   StreamCollection input_streams)
@@ -137,6 +140,11 @@ bool GLVisInitVis(StreamState::FieldType field_type,
       GetAppWindow()->setOnKeyDown(SDLK_SPACE, ThreadsPauseFunc);
       glvis_command = new GLVisCommand(&vs, stream_state, &stream_state.keep_attr);
       comm_thread = new communication_thread(std::move(input_streams), glvis_command);
+   }
+
+   if (stream_state.quad_f)
+   {
+      GetAppWindow()->setOnKeyDown('Q', SwitchQuadSolution);
    }
 
    double mesh_range = -1.0;
@@ -1939,4 +1947,13 @@ int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
    }
 
    return read_err;
+}
+
+void SwitchQuadSolution()
+{
+   int iqs = ((int)stream_state.GetQuadSolution()+1)
+             % ((int)StreamState::QuadSolution::MAX);
+   stream_state.SetQuadSolution((StreamState::QuadSolution)iqs);
+   stream_state.ResetMeshAndSolution(vs);
+   SendExposeEvent();
 }

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -117,8 +117,8 @@ int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
 bool GLVisInitVis(StreamState::FieldType field_type,
                   StreamCollection input_streams)
 {
-   if (field_type < StreamState::FieldType::MIN
-       || field_type > StreamState::FieldType::MAX)
+   if (field_type <= StreamState::FieldType::MIN
+       || field_type >= StreamState::FieldType::MAX)
    {
       return false;
    }

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1139,17 +1139,17 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
          {
             new_session.state.ReadStreams(input_streams);
             ofs.precision(8);
-            if (new_session.state.grid_f)
-            {
-               ofs << "solution\n";
-               new_session.state.mesh->Print(ofs);
-               new_session.state.grid_f->Save(ofs);
-            }
             if (new_session.state.quad_f)
             {
                ofs << "quadrature\n";
                new_session.state.mesh->Print(ofs);
                new_session.state.quad_f->Save(ofs);
+            }
+            else if (new_session.state.grid_f)
+            {
+               ofs << "solution\n";
+               new_session.state.mesh->Print(ofs);
+               new_session.state.grid_f->Save(ofs);
             }
          }
          ofs.close();

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -186,7 +186,7 @@ bool GLVisInitVis(StreamState::FieldType field_type,
       {
          VisualizationSceneSolution3d * vss;
          vs = vss = new VisualizationSceneSolution3d(*stream_state.mesh,
-                                                     stream_state.sol);
+                                                     stream_state.sol, stream_state.mesh_quad.get());
          if (stream_state.grid_f)
          {
             vss->SetGridFunction(stream_state.grid_f.get());

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -161,11 +161,12 @@ bool GLVisInitVis(StreamState::FieldType field_type,
          if (stream_state.normals.Size() > 0)
          {
             vs = vss = new VisualizationSceneSolution(*stream_state.mesh, stream_state.sol,
-                                                      &stream_state.normals);
+                                                      stream_state.mesh_quad.get(), &stream_state.normals);
          }
          else
          {
-            vs = vss = new VisualizationSceneSolution(*stream_state.mesh, stream_state.sol);
+            vs = vss = new VisualizationSceneSolution(*stream_state.mesh, stream_state.sol,
+                                                      stream_state.mesh_quad.get());
          }
          if (stream_state.grid_f)
          {

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -255,7 +255,7 @@ bool GLVisInitVis(StreamState::FieldType field_type,
       if (stream_state.grid_f)
       {
          vs->AutoRefine();
-         vs->SetShading(2, true);
+         vs->SetShading(VisualizationSceneScalarData::Shading::Noncomforming, true);
       }
       if (mesh_range > 0.0)
       {
@@ -686,20 +686,21 @@ void ExecuteScriptCommand()
       {
          scr >> ws >> word;
          cout << "Script: shading: " << flush;
-         int s = -1;
+         VisualizationSceneScalarData::Shading s =
+            VisualizationSceneScalarData::Shading::Invalid;
          if (word == "flat")
          {
-            s = 0;
+            s = VisualizationSceneScalarData::Shading::Flat;
          }
          else if (word == "smooth")
          {
-            s = 1;
+            s = VisualizationSceneScalarData::Shading::Smooth;
          }
          else if (word == "cool")
          {
-            s = 2;
+            s = VisualizationSceneScalarData::Shading::Noncomforming;
          }
-         if (s != -1)
+         if (s != VisualizationSceneScalarData::Shading::Invalid)
          {
             vs->SetShading(s, false);
             cout << word << endl;

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -232,7 +232,7 @@ bool GLVisInitVis(StreamState::FieldType field_type,
          else
          {
             vs = new VisualizationSceneVector(*stream_state.mesh, stream_state.solu,
-                                              stream_state.solv);
+                                              stream_state.solv, stream_state.mesh_quad.get());
          }
       }
       else if (stream_state.mesh->SpaceDimension() == 3)

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1954,6 +1954,7 @@ void SwitchQuadSolution()
    int iqs = ((int)stream_state.GetQuadSolution()+1)
              % ((int)StreamState::QuadSolution::MAX);
    stream_state.SetQuadSolution((StreamState::QuadSolution)iqs);
+   stream_state.Extrude1DMeshAndSolution();
    stream_state.ResetMeshAndSolution(vs);
    SendExposeEvent();
 }

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -46,19 +46,19 @@ void StreamState::Extrude1DMeshAndSolution()
 
    Mesh *mesh2d = Extrude1D(mesh.get(), 1, 0.1*(xmax - xmin));
 
-   if (grid_f)
-   {
-      GridFunction *grid_f_2d =
-         Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
-
-      grid_f.reset(grid_f_2d);
-   }
-   else if (quad_f)
+   if (quad_f)
    {
       QuadratureFunction *quad_f_2d =
          Extrude1DQuadFunction(mesh.get(), mesh2d, quad_f.get(), 1);
 
       quad_f.reset(quad_f_2d);
+   }
+   else if (grid_f)
+   {
+      GridFunction *grid_f_2d =
+         Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
+
+      grid_f.reset(grid_f_2d);
    }
    else if (sol.Size() == mesh->GetNV())
    {

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -23,17 +23,17 @@ QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
 
 StreamState &StreamState::operator=(StreamState &&ss)
 {
-   internal.mesh = move(ss.internal.mesh);
-   internal.mesh_quad = move(ss.internal.mesh_quad);
-   internal.grid_f = move(ss.internal.grid_f);
-   internal.quad_f = move(ss.internal.quad_f);
+   internal.mesh = std::move(ss.internal.mesh);
+   internal.mesh_quad = std::move(ss.internal.mesh_quad);
+   internal.grid_f = std::move(ss.internal.grid_f);
+   internal.quad_f = std::move(ss.internal.quad_f);
 
-   sol = move(ss.sol);
-   solu = move(ss.solu);
-   solv = move(ss.solv);
-   solw = move(ss.solw);
-   normals = move(ss.normals);
-   keys = move(ss.keys);
+   sol = std::move(ss.sol);
+   solu = std::move(ss.solu);
+   solv = std::move(ss.solv);
+   solw = std::move(ss.solw);
+   normals = std::move(ss.normals);
+   keys = std::move(ss.keys);
 
    is_gf = ss.is_gf;
    is_qf = ss.is_qf;
@@ -47,12 +47,12 @@ StreamState &StreamState::operator=(StreamState &&ss)
 void StreamState::SetMesh(mfem::Mesh *mesh_)
 {
    internal.mesh.reset(mesh_);
-   SetMesh(move(internal.mesh));
+   SetMesh(std::move(internal.mesh));
 }
 
 void StreamState::SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh)
 {
-   internal.mesh = move(pmesh);
+   internal.mesh = std::move(pmesh);
    internal.mesh_quad.reset();
    if (grid_f && grid_f->FESpace()->GetMesh() != mesh.get()) { SetGridFunction(NULL); }
    if (quad_f && quad_f->GetSpace()->GetMesh() != mesh.get()) { SetQuadFunction(NULL); }
@@ -61,12 +61,12 @@ void StreamState::SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh)
 void StreamState::SetGridFunction(mfem::GridFunction *gf)
 {
    internal.grid_f.reset(gf);
-   SetGridFunction(move(internal.grid_f));
+   SetGridFunction(std::move(internal.grid_f));
 }
 
 void StreamState::SetGridFunction(std::unique_ptr<mfem::GridFunction> &&pgf)
 {
-   internal.grid_f = move(pgf);
+   internal.grid_f = std::move(pgf);
    internal.quad_f.reset();
    quad_sol = QuadSolution::NONE;
 }
@@ -89,7 +89,7 @@ void StreamState::SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction>
       internal.grid_f.reset();
       quad_sol = QuadSolution::NONE;
    }
-   internal.quad_f = move(pqf);
+   internal.quad_f = std::move(pqf);
 }
 
 void StreamState::Extrude1DMeshAndSolution()

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -283,6 +283,7 @@ StreamState::FieldType StreamState::ReadStream(istream &is,
    else if (data_type == "quadrature")
    {
       mesh.reset(new Mesh(is, 1, 0, fix_elem_orient));
+      mesh_quad.reset();
       quad_f.reset(new QuadratureFunction(mesh.get(), is));
       SetQuadSolution();
       field_type = (quad_f->GetVDim() == 1) ? FieldType::SCALAR : FieldType::VECTOR;
@@ -484,6 +485,7 @@ StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
    }
 
    mesh.reset(new Mesh(mesh_array, nproc));
+   mesh_quad.reset();
    if (gf_count > 0)
    {
       grid_f.reset(new GridFunction(mesh.get(), gf_array, nproc));

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -52,6 +52,7 @@ void StreamState::Extrude1DMeshAndSolution()
          Extrude1DQuadFunction(mesh.get(), mesh2d, quad_f.get(), 1);
 
       quad_f.reset(quad_f_2d);
+      SetQuadSolution();
    }
    else if (grid_f)
    {
@@ -149,6 +150,12 @@ void StreamState::SetMeshSolution()
 
 void StreamState::SetQuadSolution(QuadSolution type)
 {
+   /*if(type == QuadSolution::LOR_GLL)
+   {
+      //assume identical order
+      const int order = quad_f->GetIntRule(0).Size();
+      Mesh *mesh_lor = new Mesh(Mesh::MakeRefined(*mesh, order, ));
+   }*/
    //if(type == QuadSolution::HO_L2)
    {
       //assume identical order

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -570,6 +570,8 @@ bool StreamState::SetNewMeshAndSolution(StreamState new_state,
    {
       std::unique_ptr<mfem::Mesh> new_m = std::move(new_state.mesh);
       std::unique_ptr<mfem::GridFunction> new_g = std::move(new_state.grid_f);
+      std::unique_ptr<mfem::Mesh> new_mq = std::move(new_state.mesh_quad);
+      std::unique_ptr<mfem::QuadratureFunction> new_q = std::move(new_state.quad_f);
       if (new_m->SpaceDimension() == 2)
       {
          if (new_g->VectorDim() == 1)
@@ -606,6 +608,8 @@ bool StreamState::SetNewMeshAndSolution(StreamState new_state,
       }
       grid_f = std::move(new_g);
       mesh = std::move(new_m);
+      quad_f = std::move(new_q);
+      mesh_quad = std::move(new_mq);
       return true;
    }
    else

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -195,6 +195,8 @@ void StreamState::SetQuadSolution(QuadSolution type)
       gf->MakeOwner(fec);
       grid_f.reset(gf);
    }
+
+   quad_sol = type;
 }
 
 // Read the content of an input stream (e.g. from socket/file)

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -164,6 +164,8 @@ void StreamState::SetQuadSolution(QuadSolution type)
       FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
                                                        quad_f->GetVDim(), Ordering::byVDIM);
       MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
+      cout << "Representing quadrature by grid function of order "
+           << order << endl;
       GridFunction *gf = new GridFunction(fes, *quad_f, 0);
       gf->MakeOwner(fec);
       grid_f.reset(gf);

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -696,7 +696,7 @@ void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
       }
       else
       {
-         SetGridFunction(ProjectVectorFEGridFunction(std::move(internal.grid_f)));
+         ProjectVectorFEGridFunction();
 
          VisualizationSceneVector3d *vss =
             dynamic_cast<VisualizationSceneVector3d *>(vs);

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -156,9 +156,9 @@ void StreamState::SetQuadSolution(QuadSolution type)
       FiniteElementCollection *fec = new L2_FECollection(order, mesh->Dimension());
       FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
                                                        quad_f->GetVDim(), Ordering::byVDIM);
-      GridFunction *gf = new GridFunction(fes);
+      MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
+      GridFunction *gf = new GridFunction(fes, *quad_f, 0);
       gf->MakeOwner(fec);
-      *gf = *quad_f;
       grid_f.reset(gf);
    }
 }

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -23,10 +23,7 @@ QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
 
 StreamState &StreamState::operator=(StreamState &&ss)
 {
-   internal.mesh = std::move(ss.internal.mesh);
-   internal.mesh_quad = std::move(ss.internal.mesh_quad);
-   internal.grid_f = std::move(ss.internal.grid_f);
-   internal.quad_f = std::move(ss.internal.quad_f);
+   internal = std::move(ss.internal);
 
    sol = std::move(ss.sol);
    solu = std::move(ss.solu);
@@ -40,6 +37,8 @@ StreamState &StreamState::operator=(StreamState &&ss)
    fix_elem_orient = ss.fix_elem_orient;
    save_coloring = ss.save_coloring;
    keep_attr = ss.keep_attr;
+
+   quad_sol = ss.quad_sol;
 
    return *this;
 }

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -572,53 +572,56 @@ bool StreamState::SetNewMeshAndSolution(StreamState new_state,
    if (new_state.mesh->SpaceDimension() == mesh->SpaceDimension() &&
        new_state.grid_f->VectorDim() == grid_f->VectorDim())
    {
-      std::unique_ptr<mfem::Mesh> new_m = std::move(new_state.mesh);
-      std::unique_ptr<mfem::GridFunction> new_g = std::move(new_state.grid_f);
-      std::unique_ptr<mfem::Mesh> new_mq = std::move(new_state.mesh_quad);
-      std::unique_ptr<mfem::QuadratureFunction> new_q = std::move(new_state.quad_f);
-      if (new_m->SpaceDimension() == 2)
-      {
-         if (new_g->VectorDim() == 1)
-         {
-            VisualizationSceneSolution *vss =
-               dynamic_cast<VisualizationSceneSolution *>(vs);
-            new_g->GetNodalValues(sol);
-            vss->NewMeshAndSolution(new_m.get(), &sol, new_g.get());
-         }
-         else
-         {
-            VisualizationSceneVector *vsv =
-               dynamic_cast<VisualizationSceneVector *>(vs);
-            vsv->NewMeshAndSolution(*new_g);
-         }
-      }
-      else
-      {
-         if (new_g->VectorDim() == 1)
-         {
-            VisualizationSceneSolution3d *vss =
-               dynamic_cast<VisualizationSceneSolution3d *>(vs);
-            new_g->GetNodalValues(sol);
-            vss->NewMeshAndSolution(new_m.get(), &sol, new_g.get());
-         }
-         else
-         {
-            new_g = ProjectVectorFEGridFunction(std::move(new_g));
+      grid_f = std::move(new_state.grid_f);
+      mesh = std::move(new_state.mesh);
+      quad_f = std::move(new_state.quad_f);
+      mesh_quad = std::move(new_state.mesh_quad);
 
-            VisualizationSceneVector3d *vss =
-               dynamic_cast<VisualizationSceneVector3d *>(vs);
-            vss->NewMeshAndSolution(new_m.get(), new_g.get());
-         }
-      }
-      grid_f = std::move(new_g);
-      mesh = std::move(new_m);
-      quad_f = std::move(new_q);
-      mesh_quad = std::move(new_mq);
+      ResetMeshAndSolution(vs);
+
       return true;
    }
    else
    {
       return false;
+   }
+}
+
+void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
+{
+   if (mesh->SpaceDimension() == 2)
+   {
+      if (grid_f->VectorDim() == 1)
+      {
+         VisualizationSceneSolution *vss =
+            dynamic_cast<VisualizationSceneSolution *>(vs);
+         grid_f->GetNodalValues(sol);
+         vss->NewMeshAndSolution(mesh.get(), &sol, grid_f.get());
+      }
+      else
+      {
+         VisualizationSceneVector *vsv =
+            dynamic_cast<VisualizationSceneVector *>(vs);
+         vsv->NewMeshAndSolution(*grid_f);
+      }
+   }
+   else
+   {
+      if (grid_f->VectorDim() == 1)
+      {
+         VisualizationSceneSolution3d *vss =
+            dynamic_cast<VisualizationSceneSolution3d *>(vs);
+         grid_f->GetNodalValues(sol);
+         vss->NewMeshAndSolution(mesh.get(), &sol, grid_f.get());
+      }
+      else
+      {
+         grid_f = ProjectVectorFEGridFunction(std::move(grid_f));
+
+         VisualizationSceneVector3d *vss =
+            dynamic_cast<VisualizationSceneVector3d *>(vs);
+         vss->NewMeshAndSolution(mesh.get(), grid_f.get());
+      }
    }
 }
 

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -152,7 +152,7 @@ void StreamState::CollectQuadratures(QuadratureFunction *qf_array[],
    {
       const real_t *l_data = qf_array[p]->GetData();
       const int l_size = qf_array[p]->Size();
-      MFEM_ASSERT(g_data + l_size >= quad_f->GetData() + quad_f->Size(),
+      MFEM_ASSERT(g_data + l_size <= quad_f->GetData() + quad_f->Size(),
                   "Local parts do not fit to the global quadrature function!");
       memcpy(g_data, l_data, l_size * sizeof(real_t));
       g_data += l_size;

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -505,6 +505,23 @@ StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
    return field_type;
 }
 
+void StreamState::WriteStream(std::ostream &os)
+{
+   os.precision(8);
+   if (quad_f)
+   {
+      os << "quadrature\n";
+      mesh->Print(os);
+      quad_f->Save(os);
+   }
+   else if (grid_f)
+   {
+      os << "solution\n";
+      mesh->Print(os);
+      grid_f->Save(os);
+   }
+}
+
 // Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec
 // or Raviart-Thomas space) with a discontinuous piece-wise polynomial Cartesian
 // product vector grid function of the same order.

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -719,7 +719,7 @@ void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
          VisualizationSceneSolution *vss =
             dynamic_cast<VisualizationSceneSolution *>(vs);
          grid_f->GetNodalValues(sol);
-         vss->NewMeshAndSolution(mesh.get(), &sol, grid_f.get());
+         vss->NewMeshAndSolution(mesh.get(), mesh_quad.get(), &sol, grid_f.get());
       }
       else
       {

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -725,7 +725,7 @@ void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
       {
          VisualizationSceneVector *vsv =
             dynamic_cast<VisualizationSceneVector *>(vs);
-         vsv->NewMeshAndSolution(*grid_f);
+         vsv->NewMeshAndSolution(*grid_f, mesh_quad.get());
       }
    }
    else

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -735,7 +735,7 @@ void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
          VisualizationSceneSolution3d *vss =
             dynamic_cast<VisualizationSceneSolution3d *>(vs);
          grid_f->GetNodalValues(sol);
-         vss->NewMeshAndSolution(mesh.get(), &sol, grid_f.get());
+         vss->NewMeshAndSolution(mesh.get(), mesh_quad.get(), &sol, grid_f.get());
       }
       else
       {

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -222,6 +222,18 @@ void StreamState::SetQuadSolution(QuadSolution type)
       internal.mesh_quad.reset();
    }
 
+   //check for tensor-product basis
+   if (order > 0)
+   {
+      Array<Geometry::Type> geoms;
+      mesh->GetGeometries(mesh->Dimension(), geoms);
+      for (auto geom : geoms)
+         if (!Geometry::IsTensorProduct(geom))
+         {
+            MFEM_ABORT("High-order quadratures are available only for tensor-product finite elements");
+         }
+   }
+
    switch (type)
    {
       case QuadSolution::LOR_ClosedGL:
@@ -250,19 +262,6 @@ void StreamState::SetQuadSolution(QuadSolution type)
       case QuadSolution::HO_L2:
       {
          FiniteElementCollection *fec = new L2_FECollection(order, mesh->Dimension());
-         if (order > 0)
-         {
-            Array<Geometry::Type> geoms;
-            mesh->GetGeometries(mesh->Dimension(), geoms);
-            for (auto geom : geoms)
-               if (!Geometry::IsTensorProduct(geom))
-               {
-                  cout << "High-order representation is available only for tensor-product bases"
-                       << endl;
-                  SetQuadSolution(QuadSolution::LOR_ClosedGL);
-                  return;
-               }
-         }
          FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
                                                           quad_f->GetVDim(), Ordering::byVDIM);
          MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
@@ -274,7 +273,7 @@ void StreamState::SetQuadSolution(QuadSolution type)
       }
       break;
       default:
-         cout << "Unknon quadrarture function representation" << endl;
+         cout << "Unknown quadrature function representation" << endl;
          return;
    }
 

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -152,6 +152,12 @@ void StreamState::SetQuadSolution(QuadSolution type)
 {
    //assume identical order
    const int order = quad_f->GetIntRule(0).GetOrder()/2;//<---Gauss-Legendre
+   //use the original mesh when available
+   if (mesh_quad.get())
+   {
+      mesh.swap(mesh_quad);
+      mesh_quad.reset();
+   }
    if (type == QuadSolution::LOR_GLL)
    {
       const int ref_factor = order + 1;
@@ -168,6 +174,7 @@ void StreamState::SetQuadSolution(QuadSolution type)
          GridFunction *gf = new GridFunction(fes, *quad_f, 0);
          gf->MakeOwner(fec);
          grid_f.reset(gf);
+         mesh.swap(mesh_quad);
          mesh.reset(mesh_lor);
       }
       else
@@ -511,7 +518,14 @@ void StreamState::WriteStream(std::ostream &os)
    if (quad_f)
    {
       os << "quadrature\n";
-      mesh->Print(os);
+      if (mesh_quad.get())
+      {
+         mesh_quad->Print(os);
+      }
+      else
+      {
+         mesh->Print(os);
+      }
       quad_f->Save(os);
    }
    else if (grid_f)

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -743,7 +743,7 @@ void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
 
          VisualizationSceneVector3d *vss =
             dynamic_cast<VisualizationSceneVector3d *>(vs);
-         vss->NewMeshAndSolution(mesh.get(), grid_f.get());
+         vss->NewMeshAndSolution(mesh.get(), mesh_quad.get(), grid_f.get());
       }
    }
 }

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -28,12 +28,6 @@ void StreamState::Extrude1DMeshAndSolution()
       return;
    }
 
-   if (mesh_quad)
-   {
-      mesh.swap(mesh_quad);
-      mesh_quad.reset();
-   }
-
    // find xmin and xmax over the vertices of the 1D mesh
    double xmin = numeric_limits<double>::infinity();
    double xmax = -xmin;
@@ -52,14 +46,7 @@ void StreamState::Extrude1DMeshAndSolution()
 
    Mesh *mesh2d = Extrude1D(mesh.get(), 1, 0.1*(xmax - xmin));
 
-   if (quad_f)
-   {
-      QuadratureFunction *quad_f_2d =
-         Extrude1DQuadFunction(mesh.get(), mesh2d, quad_f.get(), 1);
-
-      quad_f.reset(quad_f_2d);
-   }
-   else if (grid_f)
+   if (grid_f)
    {
       GridFunction *grid_f_2d =
          Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
@@ -76,8 +63,8 @@ void StreamState::Extrude1DMeshAndSolution()
       sol = sol2d;
    }
 
+   if (!mesh_quad) { mesh.swap(mesh_quad); }
    mesh.reset(mesh2d);
-   if (quad_f) { SetQuadSolution(); }
 }
 
 void StreamState::CollectQuadratures(QuadratureFunction *qf_array[],

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -28,6 +28,12 @@ void StreamState::Extrude1DMeshAndSolution()
       return;
    }
 
+   if (mesh_quad)
+   {
+      mesh.swap(mesh_quad);
+      mesh_quad.reset();
+   }
+
    // find xmin and xmax over the vertices of the 1D mesh
    double xmin = numeric_limits<double>::infinity();
    double xmax = -xmin;
@@ -52,7 +58,6 @@ void StreamState::Extrude1DMeshAndSolution()
          Extrude1DQuadFunction(mesh.get(), mesh2d, quad_f.get(), 1);
 
       quad_f.reset(quad_f_2d);
-      SetQuadSolution();
    }
    else if (grid_f)
    {
@@ -72,6 +77,7 @@ void StreamState::Extrude1DMeshAndSolution()
    }
 
    mesh.reset(mesh2d);
+   if (quad_f) { SetQuadSolution(); }
 }
 
 void StreamState::CollectQuadratures(QuadratureFunction *qf_array[],

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -151,13 +151,13 @@ void StreamState::SetQuadSolution(QuadSolution type)
       mesh.swap(mesh_quad);
       mesh_quad.reset();
    }
-   if (type == QuadSolution::LOR_GLL)
+   if (type == QuadSolution::LOR_ClosedGL)
    {
       const int ref_factor = order + 1;
       if (ref_factor > 1)
       {
          Mesh *mesh_lor = new Mesh(Mesh::MakeRefined(*mesh, ref_factor,
-                                                     BasisType::GaussLobatto));
+                                                     BasisType::ClosedGL));
          FiniteElementCollection *fec = new L2_FECollection(0, mesh->Dimension());
          FiniteElementSpace *fes = new FiniteElementSpace(mesh_lor, fec,
                                                           quad_f->GetVDim(), Ordering::byVDIM);

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -49,9 +49,13 @@ struct StreamState
 
    enum class QuadSolution
    {
+      MIN = -1,
+      //----------
       LOR_GLL,
       HO_L2,
-   };
+      //----------
+      MAX
+   } quad_sol;
 
    /// Helper function for visualizing 1D data
    void Extrude1DMeshAndSolution();
@@ -64,6 +68,9 @@ struct StreamState
 
    /// Set a quadrature function solution producing a proxy grid function
    void SetQuadSolution(QuadSolution type = QuadSolution::LOR_GLL);
+
+   /// Get the current representation of quadrature solution
+   inline QuadSolution GetQuadSolution() const { return quad_sol; }
 
    FieldType ReadStream(std::istream &is, const std::string &data_type);
 

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -87,6 +87,12 @@ struct StreamState
    /// updated.
    bool SetNewMeshAndSolution(StreamState new_state,
                               VisualizationScene* vs);
+
+   /// Updates the given VisualizationScene pointer with the new data
+   /// of this object.
+   /// @note: Use with caution when the update is compatible
+   /// @see SetNewMeshAndSolution()
+   void ResetMeshAndSolution(VisualizationScene* vs);
 };
 
 // Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -26,6 +26,7 @@ struct StreamState
    mfem::Vector sol, solu, solv, solw, normals;
    std::string keys;
    std::unique_ptr<mfem::Mesh> mesh;
+   std::unique_ptr<mfem::Mesh> mesh_quad;
    std::unique_ptr<mfem::GridFunction> grid_f;
    std::unique_ptr<mfem::QuadratureFunction> quad_f;
    int is_gf{0};

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -63,7 +63,8 @@ public:
       MIN = -1,
       //----------
       LOR_ClosedGL,
-      HO_L2,
+      HO_L2_collocated,
+      HO_L2_projected,
       //----------
       MAX
    } quad_sol {QuadSolution::NONE};

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -27,7 +27,9 @@ struct StreamState
    std::string keys;
    std::unique_ptr<mfem::Mesh> mesh;
    std::unique_ptr<mfem::GridFunction> grid_f;
+   std::unique_ptr<mfem::QuadratureFunction> quad_f;
    int is_gf{0};
+   int is_qf{0};
    bool fix_elem_orient{false};
    bool save_coloring{false};
    bool keep_attr{false};

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -49,13 +49,14 @@ struct StreamState
 
    enum class QuadSolution
    {
+      NONE = -1,
       MIN = -1,
       //----------
       LOR_ClosedGL,
       HO_L2,
       //----------
       MAX
-   } quad_sol;
+   } quad_sol {QuadSolution::NONE};
 
    /// Helper function for visualizing 1D data
    void Extrude1DMeshAndSolution();

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -68,6 +68,8 @@ struct StreamState
 
    FieldType ReadStreams(const StreamCollection& input_streams);
 
+   void WriteStream(std::ostream &os);
+
    /// Sets a new mesh and solution from another StreamState object, and
    /// updates the given VisualizationScene pointer with the new data.
    ///

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -51,7 +51,7 @@ struct StreamState
    {
       MIN = -1,
       //----------
-      LOR_GLL,
+      LOR_ClosedGL,
       HO_L2,
       //----------
       MAX
@@ -67,7 +67,7 @@ struct StreamState
    void SetMeshSolution();
 
    /// Set a quadrature function solution producing a proxy grid function
-   void SetQuadSolution(QuadSolution type = QuadSolution::LOR_GLL);
+   void SetQuadSolution(QuadSolution type = QuadSolution::LOR_ClosedGL);
 
    /// Get the current representation of quadrature solution
    inline QuadSolution GetQuadSolution() const { return quad_sol; }

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -37,6 +37,9 @@ struct StreamState
    /// Helper function for visualizing 1D data
    void Extrude1DMeshAndSolution();
 
+   /// Helper function to build the quadrature function from pieces
+   void CollectQuadratures(mfem::QuadratureFunction *qf_array[], int npieces);
+
    /// Set a (checkerboard) solution when only the mesh is given
    void SetMeshSolution();
 

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -34,6 +34,18 @@ struct StreamState
    bool save_coloring{false};
    bool keep_attr{false};
 
+   enum class FieldType
+   {
+      UNKNOWN = -1,
+      MIN = -1,
+      //----------
+      SCALAR,
+      VECTOR,
+      MESH,
+      //----------
+      MAX
+   };
+
    /// Helper function for visualizing 1D data
    void Extrude1DMeshAndSolution();
 
@@ -43,9 +55,9 @@ struct StreamState
    /// Set a (checkerboard) solution when only the mesh is given
    void SetMeshSolution();
 
-   int ReadStream(std::istream &is, const std::string &data_type);
+   FieldType ReadStream(std::istream &is, const std::string &data_type);
 
-   int ReadStreams(const StreamCollection& input_streams);
+   FieldType ReadStreams(const StreamCollection& input_streams);
 
    /// Sets a new mesh and solution from another StreamState object, and
    /// updates the given VisualizationScene pointer with the new data.

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -46,6 +46,12 @@ struct StreamState
       MAX
    };
 
+   enum class QuadSolution
+   {
+      LOR_GLL,
+      HO_L2,
+   };
+
    /// Helper function for visualizing 1D data
    void Extrude1DMeshAndSolution();
 
@@ -54,6 +60,9 @@ struct StreamState
 
    /// Set a (checkerboard) solution when only the mesh is given
    void SetMeshSolution();
+
+   /// Set a quadrature function solution producing a proxy grid function
+   void SetQuadSolution(QuadSolution type = QuadSolution::LOR_GLL);
 
    FieldType ReadStream(std::istream &is, const std::string &data_type);
 

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -433,7 +433,15 @@ int GLVisCommand::Execute()
             }
             else
             {
-               new_state.SetQuadSolution();
+               auto qs = curr_state.GetQuadSolution();
+               if (qs != StreamState::QuadSolution::NONE)
+               {
+                  new_state.SetQuadSolution(qs);
+               }
+               else
+               {
+                  new_state.SetQuadSolution();
+               }
                new_state.Extrude1DMeshAndSolution();
             }
          }

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -86,7 +86,7 @@ int GLVisCommand::NewMeshAndSolution(StreamState &&ss)
       return -1;
    }
    command = NEW_MESH_AND_SOLUTION;
-   new_state = move(ss);
+   new_state = std::move(ss);
    if (signal() < 0)
    {
       return -2;

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -454,6 +454,7 @@ int GLVisCommand::Execute()
             else
             {
                new_state.SetQuadSolution();
+               new_state.Extrude1DMeshAndSolution();
             }
          }
          if (curr_state.SetNewMeshAndSolution(std::move(new_state), *vs))

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -580,20 +580,21 @@ int GLVisCommand::Execute()
       case SHADING:
       {
          cout << "Command: shading: " << flush;
-         int s = -1;
+         VisualizationSceneScalarData::Shading s =
+            VisualizationSceneScalarData::Shading::Invalid;
          if (shading == "flat")
          {
-            s = 0;
+            s = VisualizationSceneScalarData::Shading::Flat;
          }
          else if (shading == "smooth")
          {
-            s = 1;
+            s = VisualizationSceneScalarData::Shading::Smooth;
          }
          else if (shading == "cool")
          {
-            s = 2;
+            s = VisualizationSceneScalarData::Shading::Noncomforming;
          }
-         if (s != -1)
+         if (s != VisualizationSceneScalarData::Shading::Invalid)
          {
             (*vs)->SetShading(s, false);
             cout << shading << endl;

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -108,6 +108,8 @@ public:
    // called by worker threads
    int NewMeshAndSolution(std::unique_ptr<Mesh> _new_m,
                           std::unique_ptr<GridFunction> _new_g);
+   int NewMeshAndQuadrature(std::unique_ptr<Mesh> _new_m,
+                            std::unique_ptr<QuadratureFunction> _new_q);
    int Screenshot(const char *filename);
    int KeyCommands(const char *keys);
    int WindowSize(int w, int h);

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -106,10 +106,7 @@ public:
    bool FixElementOrientations() { return curr_state.fix_elem_orient; }
 
    // called by worker threads
-   int NewMeshAndSolution(std::unique_ptr<Mesh> _new_m,
-                          std::unique_ptr<GridFunction> _new_g);
-   int NewMeshAndQuadrature(std::unique_ptr<Mesh> _new_m,
-                            std::unique_ptr<QuadratureFunction> _new_q);
+   int NewMeshAndSolution(StreamState &&ss);
    int Screenshot(const char *filename);
    int KeyCommands(const char *keys);
    int WindowSize(int w, int h);

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1253,10 +1253,11 @@ void VisualizationSceneScalarData::SetAutoscale(int _autoscale)
 }
 
 VisualizationSceneScalarData::VisualizationSceneScalarData(
-   Mesh & m, Vector & s)
+   Mesh & m, Vector & s, Mesh *mc)
    : a_label_x("x"), a_label_y("y"), a_label_z("z")
 {
    mesh = &m;
+   mesh_coarse = mc;
    sol  = &s;
 
    Init();

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -54,6 +54,19 @@ public:
 
 class VisualizationSceneScalarData : public VisualizationScene
 {
+public:
+   enum class Shading
+   {
+      Invalid = -1,
+      Min = -1,
+      //---------
+      Flat,
+      Smooth,
+      Noncomforming,
+      //---------
+      Max
+   };
+
 protected:
    Mesh   *mesh;
    Vector *sol;
@@ -63,6 +76,7 @@ protected:
    std::string a_label_x, a_label_y, a_label_z;
 
    int scaling, colorbar, drawaxes;
+   Shading shading;
    int auto_ref_max, auto_ref_max_surf_elem;
 
    vector<gl3::GlDrawable*> updated_bufs;
@@ -127,18 +141,6 @@ protected:
    void Cone(gl3::GlDrawable& buf, glm::mat4 transform, double cval);
 
 public:
-   enum class Shading
-   {
-      Invalid = -1,
-      Min = -1,
-      //---------
-      Flat,
-      Smooth,
-      Noncomforming,
-      //---------
-      Max
-   };
-
    Plane *CuttingPlane;
    int key_r_state;
    /** Shrink factor with respect to the center of each element (2D) or the
@@ -195,6 +197,8 @@ public:
    void SetValueRange(double, double);
 
    virtual void SetShading(Shading, bool) = 0;
+   virtual void ToogleShading() { SetShading((Shading)(((int)shading + 1) % (int)Shading::Max), true); }
+   virtual Shading GetShading() { return shading; }
    virtual void SetRefineFactors(int, int) = 0;
    void SetAutoRefineLimits(int max_ref, int max_surf_elem)
    {

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -68,8 +68,8 @@ public:
    };
 
 protected:
-   Mesh   *mesh;
-   Vector *sol;
+   Mesh   *mesh{}, *mesh_coarse{};
+   Vector *sol{};
 
    double minv, maxv;
 
@@ -151,7 +151,7 @@ public:
 
    VisualizationSceneScalarData()
       : a_label_x("x"), a_label_y("y"), a_label_z("z") {}
-   VisualizationSceneScalarData (Mesh & m, Vector & s);
+   VisualizationSceneScalarData (Mesh & m, Vector & s, Mesh *mc = NULL);
 
    virtual ~VisualizationSceneScalarData();
 

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -127,6 +127,18 @@ protected:
    void Cone(gl3::GlDrawable& buf, glm::mat4 transform, double cval);
 
 public:
+   enum class Shading
+   {
+      Invalid = -1,
+      Min = -1,
+      //---------
+      Flat,
+      Smooth,
+      Noncomforming,
+      //---------
+      Max
+   };
+
    Plane *CuttingPlane;
    int key_r_state;
    /** Shrink factor with respect to the center of each element (2D) or the
@@ -182,7 +194,7 @@ public:
    virtual void UpdateValueRange(bool prepare) = 0;
    void SetValueRange(double, double);
 
-   virtual void SetShading(int, bool) = 0;
+   virtual void SetShading(Shading, bool) = 0;
    virtual void SetRefineFactors(int, int) = 0;
    void SetAutoRefineLimits(int max_ref, int max_surf_elem)
    {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -76,12 +76,12 @@ std::string VisualizationSceneSolution::GetHelpString() const
       << "| O -  Switch 'o' func. (NC shading) |" << endl
       << "| p/P  Cycle through color palettes  |" << endl
       << "| q -  Quits                         |" << endl
+      << "| Q -  Cycle quadrature data mode    |" << endl
       << "| r -  Reset the plot to 3D view     |" << endl
       << "| R -  Reset the plot to 2D view     |" << endl
       << "| s -  Turn on/off unit cube scaling |" << endl
       << "| S -  Take snapshot/Record a movie  |" << endl
       << "| t -  Cycle materials and lights    |" << endl
-      << "| Q -  Cycle quadrature data repre.  |" << endl
       << "| y/Y  Rotate the cutting plane      |" << endl
       << "| z/Z  Move the cutting plane        |" << endl
       << "| \\ -  Set light source position     |" << endl

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -356,7 +356,7 @@ static void KeyZPressed()
 
 static void KeyF3Pressed()
 {
-   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
+   if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       vssol->shrink *= 0.9;
       vssol->Prepare();
@@ -370,7 +370,7 @@ static void KeyF3Pressed()
 
 static void KeyF4Pressed()
 {
-   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
+   if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       vssol->shrink *= 1.11111111111111111111111;
       vssol->Prepare();
@@ -383,7 +383,7 @@ static void KeyF4Pressed()
 
 static void KeyF11Pressed()
 {
-   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
+   if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if (vssol->matc.Width() == 0)
       {
@@ -401,7 +401,7 @@ static void KeyF11Pressed()
 
 static void KeyF12Pressed()
 {
-   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
+   if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if (vssol->matc.Width() == 0)
       {
@@ -877,7 +877,7 @@ void VisualizationSceneSolution::ToggleShading()
 {
    if (rsol)
    {
-      SetShading((Shading)(((int)shading + 1) % (int)Shading::Max), true);
+      VisualizationSceneScalarData::ToogleShading();
    }
    else
    {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -356,7 +356,7 @@ static void KeyZPressed()
 
 static void KeyF3Pressed()
 {
-   if (vssol->shading == 2)
+   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       vssol->shrink *= 0.9;
       vssol->Prepare();
@@ -370,7 +370,7 @@ static void KeyF3Pressed()
 
 static void KeyF4Pressed()
 {
-   if (vssol->shading == 2)
+   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       vssol->shrink *= 1.11111111111111111111111;
       vssol->Prepare();
@@ -383,7 +383,7 @@ static void KeyF4Pressed()
 
 static void KeyF11Pressed()
 {
-   if (vssol->shading == 2)
+   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if (vssol->matc.Width() == 0)
       {
@@ -401,7 +401,7 @@ static void KeyF11Pressed()
 
 static void KeyF12Pressed()
 {
-   if (vssol->shading == 2)
+   if (vssol->shading == VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if (vssol->matc.Width() == 0)
       {
@@ -437,7 +437,8 @@ void VisualizationSceneSolution::Init()
    rsol  = NULL;
    vssol = this;
 
-   drawelems = shading = 1;
+   drawelems = 1;
+   shading = Shading::Smooth;
    drawmesh  = 0;
    draworder = 0;
    drawnums  = 0;
@@ -558,7 +559,7 @@ void VisualizationSceneSolution::ToggleDrawElems()
       maxv_sol = maxv;
       have_sol_range = true;
    }
-   else if (shading == 2)
+   else if (shading == Shading::Noncomforming)
    {
       if (drawelems == 1 && have_sol_range)
       {
@@ -823,21 +824,21 @@ int VisualizationSceneSolution::GetRefinedValuesAndNormals(
    return have_normals;
 }
 
-void VisualizationSceneSolution::SetShading(int s, bool print)
+void VisualizationSceneSolution::SetShading(Shading s, bool print)
 {
-   if (shading == s || s < 0)
+   if (shading == s || s <= Shading::Min)
    {
       return;
    }
 
    if (rsol)
    {
-      if (s > 2)
+      if (s >= Shading::Max)
       {
          return;
       }
 
-      if (s == 2 || shading == 2)
+      if (s == Shading::Noncomforming || shading == Shading::Noncomforming)
       {
          shading = s;
          have_sol_range = false;
@@ -856,7 +857,7 @@ void VisualizationSceneSolution::SetShading(int s, bool print)
    }
    else
    {
-      if (s > 1)
+      if (s > Shading::Smooth)
       {
          return;
       }
@@ -868,7 +869,7 @@ void VisualizationSceneSolution::SetShading(int s, bool print)
    {"flat", "smooth", "non-conforming (with subdivision)"};
    if (print)
    {
-      cout << "Shading type : " << shading_type[shading] << endl;
+      cout << "Shading type : " << shading_type[(int)shading] << endl;
    }
 }
 
@@ -876,11 +877,11 @@ void VisualizationSceneSolution::ToggleShading()
 {
    if (rsol)
    {
-      SetShading((shading + 1) % 3, true);
+      SetShading((Shading)(((int)shading + 1) % (int)Shading::Max), true);
    }
    else
    {
-      SetShading(1 - shading, true);
+      SetShading((Shading)(1 - (int)shading), true);
    }
 }
 
@@ -920,7 +921,7 @@ void VisualizationSceneSolution::ToggleRefinements()
          }
          break;
    }
-   if (update && shading == 2)
+   if (update && shading == Shading::Noncomforming)
    {
       have_sol_range = false;
       DoAutoscale(false);
@@ -971,7 +972,7 @@ void VisualizationSceneSolution::SetRefineFactors(int tot, int bdr)
    TimesToRefine = tot;
    EdgeRefineFactor = bdr;
 
-   if (shading == 2)
+   if (shading == Shading::Noncomforming)
    {
       have_sol_range = false;
       DoAutoscale(false);
@@ -1054,7 +1055,7 @@ void VisualizationSceneSolution::FindNewBox(double rx[], double ry[],
 {
    int i, j;
 
-   if (shading != 2)
+   if (shading != Shading::Noncomforming)
    {
       int nv = mesh -> GetNV();
 
@@ -1437,10 +1438,10 @@ void VisualizationSceneSolution::Prepare()
 
    switch (shading)
    {
-      case 0:
+      case Shading::Flat:
          PrepareFlat();
          return;
-      case 2:
+      case Shading::Noncomforming:
          PrepareFlat2();
          return;
       default:
@@ -1553,7 +1554,7 @@ void VisualizationSceneSolution::Prepare()
 
 void VisualizationSceneSolution::PrepareLevelCurves()
 {
-   if (shading == 2)
+   if (shading == Shading::Noncomforming)
    {
       PrepareLevelCurves2();
       return;
@@ -1691,7 +1692,7 @@ void VisualizationSceneSolution::PrepareLevelCurves2()
 
 void VisualizationSceneSolution::PrepareLines()
 {
-   if (shading == 2 &&
+   if (shading == Shading::Noncomforming &&
        mesh->Dimension() > 1) // PrepareLines3 does not make sense for 1d meshes.
    {
       // PrepareLines2();
@@ -1762,7 +1763,7 @@ double VisualizationSceneSolution::GetElementLengthScale(int k)
 
 void VisualizationSceneSolution::PrepareElementNumbering()
 {
-   if (2 == shading)
+   if (shading == Shading::Noncomforming)
    {
       PrepareElementNumbering2();
    }
@@ -1844,7 +1845,7 @@ void VisualizationSceneSolution::PrepareElementNumbering2()
 
 void VisualizationSceneSolution::PrepareVertexNumbering()
 {
-   if (2 == shading)
+   if (shading == Shading::Noncomforming)
    {
       PrepareVertexNumbering2();
    }
@@ -2190,7 +2191,7 @@ void VisualizationSceneSolution::PrepareBoundary()
 
    bdr_buf.clear();
    gl3::GlBuilder bl = bdr_buf.createBuilder();
-   if (shading != 2)
+   if (shading != Shading::Noncomforming)
    {
       bl.glBegin(GL_LINES);
       for (i = 0; i < ne; i++)
@@ -2277,7 +2278,7 @@ void VisualizationSceneSolution::PrepareCP()
    gl3::GlBuilder bld = cp_buf.createBuilder();
    bld.glBegin(GL_LINES);
 
-   if (shading != 2)
+   if (shading != Shading::Noncomforming)
    {
       Array<int> vertices;
 

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -83,7 +83,7 @@ protected:
    double GetElementLengthScale(int k);
 
 public:
-   int shading;
+   Shading shading;
 
    int attr_to_show, bdr_attr_to_show;
    Array<int> el_attr_to_show, bdr_el_attr_to_show;
@@ -165,7 +165,7 @@ public:
       PrepareNumbering(false);
    }
 
-   virtual void SetShading(int, bool);
+   virtual void SetShading(Shading, bool);
    void ToggleShading();
 
    void ToggleDrawCP() { draw_cp = !draw_cp; PrepareCP(); }
@@ -178,7 +178,7 @@ public:
    virtual void ToggleAttributes(Array<int> &attr_list);
 
    virtual void SetDrawMesh(int i) { drawmesh = i % 3; }
-   virtual int GetShading() { return shading; }
+   virtual Shading GetShading() { return shading; }
    virtual int GetDrawMesh() { return drawmesh; }
 };
 

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -83,8 +83,6 @@ protected:
    double GetElementLengthScale(int k);
 
 public:
-   Shading shading;
-
    int attr_to_show, bdr_attr_to_show;
    Array<int> el_attr_to_show, bdr_el_attr_to_show;
 
@@ -166,7 +164,7 @@ public:
    }
 
    virtual void SetShading(Shading, bool);
-   void ToggleShading();
+   virtual void ToggleShading();
 
    void ToggleDrawCP() { draw_cp = !draw_cp; PrepareCP(); }
 
@@ -178,7 +176,6 @@ public:
    virtual void ToggleAttributes(Array<int> &attr_list);
 
    virtual void SetDrawMesh(int i) { drawmesh = i % 3; }
-   virtual Shading GetShading() { return shading; }
    virtual int GetDrawMesh() { return drawmesh; }
 };
 

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -87,7 +87,8 @@ public:
    Array<int> el_attr_to_show, bdr_el_attr_to_show;
 
    VisualizationSceneSolution();
-   VisualizationSceneSolution(Mesh &m, Vector &s, Vector *normals = NULL);
+   VisualizationSceneSolution(Mesh &m, Vector &s, Mesh *mc = NULL,
+                              Vector *normals = NULL);
 
    virtual ~VisualizationSceneSolution();
 
@@ -95,7 +96,7 @@ public:
 
    void SetGridFunction(GridFunction & u) { rsol = &u; }
 
-   void NewMeshAndSolution(Mesh *new_m, Vector *new_sol,
+   void NewMeshAndSolution(Mesh *new_m, Mesh *new_mc, Vector *new_sol,
                            GridFunction *new_u = NULL);
 
    virtual void SetNewScalingFromBox();

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1445,7 +1445,6 @@ void VisualizationSceneSolution3d::DrawCoarseSurfEdges(
    MFEM_ASSERT(mesh_coarse, "Cannot be used without the coarse mesh");
    MFEM_ASSERT(mesh->GetLastOperation() == Mesh::Operation::REFINE,
                "Not a refined mesh");
-   MFEM_ASSERT(!idxs || idxs->Size() == 8, "Not expected 4 edges");
 
    const int dim = mesh->Dimension();
    FaceElementTransformations *ftr;
@@ -1485,7 +1484,9 @@ void VisualizationSceneSolution3d::DrawCoarseSurfEdges(
 
    line.glBegin(GL_LINES);
 
-   for (int k = 0; k < 4; k++)
+   const int k_max = (idxs)?(idxs->Size()/2):(4);
+
+   for (int k = 0; k < k_max; k++)
    {
       int j, jp1;
       Vector emb_ip1, emb_ip2;

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -349,7 +349,8 @@ static void KeyoPressed(GLenum state)
       if (vssol3d -> TimesToRefine < 32)
       {
          cout << "Subdivision factor = " << ++vssol3d->TimesToRefine << endl;
-         if (vssol3d -> GetShading() == 2)
+         if (vssol3d -> GetShading() ==
+             VisualizationSceneScalarData::Shading::Noncomforming)
          {
             vssol3d->DoAutoscale(false);
             vssol3d -> Prepare();
@@ -367,7 +368,8 @@ static void KeyOPressed()
    if (vssol3d -> TimesToRefine > 1)
    {
       cout << "Subdivision factor = " << --vssol3d->TimesToRefine << endl;
-      if (vssol3d -> GetShading() == 2)
+      if (vssol3d -> GetShading() ==
+          VisualizationSceneScalarData::Shading::Noncomforming)
       {
          vssol3d->DoAutoscale(false);
          vssol3d -> Prepare();
@@ -381,7 +383,8 @@ static void KeyOPressed()
 
 static void KeywPressed()
 {
-   if (vssol3d -> GetShading() == 2)
+   if (vssol3d -> GetShading() ==
+       VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if ( fabs(vssol3d -> FaceShiftScale += 0.01) < 0.001 )
       {
@@ -398,7 +401,8 @@ static void KeywPressed()
 
 static void KeyWPressed()
 {
-   if (vssol3d -> GetShading() == 2)
+   if (vssol3d -> GetShading() ==
+       VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if ( fabs(vssol3d -> FaceShiftScale -= 0.01) < 0.001 )
       {
@@ -461,7 +465,8 @@ static void KeyF3Pressed(GLenum state)
    }
    else
    {
-      if (vssol3d->GetShading() == 2)
+      if (vssol3d->GetShading() ==
+          VisualizationSceneScalarData::Shading::Noncomforming)
       {
          if (vssol3d->GetMesh()->Dimension() == 3 && vssol3d->bdrc.Width() == 0)
          {
@@ -502,7 +507,8 @@ static void KeyF4Pressed(GLenum state)
    }
    else
    {
-      if (vssol3d->GetShading() == 2)
+      if (vssol3d->GetShading() ==
+          VisualizationSceneScalarData::Shading::Noncomforming)
       {
          if (vssol3d->GetMesh()->Dimension() == 3 && vssol3d->bdrc.Width() == 0)
          {
@@ -526,7 +532,8 @@ static void KeyF4Pressed(GLenum state)
 
 static void KeyF11Pressed()
 {
-   if (vssol3d->GetShading() == 2)
+   if (vssol3d->GetShading() ==
+       VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if (vssol3d->matc.Width() == 0)
       {
@@ -545,7 +552,8 @@ static void KeyF11Pressed()
 
 static void KeyF12Pressed()
 {
-   if (vssol3d->GetShading() == 2)
+   if (vssol3d->GetShading() ==
+       VisualizationSceneScalarData::Shading::Noncomforming)
    {
       if (vssol3d->matc.Width() == 0)
       {
@@ -699,7 +707,8 @@ void VisualizationSceneSolution3d::Init()
    drawlsurf = 0;
    cp_algo = 0;
 
-   drawelems = shading = 1;
+   drawelems = 1;
+   shading = Shading::Smooth;
    drawmesh = 0;
    draworder = 0;
    scaling = 0;
@@ -843,20 +852,21 @@ void VisualizationSceneSolution3d::NewMeshAndSolution(
    PrepareOrderingCurve();
 }
 
-void VisualizationSceneSolution3d::SetShading(int s, bool print)
+void VisualizationSceneSolution3d::SetShading(Shading s, bool print)
 {
-   if (shading == s || s < 0)
+   if (shading == s || s <= Shading::Min)
    {
       return;
    }
 
-   if (s > 2 || (GridF == NULL && s > 1))
+   if (s >= Shading::Max || (GridF == NULL && s > Shading::Smooth))
    {
       return;
    }
-   int os = shading;
+   Shading os = shading;
    shading = s;
-   if (GridF != NULL && (s == 2 || os == 2))
+   if (GridF != NULL && (s == Shading::Noncomforming ||
+                         os == Shading::Noncomforming))
    {
       DoAutoscale(false);
       PrepareLines();
@@ -869,7 +879,7 @@ void VisualizationSceneSolution3d::SetShading(int s, bool print)
    {"flat", "smooth", "non-conforming (with subdivision)"};
    if (print)
    {
-      cout << "Shading type : " << shading_type[shading] << endl;
+      cout << "Shading type : " << shading_type[(int)shading] << endl;
    }
 }
 
@@ -877,11 +887,11 @@ void VisualizationSceneSolution3d::ToggleShading()
 {
    if (GridF)
    {
-      SetShading((shading+1)%3, true);
+      SetShading((Shading)(((int)shading+1) % (int)Shading::Max), true);
    }
    else
    {
-      SetShading(1-shading, true);
+      SetShading((Shading)(1 - (int)shading), true);
    }
 }
 
@@ -894,7 +904,7 @@ void VisualizationSceneSolution3d::SetRefineFactors(int f, int ignored)
 
    TimesToRefine = f;
 
-   if (shading == 2)
+   if (shading == Shading::Noncomforming)
    {
       DoAutoscale(false);
       Prepare();
@@ -979,7 +989,7 @@ void VisualizationSceneSolution3d::FindNewBox(bool prepare)
       if (coord[2] > bb.z[1]) { bb.z[1] = coord[2]; }
    }
 
-   if (shading == 2)
+   if (shading == Shading::Noncomforming)
    {
       int dim = mesh->Dimension();
       int ne = (dim == 3) ? mesh->GetNBE() : mesh->GetNE();
@@ -1030,7 +1040,7 @@ void VisualizationSceneSolution3d::FindNewValueRange(bool prepare)
                   GridF->FESpace()->FEColl()->GetMapType(mesh->Dimension()) :
                   FiniteElement::VALUE;
 
-   if (shading < 2 || map_type != (int)FiniteElement::VALUE)
+   if (shading < Shading::Noncomforming || map_type != (int)FiniteElement::VALUE)
    {
       minv = sol->Min();
       maxv = sol->Max();
@@ -1050,7 +1060,7 @@ void VisualizationSceneSolution3d::EventUpdateColors()
    PrepareCuttingPlane();
    PrepareLevelSurf();
    PrepareOrderingCurve();
-   if (shading == 2 && drawmesh != 0 && FaceShiftScale != 0.0)
+   if (shading == Shading::Noncomforming && drawmesh != 0 && FaceShiftScale != 0.0)
    {
       PrepareLines();
    }
@@ -1127,7 +1137,7 @@ void VisualizationSceneSolution3d::ToggleCPDrawMesh()
 void VisualizationSceneSolution3d::ToggleCPAlgorithm()
 {
    cp_algo = (cp_algo+1)%2;
-   if (shading == 2 && cplane == 1)
+   if (shading == Shading::Noncomforming && cplane == 1)
    {
       CPPrepare();
    }
@@ -1817,10 +1827,10 @@ void VisualizationSceneSolution3d::Prepare()
 
    switch (shading)
    {
-      case 0:
+      case Shading::Flat:
          PrepareFlat();
          return;
-      case 2:
+      case Shading::Noncomforming:
          PrepareFlat2();
          return;
       default:
@@ -2003,7 +2013,7 @@ void VisualizationSceneSolution3d::PrepareLines()
       return;
    }
 
-   if (shading == 2)
+   if (shading == Shading::Noncomforming)
    {
       PrepareLines2();
       return;
@@ -2523,7 +2533,7 @@ void VisualizationSceneSolution3d::CuttingPlaneFunc(int func)
 
       while (n > 2)
       {
-         if (shading != 2)
+         if (shading != Shading::Noncomforming)
          {
             mesh -> GetPointMatrix (i, pointmat);
          }
@@ -2556,7 +2566,7 @@ void VisualizationSceneSolution3d::CuttingPlaneFunc(int func)
          {
             case 1:  // PrepareCuttingPlane()
             {
-               if (shading == 2)
+               if (shading == Shading::Noncomforming)
                {
                   // changes point for n > 4
                   DrawRefinedSurf(n, point[0], i, 1);
@@ -2606,7 +2616,7 @@ void VisualizationSceneSolution3d::CuttingPlaneFunc(int func)
 
             case 2:  // PrepareCuttingPlaneLines() with mesh
             {
-               if (shading == 2)
+               if (shading == Shading::Noncomforming)
                {
                   // changes point for n > 4
                   DrawRefinedSurf(n, point[0], i, 2);
@@ -2627,7 +2637,7 @@ void VisualizationSceneSolution3d::CuttingPlaneFunc(int func)
 
             case 3:  // PrepareCuttingPlaneLines() with level lines
             {
-               if (shading == 2)
+               if (shading == Shading::Noncomforming)
                {
                   // changes point for n > 4
                   DrawRefinedSurf(n, point[0], i, 3);
@@ -2918,7 +2928,7 @@ void VisualizationSceneSolution3d::PrepareCuttingPlane2()
       mesh -> GetFaceElements (i, &e1, &e2);
       if (e2 >= 0 && partition[e1] != partition[e2])
       {
-         if (shading != 2)
+         if (shading != Shading::Noncomforming)
          {
             mesh -> GetFaceVertices (i, nodes);
             for (j = 0; j < nodes.Size(); j++)
@@ -3080,7 +3090,7 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines2()
       mesh -> GetFaceElements (i, &e1, &e2);
       if (e2 >= 0 && partition[e1] != partition[e2])
       {
-         if (shading != 2)
+         if (shading != Shading::Noncomforming)
          {
             mesh -> GetFaceVertices (i, nodes);
             for (j = 0; j < nodes.Size(); j++)
@@ -3869,7 +3879,7 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
 
    Array<int> faces, ofaces;
 
-   if (shading != 2)
+   if (shading != Shading::Noncomforming)
    {
       for (int ie = 0; ie < mesh->GetNE(); ie++)
       {

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -887,7 +887,7 @@ void VisualizationSceneSolution3d::ToggleShading()
 {
    if (GridF)
    {
-      SetShading((Shading)(((int)shading+1) % (int)Shading::Max), true);
+      VisualizationSceneScalarData::ToogleShading();
    }
    else
    {

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3246,14 +3246,64 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines2()
             switch (cp_drawmesh)
             {
                case 1:
-                  // glBegin(GL_POLYGON);
-                  line.glBegin(GL_LINE_LOOP);
-                  for (j = 0; j < nodes.Size(); j++)
+               {
+                  if (mesh_coarse)
                   {
-                     line.glVertex3dv (point[j]);
+                     FaceElementTransformations *ftr;
+                     ftr = mesh->GetFaceElementTransformations(i);
+                     auto &ref = mesh->GetRefinementTransforms();
+                     IsoparametricTransformation trans;
+                     BiLinear2DFiniteElement fe_face;
+                     TriLinear3DFiniteElement fe;
+                     trans.SetFE(&fe);
+                     DenseMatrix emb_pointmat;
+
+                     //we assume that mesh_course is used only for tensor finite elements,
+                     //like for representation of quadratures, so in 2D it is square
+                     const int geom =
+                        Geometry::Type::CUBE; //ref.embeddings[e1].geom; //<---- bugged!?
+                     const int mat = ref.embeddings[e1].matrix;
+                     const DenseMatrix &emb_mat = ref.point_matrices[geom](mat);
+                     trans.SetPointMat(emb_mat);
+                     IntegrationRule nodes3d(4);
+                     ftr->Loc1.Transform(fe_face.GetNodes(), nodes3d);
+                     trans.Transform(nodes3d, emb_pointmat);
+
+                     line.glBegin(GL_LINES);
+
+                     for (j = 0; j < 4; j++)
+                     {
+                        int jp1 = (j+1) % 4;
+                        Vector emb_ip1, emb_ip2;
+                        emb_pointmat.GetColumnReference(j, emb_ip1);
+                        emb_pointmat.GetColumnReference(jp1, emb_ip2);
+
+                        //check if we are on the outer edge
+                        int inter = 0;
+                        for (int d = 0; d < 3; d++)
+                           if ((emb_ip1(d) != 0. && emb_ip1(d) != 1.)
+                               || (emb_ip2(d) != 0. && emb_ip2(d) != 1.))
+                           { inter++; }
+                        if (inter != 1) { continue; }
+
+                        line.glVertex3dv(point[j]);
+                        line.glVertex3dv(point[jp1]);
+                     }
+
+                     line.glEnd();
                   }
-                  line.glEnd();
+                  else
+                  {
+                     // glBegin(GL_POLYGON);
+                     line.glBegin(GL_LINE_LOOP);
+                     for (j = 0; j < nodes.Size(); j++)
+                     {
+                        line.glVertex3dv (point[j]);
+                     }
+                     line.glEnd();
+                  }
                   break;
+               }
                case 2:
                   DrawPolygonLevelLines(line, point[0], nodes.Size(), level, false);
                   break;
@@ -3278,8 +3328,62 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines2()
             switch (cp_drawmesh)
             {
                case 1:
-                  DrawRefinedSurfEdges (n, pointmat, values, RefG->RefEdges);
+               {
+                  if (mesh_coarse)
+                  {
+                     FaceElementTransformations *ftr;
+                     ftr = mesh->GetFaceElementTransformations(i);
+                     auto &ref = mesh->GetRefinementTransforms();
+                     IsoparametricTransformation trans;
+                     BiLinear2DFiniteElement fe_face;
+                     TriLinear3DFiniteElement fe;
+                     trans.SetFE(&fe);
+                     DenseMatrix emb_pointmat;
+
+                     //we assume that mesh_course is used only for tensor finite elements,
+                     //like for representation of quadratures, so in 2D it is square
+                     const int geom =
+                        Geometry::Type::CUBE; //ref.embeddings[e1].geom; //<---- bugged!?
+                     const int mat = ref.embeddings[e1].matrix;
+                     const DenseMatrix &emb_mat = ref.point_matrices[geom](mat);
+                     trans.SetPointMat(emb_mat);
+                     IntegrationRule nodes3d(4);
+                     ftr->Loc1.Transform(fe_face.GetNodes(), nodes3d);
+                     trans.Transform(nodes3d, emb_pointmat);
+
+                     gl3::GlBuilder line = cplines_buf.createBuilder();
+                     line.glBegin(GL_LINES);
+
+                     auto &RE = RefG->RefEdges;
+                     for (int k = 0; k < RE.Size()/2; k++)
+                     {
+                        IntegrationPoint ip1_3d, ip2_3d;
+                        Vector emb_ip1, emb_ip2;
+                        ftr->Loc1.Transform(RefG->RefPts[RE[2*k]], ip1_3d);
+                        ftr->Loc1.Transform(RefG->RefPts[RE[2*k+1]], ip2_3d);
+                        trans.Transform(ip1_3d, emb_ip1);
+                        trans.Transform(ip2_3d, emb_ip2);
+
+                        //check if we are on the outer edge
+                        int inter = 0;
+                        for (int d = 0; d < 3; d++)
+                           if ((emb_ip1(d) != 0. && emb_ip1(d) != 1.)
+                               || (emb_ip2(d) != 0. && emb_ip2(d) != 1.))
+                           { inter++; }
+                        if (inter != 1) { continue; }
+
+                        line.glVertex3dv(&pointmat(0, RE[2*k]));
+                        line.glVertex3dv(&pointmat(0, RE[2*k+1]));
+                     }
+
+                     line.glEnd();
+                  }
+                  else
+                  {
+                     DrawRefinedSurfEdges (n, pointmat, values, RefG->RefEdges);
+                  }
                   break;
+               }
                case 2:
                   DrawRefinedSurfLevelLines (n, pointmat, values,
                                              RefG->RefGeoms);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -3284,6 +3284,8 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines2()
                            if ((emb_ip1(d) != 0. && emb_ip1(d) != 1.)
                                || (emb_ip2(d) != 0. && emb_ip2(d) != 1.))
                            { inter++; }
+                        if (ref.embeddings[e1].parent == ref.embeddings[e2].parent)
+                        { inter--; }
                         if (inter != 1) { continue; }
 
                         line.glVertex3dv(point[j]);
@@ -3370,6 +3372,8 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines2()
                            if ((emb_ip1(d) != 0. && emb_ip1(d) != 1.)
                                || (emb_ip2(d) != 0. && emb_ip2(d) != 1.))
                            { inter++; }
+                        if (ref.embeddings[e1].parent == ref.embeddings[e2].parent)
+                        { inter--; }
                         if (inter != 1) { continue; }
 
                         line.glVertex3dv(&pointmat(0, RE[2*k]));

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -64,12 +64,12 @@ std::string VisualizationSceneSolution3d::GetHelpString() const
       << "| o/O  (De)refine elem, disc shading |" << endl
       << "| p/P  Cycle through color palettes  |" << endl
       << "| q -  Quits                         |" << endl
+      << "| Q -  Cycle quadrature data mode    |" << endl
       << "| r -  Reset the plot to 3D view     |" << endl
       << "| R -  Reset the plot to 2D view     |" << endl
       << "| s -  Turn on/off unit cube scaling |" << endl
       << "| S -  Take snapshot/Record a movie  |" << endl
       << "| t -  Cycle materials and lights    |" << endl
-      << "| Q -  Cycle quadrature data repre.  |" << endl
       << "| u/U  Move the level surface        |" << endl
       << "| v/V  Add/Delete a level surface    |" << endl
       << "| w/W  Move bdr elements up/down     |" << endl

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1456,8 +1456,8 @@ void VisualizationSceneSolution3d::DrawCoarseSurfEdges(
    }
    auto &ref = mesh->GetRefinementTransforms();
    IsoparametricTransformation trans;
-   BiLinear2DFiniteElement fe_face;
-   TriLinear3DFiniteElement fe;
+   static const BiLinear2DFiniteElement fe_face;
+   static const TriLinear3DFiniteElement fe;
    trans.SetFE(&fe);
    DenseMatrix emb_pointmat;
 
@@ -1522,7 +1522,7 @@ void VisualizationSceneSolution3d::DrawCoarseSurfEdges(
          if ((emb_ip1(d) != 0. && emb_ip1(d) != 1.)
              || (emb_ip2(d) != 0. && emb_ip2(d) != 1.))
          { inter++; }
-      if (e2>= 0 && ref.embeddings[e1].parent == ref.embeddings[e2].parent)
+      if (e2 >= 0 && ref.embeddings[e1].parent == ref.embeddings[e2].parent)
       { inter--; }
       if (inter != 1) { continue; }
 

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -23,7 +23,6 @@ class VisualizationSceneSolution3d : public VisualizationSceneScalarData
 protected:
 
    int drawmesh, drawelems, draworder;
-   Shading shading;
    int cplane;
    int cp_drawmesh, cp_drawelems, drawlsurf;
    // Algorithm used to draw the cutting plane when shading is 2 and cplane is 1

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -112,11 +112,11 @@ public:
    Array<int> bdr_attr_to_show;
 
    VisualizationSceneSolution3d();
-   VisualizationSceneSolution3d(Mesh & m, Vector & s);
+   VisualizationSceneSolution3d(Mesh & m, Vector & s, Mesh *mc);
 
    void SetGridFunction (GridFunction *gf) { GridF = gf; }
 
-   void NewMeshAndSolution(Mesh *new_m, Vector *new_sol,
+   void NewMeshAndSolution(Mesh *new_m, Mesh *new_mc, Vector *new_sol,
                            GridFunction *new_u = NULL);
 
    virtual ~VisualizationSceneSolution3d();

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -148,9 +148,8 @@ public:
    //           3 - no arrows (black), 4 - with arrows (black)
    void ToggleDrawOrdering() { draworder = (draworder+1)%5; }
 
-   void ToggleShading();
-   Shading GetShading() { return shading; };
    virtual void SetShading(Shading, bool);
+   virtual void ToggleShading();
    virtual void SetRefineFactors(int, int);
    virtual void AutoRefine();
    virtual void ToggleAttributes(Array<int> &attr_list);

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -22,7 +22,8 @@ class VisualizationSceneSolution3d : public VisualizationSceneScalarData
 {
 protected:
 
-   int drawmesh, drawelems, shading, draworder;
+   int drawmesh, drawelems, draworder;
+   Shading shading;
    int cplane;
    int cp_drawmesh, cp_drawelems, drawlsurf;
    // Algorithm used to draw the cutting plane when shading is 2 and cplane is 1
@@ -148,8 +149,8 @@ public:
    void ToggleDrawOrdering() { draworder = (draworder+1)%5; }
 
    void ToggleShading();
-   int GetShading() { return shading; };
-   virtual void SetShading(int, bool);
+   Shading GetShading() { return shading; };
+   virtual void SetShading(Shading, bool);
    virtual void SetRefineFactors(int, int);
    virtual void AutoRefine();
    virtual void ToggleAttributes(Array<int> &attr_list);

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -59,6 +59,14 @@ protected:
    void DrawRefinedSurfEdges (int n, DenseMatrix &pointmat,
                               Vector &values, Array<int> &RefEdges,
                               int part = -1);
+   void DrawBdrElCoarseSurfEdges(gl3::GlBuilder &line, int be,
+                                 DenseMatrix &pointmat, const IntegrationRule *ir = NULL,
+                                 Array<int> *idxs = NULL);
+   void DrawFaceCoarseSurfEdges(gl3::GlBuilder &line, int f, DenseMatrix &pointmat,
+                                const IntegrationRule *ir = NULL, Array<int> *idxs = NULL);
+   void DrawCoarseSurfEdges(gl3::GlBuilder &line, int f, int e1, int e2,
+                            DenseMatrix &pointmat, const IntegrationRule *ir = NULL,
+                            Array<int> *idxs = NULL);
    void LiftRefinedSurf (int n, DenseMatrix &pointmat,
                          Vector &values, int *RG);
    void DrawTetLevelSurf(gl3::GlDrawable& target, const DenseMatrix &verts,

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -51,12 +51,12 @@ std::string VisualizationSceneVector::GetHelpString() const
       << "| O -  Switch 'o' func. (NC shading) |" << endl
       << "| p/P  Cycle through color palettes  |" << endl
       << "| q -  Quits                         |" << endl
+      << "| Q -  Cycle quadrature data mode    |" << endl
       << "| r -  Reset the plot to 3D view     |" << endl
       << "| R -  Reset the plot to 2D view     |" << endl
       << "| s -  Turn on/off unit cube scaling |" << endl
       << "| S -  Take snapshot/Record a movie  |" << endl
       << "| t -  Cycle materials and lights    |" << endl
-      << "| Q -  Cycle quadrature data repre.  |" << endl
       << "| u -  Vector sampling; scalar func. |" << endl
       << "| U -  Switch 'u' functionality      |" << endl
       << "| v -  Cycle through vector fields   |" << endl

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -188,7 +188,7 @@ void KeyuPressed()
       case 0:
       case 1:
          if (update &&
-             vsvector->shading == VisualizationSceneSolution::Shading::Noncomforming)
+             vsvector->GetShading() == VisualizationSceneSolution::Shading::Noncomforming)
          {
             vsvector->PrepareVectorField();
             SendExposeEvent();

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -255,9 +255,10 @@ const char *Vec2ScalarNames[7] =
 };
 
 VisualizationSceneVector::VisualizationSceneVector(Mesh & m,
-                                                   Vector & sx, Vector & sy)
+                                                   Vector & sx, Vector & sy, Mesh *mc)
 {
    mesh = &m;
+   mesh_coarse = mc;
    solx = &sx;
    soly = &sy;
 
@@ -405,7 +406,7 @@ void VisualizationSceneVector::CycleVec2Scalar(int print)
    }
 }
 
-void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf)
+void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf, Mesh *mc)
 {
    delete sol;
 
@@ -436,6 +437,7 @@ void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf)
       }
    }
    mesh = new_mesh;
+   mesh_coarse = mc;
 
    solx = new Vector(mesh->GetNV());
    soly = new Vector(mesh->GetNV());
@@ -459,7 +461,7 @@ void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf)
       (*sol)(i) = Vec2Scalar((*solx)(i), (*soly)(i));
    }
 
-   VisualizationSceneSolution::NewMeshAndSolution(mesh, NULL, sol, &vgf);
+   VisualizationSceneSolution::NewMeshAndSolution(mesh, mesh_coarse, sol, &vgf);
 
    if (autoscale)
    {

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -187,7 +187,8 @@ void KeyuPressed()
    {
       case 0:
       case 1:
-         if (update && vsvector->shading == 2)
+         if (update &&
+             vsvector->shading == VisualizationSceneSolution::Shading::Noncomforming)
          {
             vsvector->PrepareVectorField();
             SendExposeEvent();
@@ -230,7 +231,7 @@ void VisualizationSceneVector::ToggleDrawElems()
 
    cout << "Surface elements mode : " << modes[drawelems] << endl;
 
-   if (drawelems != 0 && shading == 2)
+   if (drawelems != 0 && shading == Shading::Noncomforming)
    {
       DoAutoscaleValue(false);
       PrepareLines();
@@ -660,7 +661,7 @@ void VisualizationSceneVector::PrepareDisplacedMesh()
    // prepare the displaced mesh
    displine_buf.clear();
    gl3::GlBuilder build = displine_buf.createBuilder();
-   if (shading != 2)
+   if (shading != Shading::Noncomforming)
    {
       for (int i = 0; i < ne; i++)
       {
@@ -905,7 +906,7 @@ void VisualizationSceneVector::PrepareVectorField()
             DrawVector(v[0], v[1], (*solx)(i), (*soly)(i), (*sol)(i));
          }
 
-         if (shading == 2 && RefineFactor > 1)
+         if (shading == Shading::Noncomforming && RefineFactor > 1)
          {
             DenseMatrix vvals, pm;
             for (i = 0; i < mesh->GetNE(); i++)

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -459,7 +459,7 @@ void VisualizationSceneVector::NewMeshAndSolution(GridFunction &vgf)
       (*sol)(i) = Vec2Scalar((*solx)(i), (*soly)(i));
    }
 
-   VisualizationSceneSolution::NewMeshAndSolution(mesh, sol, &vgf);
+   VisualizationSceneSolution::NewMeshAndSolution(mesh, NULL, sol, &vgf);
 
    if (autoscale)
    {

--- a/lib/vsvector.hpp
+++ b/lib/vsvector.hpp
@@ -46,10 +46,10 @@ protected:
    IsoparametricTransformation T0;
 
 public:
-   VisualizationSceneVector(Mesh &m, Vector &sx, Vector &sy);
+   VisualizationSceneVector(Mesh &m, Vector &sx, Vector &sy, Mesh *mc = NULL);
    VisualizationSceneVector(GridFunction &vgf);
 
-   void NewMeshAndSolution(GridFunction &vgf);
+   void NewMeshAndSolution(GridFunction &vgf, Mesh *mc = NULL);
 
    virtual ~VisualizationSceneVector();
 

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -61,12 +61,12 @@ std::string VisualizationSceneVector3d::GetHelpString() const
       << "| o/O  (De)refine elem, disc shading |" << endl
       << "| p/P  Cycle through color palettes  |" << endl
       << "| q -  Quits                         |" << endl
+      << "| Q -  Cycle quadrature data mode    |" << endl
       << "| r -  Reset the plot to 3D view     |" << endl
       << "| R -  Reset the plot to 2D view     |" << endl
       << "| s -  Turn on/off unit cube scaling |" << endl
       << "| S -  Take snapshot/Record a movie  |" << endl
       << "| t -  Cycle materials and lights    |" << endl
-      << "| Q -  Cycle quadrature data repre.  |" << endl
       << "| u/U  Move the level field vectors  |" << endl
       << "| v/V  Vector field                  |" << endl
       << "| w/W  Add/Delete level field vector |" << endl

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -794,10 +794,10 @@ void VisualizationSceneVector3d::Prepare()
 
    switch (shading)
    {
-      case 0:
+      case Shading::Flat:
          PrepareFlat();
          return;
-      case 2:
+      case Shading::Noncomforming:
          PrepareFlat2();
          return;
       default:
@@ -928,7 +928,7 @@ void VisualizationSceneVector3d::PrepareLines()
 {
    if (!drawmesh) { return; }
 
-   if (shading == 2)
+   if (shading == Shading::Noncomforming)
    {
       PrepareLines2();
       return;

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -340,9 +340,10 @@ void VisualizationSceneVector3d::ToggleScalarFunction()
 }
 
 VisualizationSceneVector3d::VisualizationSceneVector3d(Mesh &m, Vector &sx,
-                                                       Vector &sy, Vector &sz)
+                                                       Vector &sy, Vector &sz, Mesh *mc)
 {
    mesh = &m;
+   mesh_coarse = mc;
    solx = &sx;
    soly = &sy;
    solz = &sz;
@@ -355,7 +356,8 @@ VisualizationSceneVector3d::VisualizationSceneVector3d(Mesh &m, Vector &sx,
    Init();
 }
 
-VisualizationSceneVector3d::VisualizationSceneVector3d(GridFunction &vgf)
+VisualizationSceneVector3d::VisualizationSceneVector3d(GridFunction &vgf,
+                                                       Mesh *mc)
 {
    FiniteElementSpace *fes = vgf.FESpace();
    if (fes == NULL || fes->GetVDim() != 3)
@@ -367,6 +369,7 @@ VisualizationSceneVector3d::VisualizationSceneVector3d(GridFunction &vgf)
    VecGridF = &vgf;
 
    mesh = fes->GetMesh();
+   mesh_coarse = mc;
 
    sfes = new FiniteElementSpace(mesh, fes->FEColl(), 1, fes->GetOrdering());
    GridF = new GridFunction(sfes);
@@ -452,7 +455,7 @@ VisualizationSceneVector3d::~VisualizationSceneVector3d()
 }
 
 void VisualizationSceneVector3d::NewMeshAndSolution(
-   Mesh *new_m, GridFunction *new_v)
+   Mesh *new_m, Mesh *new_mc, GridFunction *new_v)
 {
    delete sol;
    if (VecGridF)
@@ -487,6 +490,7 @@ void VisualizationSceneVector3d::NewMeshAndSolution(
 
    VecGridF = new_v;
    mesh = new_m;
+   mesh_coarse = new_mc;
    FindNodePos();
 
    sfes = new FiniteElementSpace(mesh, new_fes->FEColl(), 1,
@@ -980,15 +984,23 @@ void VisualizationSceneVector3d::PrepareLines()
       switch (drawmesh)
       {
          case 1:
-            line.glBegin(GL_LINE_LOOP);
-
-            for (j = 0; j < pointmat.Size(); j++)
+         {
+            if (mesh_coarse)
             {
-               line.glVertex3d (pointmat(0, j), pointmat(1, j), pointmat(2, j));
+               DrawBdrElCoarseSurfEdges(line, i, pointmat);
             }
-            line.glEnd();
-            break;
+            else
+            {
+               line.glBegin(GL_LINE_LOOP);
 
+               for (j = 0; j < pointmat.Size(); j++)
+               {
+                  line.glVertex3d (pointmat(0, j), pointmat(1, j), pointmat(2, j));
+               }
+               line.glEnd();
+            }
+            break;
+         }
          case 2:
             for (j = 0; j < pointmat.Size(); j++)
             {
@@ -1007,7 +1019,7 @@ void VisualizationSceneVector3d::PrepareLines()
 
 void VisualizationSceneVector3d::PrepareLines2()
 {
-   int i, j, k, fn, fo, di = 0;
+   int fn, fo, di = 0;
    double bbox_diam;
 
    line_buf.clear();
@@ -1026,7 +1038,7 @@ void VisualizationSceneVector3d::PrepareLines2()
                       (bb.z[1]-bb.z[0])*(bb.z[1]-bb.z[0]) );
    double sc = FaceShiftScale * bbox_diam;
 
-   for (i = 0; i < ne; i++)
+   for (int i = 0; i < ne; i++)
    {
       int attr = (dim == 3) ? mesh->GetBdrAttribute(i) : mesh->GetAttribute(i);
       if (!bdr_attr_to_show[attr-1]) { continue; }
@@ -1105,29 +1117,53 @@ void VisualizationSceneVector3d::PrepareLines2()
       if (drawmesh == 1)
       {
          Array<int> &REdges = RefG->RefEdges;
-         line.glBegin (GL_LINES);
-         for (k = 0; k < REdges.Size()/2; k++)
+         if (mesh_coarse)
          {
-            int *RE = &(REdges[2*k]);
-
             if (sc == 0.0)
             {
-               for (j = 0; j < 2; j++)
-                  line.glVertex3d (pointmat(0, RE[j]), pointmat(1, RE[j]),
-                                   pointmat(2, RE[j]));
+               DrawBdrElCoarseSurfEdges(line, i, pointmat, &RefG->RefPts, &REdges);
             }
             else
             {
-               for (j = 0; j < 2; j++)
+               DenseMatrix pointmat_shift = pointmat;
+               for (int j = 0; j < REdges.Size(); j++)
                {
-                  double val = sc * (values(RE[j]) - minv) / (maxv - minv);
-                  line.glVertex3d (pointmat(0, RE[j])+val*norm[0],
-                                   pointmat(1, RE[j])+val*norm[1],
-                                   pointmat(2, RE[j])+val*norm[2]);
+                  double val = sc * (values(REdges[j]) - minv) / (maxv - minv);
+                  for (int d = 0; d < 3; d++)
+                  {
+                     pointmat_shift(d, REdges[j]) += val*norm[d];
+                  }
                }
+               DrawBdrElCoarseSurfEdges(line, i, pointmat_shift, &RefG->RefPts, &REdges);
             }
          }
-         line.glEnd();
+         else
+         {
+            line.glBegin (GL_LINES);
+            for (int k = 0; k < REdges.Size()/2; k++)
+            {
+               int *RE = &(REdges[2*k]);
+
+               if (sc == 0.0)
+               {
+                  for (int j = 0; j < 2; j++)
+                     line.glVertex3d (pointmat(0, RE[j]),
+                                      pointmat(1, RE[j]),
+                                      pointmat(2, RE[j]));
+               }
+               else
+               {
+                  for (int j = 0; j < 2; j++)
+                  {
+                     double val = sc * (values(RE[j]) - minv) / (maxv - minv);
+                     line.glVertex3d (pointmat(0, RE[j])+val*norm[0],
+                                      pointmat(1, RE[j])+val*norm[1],
+                                      pointmat(2, RE[j])+val*norm[2]);
+                  }
+               }
+            }
+            line.glEnd();
+         }
       }
       else if (drawmesh == 2)
       {
@@ -1145,13 +1181,13 @@ void VisualizationSceneVector3d::PrepareLines2()
                sides = 4;
                break;
          }
-         for (k = 0; k < RefG->RefGeoms.Size()/sides; k++)
+         for (int k = 0; k < RefG->RefGeoms.Size()/sides; k++)
          {
             RG = &(RefG->RefGeoms[k*sides]);
 
             if (sc == 0.0)
             {
-               for (j = 0; j < sides; j++)
+               for (int j = 0; j < sides; j++)
                {
                   for (int ii = 0; ii < 3; ii++)
                   {
@@ -1162,7 +1198,7 @@ void VisualizationSceneVector3d::PrepareLines2()
             }
             else
             {
-               for (j = 0; j < sides; j++)
+               for (int j = 0; j < sides; j++)
                {
                   double val = (values(RG[j]) - minv) / (maxv - minv);
                   val *= sc;

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -36,10 +36,11 @@ protected:
 public:
    int ianim, ianimd, ianimmax, drawdisp;
 
-   VisualizationSceneVector3d(Mesh & m, Vector & sx, Vector & sy, Vector & sz);
-   VisualizationSceneVector3d (GridFunction &vgf);
+   VisualizationSceneVector3d(Mesh & m, Vector & sx, Vector & sy, Vector & sz,
+                              Mesh *mc = NULL);
+   VisualizationSceneVector3d (GridFunction &vgf, Mesh *mc = NULL);
 
-   void NewMeshAndSolution(Mesh *new_m, GridFunction *new_v);
+   void NewMeshAndSolution(Mesh *new_m, Mesh *new_mc, GridFunction *new_v);
 
    virtual ~VisualizationSceneVector3d();
 


### PR DESCRIPTION
This PR adds support for visualization of quadratures (`QuadratureFunction`). They can be loaded from a file through the new command line argument `-q` or in a socket stream with the keyword `quadrature` (instead of `solution`). Two options of visualization are offered (which can be switched by `Q` key):

- Piece-wise constant function on a refined mesh (closed Gauss-Legendre refinement)
- Discontinuous elements with DOFs collocated with the quadrature on the original mesh
- L2 projection onto discontinuous elements

Note that high-order quadratures are supported only for tensor finite elements with the first two options.

TODO 📑 :

- [x] a key for switching
- [x] maintain consistency of quadrature / grid function
- [x] testing
  - [x] 1D
  - [x] vector
  - [x] stream
  - [x] animation 
  - [x] scripts
  - [x] parallel
- [x] proper refinement (ClosedGL?)
- [x] check for tensor basis
- [x] README, CHANGELOG