### PR TITLE
[BUG] Fixed init of the main thread

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1019,6 +1019,8 @@ void PlayScript(istream &scr)
    script = &scr;
    stream_state.keys.clear();
 
+   // Make sure the singleton object returned by GetMainThread() is
+   // initialized from the main thread.
    GetMainThread();
 
    std::thread worker_thread
@@ -1492,6 +1494,8 @@ int main (int argc, char *argv[])
    // check for saved stream file
    if (stream_file != string_none)
    {
+      // Make sure the singleton object returned by GetMainThread() is
+      // initialized from the main thread.
       GetMainThread();
 
       Session stream_session(stream_state.fix_elem_orient,
@@ -1555,6 +1559,8 @@ int main (int argc, char *argv[])
    // server mode, read the mesh and the solution from a socket
    if (input == INPUT_SERVER_MODE)
    {
+      // Make sure the singleton object returned by GetMainThread() is
+      // initialized from the main thread.
       GetMainThread();
 
       // Run server in new thread
@@ -1591,6 +1597,8 @@ int main (int argc, char *argv[])
                       : StreamState::FieldType::MESH;
       }
 
+      // Make sure the singleton object returned by GetMainThread() is
+      // initialized from the main thread.
       GetMainThread();
 
       Session single_session(field_type, std::move(stream_state));

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1019,6 +1019,8 @@ void PlayScript(istream &scr)
    script = &scr;
    stream_state.keys.clear();
 
+   GetMainThread();
+
    std::thread worker_thread
    {
       [&](StreamState local_state)
@@ -1490,6 +1492,8 @@ int main (int argc, char *argv[])
    // check for saved stream file
    if (stream_file != string_none)
    {
+      GetMainThread();
+
       Session stream_session(stream_state.fix_elem_orient,
                              stream_state.save_coloring);
 
@@ -1551,6 +1555,8 @@ int main (int argc, char *argv[])
    // server mode, read the mesh and the solution from a socket
    if (input == INPUT_SERVER_MODE)
    {
+      GetMainThread();
+
       // Run server in new thread
       std::thread serverThread{GLVisServer, portnum, save_stream,
                                stream_state.fix_elem_orient,
@@ -1584,6 +1590,9 @@ int main (int argc, char *argv[])
          field_type = (use_soln) ? StreamState::FieldType::SCALAR
                       : StreamState::FieldType::MESH;
       }
+
+      GetMainThread();
+
       Session single_session(field_type, std::move(stream_state));
       single_session.StartSession();
 

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -37,6 +37,7 @@ typedef void (*Delegate)();
 typedef bool (*IdleDelegate)();
 
 class SdlMainThread;
+SdlMainThread& GetMainThread();
 
 class SdlWindow
 {


### PR DESCRIPTION
This PR fixes initialization of the main thread object, which was sometimes happening in a non-main thread first and as it calls `SDL_Init()`, it was causing crashes on Mac (including CI runners ❗ ).