### PR TITLE
Fix an issue when `numlock` is on

### DIFF
--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -274,7 +274,7 @@ void SdlWindow::keyDownEvent(SDL_Keysym& ks)
    // to be processed there.
    // Note: the same condition has to be used in signalKeyDown().
    if ((ks.sym >= 32 && ks.sym < 127) &&
-       (ks.mod & ~(KMOD_SHIFT | KMOD_CAPS)) == 0)
+       (ks.mod & (KMOD_CTRL | KMOD_ALT | KMOD_GUI)) == 0)
    {
       lastKeyDownProcessed = false;
       return;
@@ -630,7 +630,7 @@ void SdlWindow::signalKeyDown(SDL_Keycode k, SDL_Keymod m)
    queueEvents({ event });
 
    // The same condition as in keyDownEvent().
-   if ((k >= 32 && k < 127) && (m & ~(KMOD_SHIFT | KMOD_CAPS)) == 0)
+   if ((k >= 32 && k < 127) && (m & (KMOD_CTRL | KMOD_ALT | KMOD_GUI)) == 0)
    {
       event.type = SDL_TEXTINPUT;
       event.text.windowID = window_id;


### PR DESCRIPTION
When handling key-down events, do not let the state of keys like numlock influence the logic.

Currently, if `numlock` is on, keys like `P` and `O` are precessed in `keyDownEvent` whereas the intent is for them to be proceesed in `textInputEvent`.

Reported-by: @najlkin
