### PR TITLE
Fixed use-after-delete with dynamic streams and switching quadratures

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1995,8 +1995,6 @@ void SwitchQuadSolution()
 {
    int iqs = ((int)stream_state.GetQuadSolution()+1)
              % ((int)StreamState::QuadSolution::MAX);
-   stream_state.SetQuadSolution((StreamState::QuadSolution)iqs);
-   stream_state.Extrude1DMeshAndSolution();
-   stream_state.ResetMeshAndSolution(vs);
+   stream_state.SwitchQuadSolution((StreamState::QuadSolution)iqs, vs);
    SendExposeEvent();
 }

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -327,7 +327,7 @@ void StreamState::SetQuadSolution(QuadSolution type)
 void StreamState::SwitchQuadSolution(QuadSolution type, VisualizationScene *vs)
 {
    unique_ptr<Mesh> old_mesh;
-   //we must backup the refined mesh to prevent its deleting
+   // we must backup the refined mesh to prevent its deleting
    if (mesh_quad.get())
    {
       internal.mesh.swap(internal.mesh_quad);

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -324,6 +324,20 @@ void StreamState::SetQuadSolution(QuadSolution type)
    quad_sol = type;
 }
 
+void StreamState::SwitchQuadSolution(QuadSolution type, VisualizationScene *vs)
+{
+   unique_ptr<Mesh> old_mesh;
+   //we must backup the refined mesh to prevent its deleting
+   if (mesh_quad.get())
+   {
+      internal.mesh.swap(internal.mesh_quad);
+      internal.mesh_quad.swap(old_mesh);
+   }
+   SetQuadSolution(type);
+   Extrude1DMeshAndSolution();
+   ResetMeshAndSolution(*this, vs);
+}
+
 // Read the content of an input stream (e.g. from socket/file)
 StreamState::FieldType StreamState::ReadStream(istream &is,
                                                const string &data_type)

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -695,12 +695,12 @@ bool StreamState::SetNewMeshAndSolution(StreamState new_state,
    if (new_state.mesh->SpaceDimension() == mesh->SpaceDimension() &&
        new_state.grid_f->VectorDim() == grid_f->VectorDim())
    {
+      ResetMeshAndSolution(new_state, vs);
+
       internal.grid_f = std::move(new_state.internal.grid_f);
       internal.mesh = std::move(new_state.internal.mesh);
       internal.quad_f = std::move(new_state.internal.quad_f);
       internal.mesh_quad = std::move(new_state.internal.mesh_quad);
-
-      ResetMeshAndSolution(vs);
 
       return true;
    }
@@ -710,40 +710,42 @@ bool StreamState::SetNewMeshAndSolution(StreamState new_state,
    }
 }
 
-void StreamState::ResetMeshAndSolution(VisualizationScene* vs)
+void StreamState::ResetMeshAndSolution(StreamState &ss, VisualizationScene* vs)
 {
-   if (mesh->SpaceDimension() == 2)
+   if (ss.mesh->SpaceDimension() == 2)
    {
-      if (grid_f->VectorDim() == 1)
+      if (ss.grid_f->VectorDim() == 1)
       {
          VisualizationSceneSolution *vss =
             dynamic_cast<VisualizationSceneSolution *>(vs);
-         grid_f->GetNodalValues(sol);
-         vss->NewMeshAndSolution(mesh.get(), mesh_quad.get(), &sol, grid_f.get());
+         ss.grid_f->GetNodalValues(ss.sol);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
+                                 ss.grid_f.get());
       }
       else
       {
          VisualizationSceneVector *vsv =
             dynamic_cast<VisualizationSceneVector *>(vs);
-         vsv->NewMeshAndSolution(*grid_f, mesh_quad.get());
+         vsv->NewMeshAndSolution(*ss.grid_f, ss.mesh_quad.get());
       }
    }
    else
    {
-      if (grid_f->VectorDim() == 1)
+      if (ss.grid_f->VectorDim() == 1)
       {
          VisualizationSceneSolution3d *vss =
             dynamic_cast<VisualizationSceneSolution3d *>(vs);
-         grid_f->GetNodalValues(sol);
-         vss->NewMeshAndSolution(mesh.get(), mesh_quad.get(), &sol, grid_f.get());
+         ss.grid_f->GetNodalValues(ss.sol);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
+                                 ss.grid_f.get());
       }
       else
       {
-         ProjectVectorFEGridFunction();
+         ss.ProjectVectorFEGridFunction();
 
          VisualizationSceneVector3d *vss =
             dynamic_cast<VisualizationSceneVector3d *>(vs);
-         vss->NewMeshAndSolution(mesh.get(), mesh_quad.get(), grid_f.get());
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), ss.grid_f.get());
       }
    }
 }

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -91,8 +91,11 @@ public:
    /// Set a (checkerboard) solution when only the mesh is given
    void SetMeshSolution();
 
-   /// Set a quadrature function solution producing a proxy grid function
+   /// Set the quadrature function representation producing a proxy grid function
    void SetQuadSolution(QuadSolution type = QuadSolution::LOR_ClosedGL);
+
+   /// Switch the quadrature function represenation and update the visualization
+   void SwitchQuadSolution(QuadSolution type, VisualizationScene* vs);
 
    /// Get the current representation of quadrature solution
    inline QuadSolution GetQuadSolution() const { return quad_sol; }
@@ -127,12 +130,6 @@ public:
    /// @note: Use with caution when the update is compatible
    /// @see SetNewMeshAndSolution()
    static void ResetMeshAndSolution(StreamState &ss, VisualizationScene* vs);
-
-   /// Updates the given VisualizationScene pointer with the new data
-   /// of this object.
-   /// @note: Use with caution when the update is compatible and the old data are available
-   /// @see SetNewMeshAndSolution()
-   void ResetMeshAndSolution(VisualizationScene* vs) { ResetMeshAndSolution(*this, vs); }
 };
 
 #endif // GLVIS_STREAM_READER_HPP

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -110,7 +110,7 @@ public:
    ProjectVectorFEGridFunction(std::unique_ptr<mfem::GridFunction> gf);
 
    void ProjectVectorFEGridFunction()
-   { internal.grid_f = std::move(ProjectVectorFEGridFunction(std::move(internal.grid_f))); }
+   { internal.grid_f = ProjectVectorFEGridFunction(std::move(internal.grid_f)); }
 
    /// Sets a new mesh and solution from another StreamState object, and
    /// updates the given VisualizationScene pointer with the new data.

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -110,7 +110,7 @@ public:
    ProjectVectorFEGridFunction(std::unique_ptr<mfem::GridFunction> gf);
 
    void ProjectVectorFEGridFunction()
-   { internal.grid_f = ProjectVectorFEGridFunction(std::move(internal.grid_f)); }
+   { internal.grid_f = std::move(ProjectVectorFEGridFunction(std::move(internal.grid_f))); }
 
    /// Sets a new mesh and solution from another StreamState object, and
    /// updates the given VisualizationScene pointer with the new data.

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -123,10 +123,16 @@ public:
                               VisualizationScene* vs);
 
    /// Updates the given VisualizationScene pointer with the new data
-   /// of this object.
+   /// of the given StreamState object.
    /// @note: Use with caution when the update is compatible
    /// @see SetNewMeshAndSolution()
-   void ResetMeshAndSolution(VisualizationScene* vs);
+   static void ResetMeshAndSolution(StreamState &ss, VisualizationScene* vs);
+
+   /// Updates the given VisualizationScene pointer with the new data
+   /// of this object.
+   /// @note: Use with caution when the update is compatible and the old data are available
+   /// @see SetNewMeshAndSolution()
+   void ResetMeshAndSolution(VisualizationScene* vs) { ResetMeshAndSolution(*this, vs); }
 };
 
 #endif // GLVIS_STREAM_READER_HPP


### PR DESCRIPTION
This PR fixes access to the old mesh in `VisualizationScene::NewMeshAndSolution()` shortly after it was deleted in `StreamState::SetNewMeshAndSolution()` by the move of the new data there and similarly when switching quadrature function representations.

❓  This bug was introduced in #286 .