### PR TITLE
Fixed visualization of extruded 1D meshes

### DIFF
--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -1707,7 +1707,7 @@ void VisualizationSceneSolution::PrepareLines()
    line_buf.clear();
    gl3::GlBuilder lb = line_buf.createBuilder();
 
-   if (mesh_coarse)
+   if (mesh_coarse && mesh_coarse->Dimension() > 1)
    {
       auto &ref = mesh->GetRefinementTransforms();
       IsoparametricTransformation trans;
@@ -2200,7 +2200,7 @@ void VisualizationSceneSolution::PrepareLines3()
       Array<int> &RE = RefG->RefEdges;
 
       lb.glBegin (GL_LINES);
-      if (mesh_coarse)
+      if (mesh_coarse && mesh_coarse->Dimension() > 1)
       {
          auto &ref = mesh->GetRefinementTransforms();
          // we assume that mesh_course is used only for tensor finite elements,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(stream_tests
     "mobius-strip"
     "navier"
     "quad"
+    "quadrature-1D"
     "quadrature-lor"
     "remhos"
     "shaper"


### PR DESCRIPTION
This PR fixes visualization of 1D meshes, which are incorrectly recognized as coarse meshes of quadratures, since 1D meshes are backed up before the extrusion (to be used with different representations of quadratures).

Reported by: @vladotomov 

TODO:
- [x] Add 1D test