### PR TITLE
Js enum binding

### DIFF
--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -516,7 +516,6 @@ em::val getPNGByteArray()
 EMSCRIPTEN_BINDINGS(js_funcs)
 {
    em::enum_<StreamState::FieldType>("FieldType")
-   .value("ONE", StreamState::FieldType::ONE)
    .value("UNKNOWN", StreamState::FieldType::UNKNOWN)
    .value("MIN", StreamState::FieldType::MIN)
    .value("SCALAR", StreamState::FieldType::SCALAR)

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -515,6 +515,15 @@ em::val getPNGByteArray()
 // https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#built-in-type-conversions
 EMSCRIPTEN_BINDINGS(js_funcs)
 {
+   em::enum_<StreamState::FieldType>("FieldType")
+   .value("ONE", StreamState::FieldType::ONE)
+   .value("UNKNOWN", StreamState::FieldType::UNKNOWN)
+   .value("MIN", StreamState::FieldType::MIN)
+   .value("SCALAR", StreamState::FieldType::SCALAR)
+   .value("VECTOR", StreamState::FieldType::VECTOR)
+   .value("MESH", StreamState::FieldType::MESH)
+   .value("MAX", StreamState::FieldType::MAX)
+   ;
    em::function("displayStream", &js::displayStream);
    em::function("displayParallelStreams", &js::displayParallelStreams);
    em::function("updateStream", &js::updateStream);


### PR DESCRIPTION
We made some changes in https://github.com/GLVis/glvis/pull/310 to use `StreamState::FieldType` but the `enum` also needed to be bound in emscripten.