### PR TITLE
Quadrature visualization support for glvis-js

### DIFF
--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -338,13 +338,6 @@ int updateStream(std::string stream)
    std::string data_type;
    ss >> data_type;
 
-   if (data_type != "solution")
-   {
-      std::cerr << "unsupported data type '" << data_type << "' for stream update" <<
-                std::endl;
-      return 1;
-   }
-
    StreamState new_state;
    new_state.ReadStream(ss, data_type);
 


### PR DESCRIPTION
Eventually, we should refactor `aux_js.cpp` a bit so that there isn't so much repeated code with `glvis.cpp`. For now, this is just following the same design pattern to see if we can get quadrature support in `glvis-js`.