### PR TITLE
Fixed Alt handling to allow layout translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ Key commands
 - <kbd>F6</kbd> – Palette menu (negative repeat number flips the palette)
 - <kbd>F7</kbd> – Change the minimum and maximum values
 - <kbd>Shift</kbd> + <kbd>F7</kbd> – Set the bounding box from the terminal
+- <kbd>Ctrl</kbd> + <kbd>a</kbd> – Cycle through the auto-scaling options:
+  - `off`: do not change the bounding box and the value range
+  - `on` (default): recompute both the bounding box and the value range
+  - `value`: recompute only the value range
+  - `mesh`: recompute only the bounding box
 
 ## 2D scalar data
 

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -278,7 +278,7 @@ void SdlWindow::keyDownEvent(SDL_Keysym& ks)
    {
       lastKeyDownProcessed = false;
       lastKeyDownMods = ks.mod;
-      lastKeyDownChar = scan_name[0];
+      lastKeyDownChar = ks.sym;
       return;
    }
    // If the key is not in the range [32,127) then we processed the event here.

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -274,10 +274,10 @@ void SdlWindow::keyDownEvent(SDL_Keysym& ks)
    // to be processed there.
    // Note: the same condition has to be used in signalKeyDown().
    const char *scan_name = SDL_GetScancodeName(ks.scancode);
-   if ((scan_name[0] >= 32 && scan_name[0] < 127) && scan_name[1] == '\0'
-       && (ks.mod & (KMOD_CTRL | KMOD_ALT | KMOD_GUI)) == 0)
+   if ((scan_name[0] >= 32 && scan_name[0] < 127) && scan_name[1] == '\0')
    {
       lastKeyDownProcessed = false;
+      lastKeyDownMods = ks.mod;
       return;
    }
    // If any 'mod' key other than KMOD_SHIFT or KMOD_CAPS is pressed, or the key
@@ -313,13 +313,22 @@ void SdlWindow::textInputEvent(const SDL_TextInputEvent &tie)
    const char c = tie.text[0];
    if (onKeyDown[c])
    {
-      // Keys with 'mods' (other than Shift and CapsLock) are processed in
-      // keyDownEvent().
-      const int mods = 0;
-      onKeyDown[c](mods);
+      onKeyDown[c](lastKeyDownMods & ~(KMOD_CAPS | KMOD_LSHIFT | KMOD_RSHIFT));
 
       // Record the key in 'saved_keys':
+      bool isAlt = lastKeyDownMods & (KMOD_ALT);
+      bool isCtrl = lastKeyDownMods & (KMOD_CTRL);
+      if (isAlt || isCtrl)
+      {
+         saved_keys += "[";
+      }
+      if (isCtrl) { saved_keys += "C-"; }
+      if (isAlt) { saved_keys += "Alt-"; }
       saved_keys += c;
+      if (isAlt || isCtrl)
+      {
+         saved_keys += "]";
+      }
    }
 }
 

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -274,14 +274,17 @@ void SdlWindow::keyDownEvent(SDL_Keysym& ks)
    // events to be processed there.
    // Note: the same condition has to be used in signalKeyDown().
    const char *scan_name = SDL_GetScancodeName(ks.scancode);
-   if ((scan_name[0] >= 32 && scan_name[0] < 127) && scan_name[1] == '\0')
+   if ((scan_name[0] >= 32 && scan_name[0] < 127) && scan_name[1] == '\0'
+       && (ks.mod & (KMOD_CTRL | KMOD_LALT | KMOD_GUI)) == 0)
    {
       lastKeyDownProcessed = false;
       lastKeyDownMods = ks.mod;
       lastKeyDownChar = ks.sym;
       return;
    }
-   // If the key is not in the range [32,127) then we processed the event here.
+   // If any 'mod' key other than KMOD_SHIFT, KMOD_CAPS or KMOD_RALT is
+   // pressed, or the key is not in the range [32,127) then we processed the
+   // event here.
    lastKeyDownProcessed = true;
    if (onKeyDown[ks.sym])
    {
@@ -647,7 +650,7 @@ void SdlWindow::signalKeyDown(SDL_Keycode k, SDL_Keymod m)
    queueEvents({ event });
 
    // The same condition as in keyDownEvent().
-   if (k >= 32 && k < 127)
+   if ((k >= 32 && k < 127) && (m & (KMOD_CTRL | KMOD_LALT | KMOD_GUI)) == 0)
    {
       event.type = SDL_TEXTINPUT;
       event.text.windowID = window_id;

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -270,8 +270,8 @@ void SdlWindow::mouseEventUp(SDL_MouseButtonEvent& eb)
 void SdlWindow::keyDownEvent(SDL_Keysym& ks)
 {
    // Some keyDown events will be followed by a textInput event which will
-   // handle key translation due to Shift or CapsLock, so we leave such events
-   // to be processed there.
+   // handle key translation due to Shift, CapsLock or AltGr, so we leave such
+   // events to be processed there.
    // Note: the same condition has to be used in signalKeyDown().
    const char *scan_name = SDL_GetScancodeName(ks.scancode);
    if ((scan_name[0] >= 32 && scan_name[0] < 127) && scan_name[1] == '\0')
@@ -280,8 +280,7 @@ void SdlWindow::keyDownEvent(SDL_Keysym& ks)
       lastKeyDownMods = ks.mod;
       return;
    }
-   // If any 'mod' key other than KMOD_SHIFT or KMOD_CAPS is pressed, or the key
-   // is not in the range [32,127) then we processed the event here.
+   // If the key is not in the range [32,127) then we processed the event here.
    lastKeyDownProcessed = true;
    if (onKeyDown[ks.sym])
    {

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -641,7 +641,7 @@ void SdlWindow::signalKeyDown(SDL_Keycode k, SDL_Keymod m)
    queueEvents({ event });
 
    // The same condition as in keyDownEvent().
-   if ((k >= 32 && k < 127) && (m & (KMOD_CTRL | KMOD_ALT | KMOD_GUI)) == 0)
+   if (k >= 32 && k < 127)
    {
       event.type = SDL_TEXTINPUT;
       event.text.windowID = window_id;

--- a/lib/sdl.cpp
+++ b/lib/sdl.cpp
@@ -278,6 +278,7 @@ void SdlWindow::keyDownEvent(SDL_Keysym& ks)
    {
       lastKeyDownProcessed = false;
       lastKeyDownMods = ks.mod;
+      lastKeyDownChar = scan_name[0];
       return;
    }
    // If the key is not in the range [32,127) then we processed the event here.
@@ -309,7 +310,13 @@ void SdlWindow::textInputEvent(const SDL_TextInputEvent &tie)
    // This event follows a keyDown event where we've recorded if the event was
    // processed in keyDownEvent(). If it was not processed, we do it here.
    if (lastKeyDownProcessed) { return; }
-   const char c = tie.text[0];
+   char c = tie.text[0];
+   if (!onKeyDown[c])
+   {
+      // If the key was translated to something that is not handled, return to
+      // the physical key passed in the keyDown event.
+      c = lastKeyDownChar;
+   }
    if (onKeyDown[c])
    {
       onKeyDown[c](lastKeyDownMods & ~(KMOD_CAPS | KMOD_LSHIFT | KMOD_RSHIFT));

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -127,6 +127,7 @@ private:
    std::string screenshot_file;
    bool screenshot_convert;
    bool lastKeyDownProcessed;
+   Uint16 lastKeyDownMods;
 
    // internal event handlers
    void windowEvent(SDL_WindowEvent& ew);

--- a/lib/sdl.hpp
+++ b/lib/sdl.hpp
@@ -128,6 +128,7 @@ private:
    bool screenshot_convert;
    bool lastKeyDownProcessed;
    Uint16 lastKeyDownMods;
+   char lastKeyDownChar;
 
    // internal event handlers
    void windowEvent(SDL_WindowEvent& ew);


### PR DESCRIPTION
Fixed Alt handling to allow key translation for different layouts by passing modifiers to the text input event.

👉 Please test on different platforms. On Windows+WSL or Linux: Left Alt does *not* translate the key and Right Alt (AltGr) does translate the key.

❓ This is a possible fix for #311 .