### PR TITLE
Final changes for glvis-4.3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,17 +15,17 @@ Version 4.3.2 released on Sep 27, 2024
 - Fixed the Mac binary build in GitHub CI and provided a signed and notarized
   version for download from the website.
 
-- Miscellaneous CI improvements including: generating image diffs for tests,
-  set `fail-fast: false` so that tests always run, rename artifacts to help
-  avoid confusion, code-cleanup/light refactoring.
-
 - Fixed handling of key press events to work with localized layouts and enable
   key translation with 'AltGr'.
 
+- Updated JavaScript bindings to fix issues in glvis-js and pyglvis, and added
+  support for quadrature data visualization.
+
 - Fixed visualization of 1D data and added a regression test.
 
-- Updated javascript bindings to fix issues in glvis-js and pyglvis, and 
-  add support for quadrature data visualization.
+- Miscellaneous CI improvements including: generating image diffs for tests,
+  set `fail-fast: false` so that tests always run, rename artifacts to help
+  avoid confusion, code-cleanup/light refactoring.
 
 
 Version 4.3 released on Aug 7, 2024

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,8 @@
 Version 4.3.2 released on Sep 27, 2024
 ======================================
 
-- Fix the Mac binary build in GitHub CI.
+- Fixed the Mac binary build in GitHub CI and provided a signed and notarized
+  version for download from the website.
 
 - Miscellaneous CI improvements including: generating image diffs for tests,
   set `fail-fast: false` so that tests always run, rename artifacts to help

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,9 @@ Version 4.3.2 released on Sep 27, 2024
 
 - Fixed visualization of 1D data and added a regression test.
 
+- Updated javascript bindings to fix issues in glvis-js and pyglvis, and 
+  add support for quadrature data visualization.
+
 
 Version 4.3 released on Aug 7, 2024
 ===================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,8 +9,8 @@
                              https://glvis.org
 
 
-Version 4.3.1 (development)
-===========================
+Version 4.3.2 released on Sep 27, 2024
+======================================
 
 - Fix the Mac binary build in GitHub CI.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/GLVis/glvis/releases/latest"><img alt="Release" src="https://img.shields.io/badge/release-v4.3-success.svg"></a>
+<a href="https://github.com/GLVis/glvis/releases/latest"><img alt="Release" src="https://img.shields.io/badge/release-v4.3.2-success.svg"></a>
 <a href="https://github.com/GLVis/glvis/actions/workflows/builds.yml"><img alt="Build" src="https://github.com/GLVis/glvis/actions/workflows/builds.yml/badge.svg"></a>
 <a href="https://github.com/glvis/glvis/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-BSD-success.svg"></a>
 <a href="https://glvis.github.io/doxygen/html/index.html"><img alt="Doxygen" src="https://img.shields.io/badge/code-documented-success.svg"></a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
                              https://glvis.org
 
-<a href="https://github.com/GLVis/glvis/releases/latest"><img alt="Release" src="https://img.shields.io/badge/release-v4.3-success.svg"></a>
+<a href="https://github.com/GLVis/glvis/releases/latest"><img alt="Release" src="https://img.shields.io/badge/release-v4.3.2-success.svg"></a>
 <a href="https://github.com/GLVis/glvis/actions/workflows/builds.yml"><img alt="Build" src="https://github.com/GLVis/glvis/actions/workflows/builds.yml/badge.svg"></a>
 <a href="https://github.com/glvis/glvis/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-BSD-success.svg"></a>
 <a href="https://glvis.github.io/doxygen/html/index.html"><img alt="Doxygen" src="https://img.shields.io/badge/code-documented-success.svg"></a>

--- a/share/Info.cmake.plist.in
+++ b/share/Info.cmake.plist.in
@@ -11,7 +11,7 @@
   <key>CFBundleIconFile</key>
   <string>GLVis.icns</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.3</string>
+  <string>4.3.2</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundlePackageType</key>

--- a/share/Info.plist
+++ b/share/Info.plist
@@ -11,7 +11,7 @@
   <key>CFBundleIconFile</key>
   <string>GLVis.icns</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.3</string>
+  <string>4.3.2</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundlePackageType</key>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "glvis",
-  "version": "4.3",
+  "version": "4.3.2",
   "dependencies": [
     "fontconfig",
     "freetype",


### PR DESCRIPTION
📆 Target release date: September 27, 2024

**TODO:**
- [x] Update CHANGELOG
- [x] Update version number from `4.3` to `4.3.2`
- [x] Companion website PR: https://github.com/GLVis/web/pull/15

**After the release:**
- [ ] Update [glvis-js](https://github.com/GLVis/glvis-js) and [glvis.org/live](https://glvis.org/live/) (DO THIS BEFORE pyglvis)

**Postponed:**
- [ ] Add style check to PR CIs
- [ ] https://github.com/GLVis/glvis/issues/241
- [ ] #315 

See also https://github.com/GLVis/glvis/issues/304
