### PR TITLE
Fix a Window warning on X11 when XInput2 is not available

### DIFF
--- a/lib/sdl_x11.cpp
+++ b/lib/sdl_x11.cpp
@@ -45,7 +45,6 @@ void SdlX11Platform::RegisterWindow(SDL_Window* window)
       return;
    }
    Display *disp = sysinfo.info.x11.display;
-   Window wnd = sysinfo.info.x11.window;
 
    display_fds.emplace(window, ConnectionNumber(disp));
 
@@ -80,6 +79,7 @@ void SdlX11Platform::RegisterWindow(SDL_Window* window)
    {
       cerr << "Failed to disable XInput on the default root window!" << endl;
    }
+   Window wnd = sysinfo.info.x11.window;
    if (XISelectEvents_(disp, wnd, &event_mask, 1) != Success)
    {
       cerr << "Failed to disable XInput on the current window!" << endl;


### PR DESCRIPTION
The warning that this PR fixes is:
```
lib/sdl_x11.cpp: In member function ‘virtual void SdlX11Platform::RegisterWindow(SDL_Window*)’:
lib/sdl_x11.cpp:48:11: warning: unused variable ‘wnd’ [-Wunused-variable]
   48 |    Window wnd = sysinfo.info.x11.window;
      |           ^~~
```
