### PR TITLE
Visualization of 2D grid functions with 3 vector dimensions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,10 @@ Version 4.3.3 (development)
 
 - Fixed a bug where discrete textures would not repeat.
 
+- Added support for 2D data (mesh and grid function) using scalar finite
+  elements with 3 vector dimensions or vector finite elements with 3 range
+  dimensions (requires MFEM v4.8).
+
 
 Version 4.3.2 released on Sep 27, 2024
 ======================================

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -223,8 +223,7 @@ bool GLVisInitVis(StreamState::FieldType field_type,
    }
    else if (field_type == StreamState::FieldType::VECTOR)
    {
-      if (stream_state.mesh->SpaceDimension() == 2 && (!stream_state.grid_f ||
-                                                       stream_state.grid_f->VectorDim() == 2))
+      if (stream_state.mesh->SpaceDimension() == 2)
       {
          if (stream_state.grid_f)
          {
@@ -236,38 +235,11 @@ bool GLVisInitVis(StreamState::FieldType field_type,
                                               stream_state.solv, stream_state.mesh_quad.get());
          }
       }
-      else if (stream_state.mesh->SpaceDimension() == 3 || (stream_state.grid_f &&
-                                                            stream_state.grid_f->VectorDim() == 3))
+      else if (stream_state.mesh->SpaceDimension() == 3)
       {
          if (stream_state.grid_f)
          {
             stream_state.ProjectVectorFEGridFunction();
-            // Extrude 2D3V grid functions to 3D
-            if (stream_state.mesh->SpaceDimension() < 3)
-            {
-               Mesh *mesh3d = new Mesh(*stream_state.mesh);
-               const FiniteElementSpace *fesx = stream_state.mesh->GetNodalFESpace();
-               const FiniteElementCollection *fecx = (fesx)?(fesx->FEColl()):(NULL);
-               if (fecx)
-               {
-                  mesh3d->SetCurvature(fecx->GetOrder(),
-                                       fecx->GetContType() == FiniteElementCollection::DISCONTINUOUS,
-                                       3);
-               }
-               else
-               {
-                  mesh3d->SetCurvature(1, false, 3);
-               }
-               FiniteElementSpace *fes2d = stream_state.grid_f->FESpace();
-               FiniteElementSpace *fes3d = new FiniteElementSpace(*fes2d, mesh3d);
-               GridFunction *gf3d = new GridFunction(fes3d);
-               *gf3d = *stream_state.grid_f;
-               stream_state.grid_f->MakeOwner(NULL);
-               gf3d->MakeOwner(const_cast<FiniteElementCollection*>(fes2d->FEColl()));
-               stream_state.SetGridFunction(gf3d);
-               delete fes2d;
-               stream_state.SetMesh(mesh3d);
-            }
             vs = new VisualizationSceneVector3d(*stream_state.grid_f,
                                                 stream_state.mesh_quad.get());
          }
@@ -355,7 +327,7 @@ int ScriptReadSolution(istream &scr, StreamState& state)
       state.SetGridFunction(new GridFunction(state.mesh.get(), isol));
    }
 
-   state.Extrude1DMeshAndSolution();
+   state.ExtrudeMeshAndSolution();
 
    return 0;
 }
@@ -396,7 +368,7 @@ int ScriptReadQuadrature(istream &scr, StreamState& state)
    }
 
    state.SetQuadSolution();
-   state.Extrude1DMeshAndSolution();
+   state.ExtrudeMeshAndSolution();
 
    return 0;
 }
@@ -430,7 +402,7 @@ int ScriptReadParSolution(istream &scr, StreamState& state)
                                          sol_prefix.c_str(), state);
    if (!err_read)
    {
-      state.Extrude1DMeshAndSolution();
+      state.ExtrudeMeshAndSolution();
    }
    return err_read;
 }
@@ -465,7 +437,7 @@ int ScriptReadParQuadrature(istream &scr, StreamState& state)
    if (!err_read)
    {
       state.SetQuadSolution();
-      state.Extrude1DMeshAndSolution();
+      state.ExtrudeMeshAndSolution();
    }
    return err_read;
 }
@@ -487,7 +459,7 @@ int ScriptReadDisplMesh(istream &scr, StreamState& state)
       cout << word << endl;
       meshstate.SetMesh(new Mesh(imesh, 1, 0, state.fix_elem_orient));
    }
-   meshstate.Extrude1DMeshAndSolution();
+   meshstate.ExtrudeMeshAndSolution();
    Mesh* const m = meshstate.mesh.get();
    if (init_nodes == NULL)
    {
@@ -1738,7 +1710,7 @@ void ReadSerial(StreamState& state)
       state.SetMeshSolution();
    }
 
-   state.Extrude1DMeshAndSolution();
+   state.ExtrudeMeshAndSolution();
 }
 
 
@@ -1843,7 +1815,7 @@ void ReadParallel(int np, StreamState& state)
       exit(1);
    }
 
-   state.Extrude1DMeshAndSolution();
+   state.ExtrudeMeshAndSolution();
 }
 
 int ReadParMeshAndGridFunction(int np, const char *mesh_prefix,

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -147,6 +147,10 @@ void StreamState::Extrude2D3VMeshAndSolution()
 {
    if (mesh->SpaceDimension() == 3 || !grid_f || grid_f->VectorDim() < 3) { return; }
 
+   // not all vector elements can be embedded in 3D, so conversion to L2 elements
+   // is performed already here
+   ProjectVectorFEGridFunction();
+
    Mesh *mesh3d = new Mesh(*mesh);
    const FiniteElementSpace *fesx = mesh->GetNodalFESpace();
    const FiniteElementCollection *fecx = (fesx)?(fesx->FEColl()):(NULL);

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -82,8 +82,14 @@ public:
    void SetQuadFunction(mfem::QuadratureFunction *qf);
    void SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction> &&pqf);
 
+   /// Helper function for visualizing 1D or 2D3V data
+   void ExtrudeMeshAndSolution();
+
    /// Helper function for visualizing 1D data
    void Extrude1DMeshAndSolution();
+
+   /// Helper function for visualization of 2D3V data
+   void Extrude2D3VMeshAndSolution();
 
    /// Helper function to build the quadrature function from pieces
    void CollectQuadratures(mfem::QuadratureFunction *qf_array[], int npieces);

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -472,7 +472,7 @@ int GLVisCommand::Execute()
                {
                   new_state.SetQuadSolution();
                }
-               new_state.Extrude1DMeshAndSolution();
+               new_state.ExtrudeMeshAndSolution();
             }
          }
          if (curr_state.SetNewMeshAndSolution(std::move(new_state), *vs))
@@ -956,7 +956,7 @@ void communication_thread::execute()
 
          // cout << "Stream: new solution" << endl;
 
-         tmp.Extrude1DMeshAndSolution();
+         tmp.ExtrudeMeshAndSolution();
 
          if (glvis_command->NewMeshAndSolution(std::move(tmp)))
          {

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -404,6 +404,15 @@ void VisualizationSceneVector3d::Init()
 
    VisualizationSceneSolution3d::Init();
 
+   mesh_volume = 0.0;
+   if (mesh)
+   {
+      for (int i=0; i<mesh->GetNE(); i++)
+      {
+         mesh_volume += mesh->GetElementVolume(i);
+      }
+   }
+
    PrepareVectorField();
    PrepareDisplacedMesh();
 
@@ -1333,8 +1342,8 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlDrawable& buf,
                                             double sz, double s)
 {
    static int nv = mesh -> GetNV();
-   static double volume = (bb.x[1]-bb.x[0])  *(bb.y[1]-bb.y[0])
-                          * ((bb.z[1] > bb.z[0])?(bb.z[1]-bb.z[0]):(1.));
+   static double bb_vol = (bb.x[1]-bb.x[0])*(bb.y[1]-bb.y[0])*(bb.z[1]-bb.z[0]);
+   static double volume = std::max(bb_vol, mesh_volume);
    static double h      = pow(volume/nv, 0.333);
    static double hh     = pow(volume, 0.333) / 10;
 

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -1333,7 +1333,8 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlDrawable& buf,
                                             double sz, double s)
 {
    static int nv = mesh -> GetNV();
-   static double volume = (bb.x[1]-bb.x[0])*(bb.y[1]-bb.y[0])*(bb.z[1]-bb.z[0]);
+   static double volume = (bb.x[1]-bb.x[0])  *(bb.y[1]-bb.y[0])
+                          * ((bb.z[1] > bb.z[0])?(bb.z[1]-bb.z[0]):(1.));
    static double h      = pow(volume/nv, 0.333);
    static double hh     = pow(volume, 0.333) / 10;
 

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -22,6 +22,7 @@ protected:
 
    Vector *solx, *soly, *solz;
    int drawvector, scal_func;
+   double mesh_volume;
    gl3::GlDrawable vector_buf;
    gl3::GlDrawable displine_buf;
 


### PR DESCRIPTION
This addresses the issue of elements with vdim=3 in 2D (or 1D) from #326 and vector elements RT/ND_R2D spaces from #291 .
◀️ dependency: RT/ND_R2D support requires GLVis compiled with mfem/mfem#4731 .
![image](https://github.com/user-attachments/assets/f5ede7b2-faf6-42b6-bb80-62b3f89f237e)