### PR TITLE
2d3v-vis suggestion 

### DIFF
--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -404,12 +404,12 @@ void VisualizationSceneVector3d::Init()
 
    VisualizationSceneSolution3d::Init();
 
-   volume = 0.0;
+   mesh_volume = 0.0;
    if (mesh)
    {
       for (int i=0; i<mesh->GetNE(); i++)
       {
-         volume += mesh->GetElementVolume(i);
+         mesh_volume += mesh->GetElementVolume(i);
       }
    }
 
@@ -1342,6 +1342,8 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlDrawable& buf,
                                             double sz, double s)
 {
    static int nv = mesh -> GetNV();
+   static double bb_vol = (bb.x[1]-bb.x[0])*(bb.y[1]-bb.y[0])*(bb.z[1]-bb.z[0]);
+   static double volume = std::max(bb_vol, mesh_volume);
    static double h      = pow(volume/nv, 0.333);
    static double hh     = pow(volume, 0.333) / 10;
 

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -404,6 +404,15 @@ void VisualizationSceneVector3d::Init()
 
    VisualizationSceneSolution3d::Init();
 
+   volume = 0.0;
+   if (mesh)
+   {
+      for (int i=0; i<mesh->GetNE(); i++)
+      {
+         volume += mesh->GetElementVolume(i);
+      }
+   }
+
    PrepareVectorField();
    PrepareDisplacedMesh();
 
@@ -1333,7 +1342,6 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlDrawable& buf,
                                             double sz, double s)
 {
    static int nv = mesh -> GetNV();
-   static double volume = (bb.x[1]-bb.x[0])*(bb.y[1]-bb.y[0])*(bb.z[1]-bb.z[0]);
    static double h      = pow(volume/nv, 0.333);
    static double hh     = pow(volume, 0.333) / 10;
 

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -22,6 +22,7 @@ protected:
 
    Vector *solx, *soly, *solz;
    int drawvector, scal_func;
+   double volume;
    gl3::GlDrawable vector_buf;
    gl3::GlDrawable displine_buf;
 

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -22,7 +22,7 @@ protected:
 
    Vector *solx, *soly, *solz;
    int drawvector, scal_func;
-   double volume;
+   double mesh_volume;
    gl3::GlDrawable vector_buf;
    gl3::GlDrawable displine_buf;
 


### PR DESCRIPTION
This produces better scaling for some vector display types (cycled using 'v') on 2D meshes embedded in 3D space.