### PR TITLE
Vector 1D grid functions including R1D

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,8 +26,10 @@ Version 4.3.3 (development)
 - Fixed a bug where discrete textures would not repeat.
 
 - Added support for 2D data (mesh and grid function) using scalar finite
-  elements with 3 vector dimensions or vector finite elements with 3 range
-  dimensions (requires MFEM v4.8).
+  elements with 3 vector dimensions
+
+- Added support for 1D/2D vector finite elements with 3 range dimensions
+  (requires MFEM v4.8).
 
 
 Version 4.3.2 released on Sep 27, 2024

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,8 +25,8 @@ Version 4.3.3 (development)
 
 - Fixed a bug where discrete textures would not repeat.
 
-- Added support for 2D data (mesh and grid function) using scalar finite
-  elements with 3 vector dimensions
+- Added support for 1D/2D data (mesh and grid function) using scalar finite
+  elements with up to 3 vector dimensions
 
 - Added support for 1D/2D vector finite elements with 3 range dimensions
   (requires MFEM v4.8).

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -144,7 +144,12 @@ void StreamState::Extrude1DMeshAndSolution()
       if (grid_f->VectorDim() > 1)
       {
          ProjectVectorFEGridFunction();
+      }
 
+      grid_f_2d = Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
+
+      if (grid_f_2d->VectorDim() < grid_f->VectorDim())
+      {
          // workaround for older MFEM where Extrude1DGridFunction()
          // does not work for vector grid functions
          FiniteElementCollection *fec2d = new L2_FECollection(
@@ -157,11 +162,7 @@ void StreamState::Extrude1DMeshAndSolution()
          ::VectorExtrudeCoefficient vc2d(mesh.get(), vcsol, 1);
          grid_f_2d->ProjectCoefficient(vc2d);
       }
-      else
-      {
-         grid_f_2d =
-            Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
-      }
+
       internal.grid_f.reset(grid_f_2d);
    }
    else if (sol.Size() == mesh->GetNV())

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -139,19 +139,19 @@ void StreamState::Extrude1DMeshAndSolution()
 
    if (grid_f)
    {
-      GridFunction *grid_f_2d = NULL;
-
       if (grid_f->VectorDim() > 1)
       {
          ProjectVectorFEGridFunction();
       }
 
-      grid_f_2d = Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
+      GridFunction *grid_f_2d = Extrude1DGridFunction(mesh.get(), mesh2d,
+                                                      grid_f.get(), 1);
 
       if (grid_f_2d->VectorDim() < grid_f->VectorDim())
       {
          // workaround for older MFEM where Extrude1DGridFunction()
          // does not work for vector grid functions
+         delete grid_f_2d;
          FiniteElementCollection *fec2d = new L2_FECollection(
             grid_f->FESpace()->FEColl()->GetOrder(), 2);
          FiniteElementSpace *fes2d = new FiniteElementSpace(mesh2d, fec2d,

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -17,6 +17,21 @@
 using namespace std;
 using namespace mfem;
 
+/// Class used for extruding vector GridFunctions
+class VectorExtrudeCoefficient : public VectorCoefficient
+{
+private:
+   int n;
+   Mesh *mesh_in;
+   VectorCoefficient &sol_in;
+public:
+   VectorExtrudeCoefficient(Mesh *m, VectorCoefficient &s, int n_)
+      : VectorCoefficient(s.GetVDim()), n(n_), mesh_in(m), sol_in(s) { }
+   void Eval(Vector &v, ElementTransformation &T,
+             const IntegrationPoint &ip) override;
+   virtual ~VectorExtrudeCoefficient() { }
+};
+
 /// Helper function for extrusion of 1D quadrature functions to 2D
 QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
                                           QuadratureFunction *qf, int ny);
@@ -124,9 +139,29 @@ void StreamState::Extrude1DMeshAndSolution()
 
    if (grid_f)
    {
-      GridFunction *grid_f_2d =
-         Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
+      GridFunction *grid_f_2d = NULL;
 
+      if (grid_f->VectorDim() > 1)
+      {
+         ProjectVectorFEGridFunction();
+
+         // workaround for older MFEM where Extrude1DGridFunction()
+         // does not work for vector grid functions
+         FiniteElementCollection *fec2d = new L2_FECollection(
+            grid_f->FESpace()->FEColl()->GetOrder(), 2);
+         FiniteElementSpace *fes2d = new FiniteElementSpace(mesh2d, fec2d,
+                                                            grid_f->FESpace()->GetVDim());
+         grid_f_2d = new GridFunction(fes2d);
+         grid_f_2d->MakeOwner(fec2d);
+         VectorGridFunctionCoefficient vcsol(grid_f.get());
+         ::VectorExtrudeCoefficient vc2d(mesh.get(), vcsol, 1);
+         grid_f_2d->ProjectCoefficient(vc2d);
+      }
+      else
+      {
+         grid_f_2d =
+            Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
+      }
       internal.grid_f.reset(grid_f_2d);
    }
    else if (sol.Size() == mesh->GetNV())
@@ -802,6 +837,15 @@ void StreamState::ResetMeshAndSolution(StreamState &ss, VisualizationScene* vs)
          vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), ss.grid_f.get());
       }
    }
+}
+
+void ::VectorExtrudeCoefficient::Eval(Vector &v, ElementTransformation &T,
+                                      const IntegrationPoint &ip)
+{
+   ElementTransformation *T_in =
+      mesh_in->GetElementTransformation(T.ElementNo / n);
+   T_in->SetIntPoint(&ip);
+   sol_in.Eval(v, *T_in, ip);
 }
 
 QuadratureFunction *Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,


### PR DESCRIPTION
Added support for vector 1D grid functions including RT/ND_R1D hybrid elements. Ideally, this should be handled on the side of MFEM, where mfem/mfem#4781 adds this, but a workaround/backup implementation on the side of GLVis is provided.