### PR TITLE
Loading of data collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,13 @@ Version 4.3.3 (development)
   elements with 3 vector dimensions or vector finite elements with 3 range
   dimensions (requires MFEM v4.8).
 
+- Added loading of data collections (VisIt, Sidre, FMS and Conduit) through
+  parameters '-visit', '-sidre', '-fms' and '-conduit' respectively. The name
+  of the field can be specified through '-g' or '-q' for a quadrature field.
+  Optionally, the cycle and protocol can be provided through 'dc-cycle' and
+  'dc-prot' parameters respectively. Note GLVis must be compiled with MFEM
+  configured with the associated libraries.
+
 
 Version 4.3.2 released on Sep 27, 2024
 ======================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,13 @@ Version 4.3.3 (development)
 - Palettes can now also be specified with explicit alpha channels. See the
   example file share/palettes-variable-opacity.txt.
 
+- Added loading of data collections (VisIt, Sidre, FMS and Conduit) through
+  parameters '-visit', '-sidre', '-fms' and '-conduit' respectively. The name
+  of the field can be specified through '-g' or '-q' for a quadrature field.
+  Optionally, the cycle and protocol can be provided through 'dc-cycle' and
+  'dc-prot' parameters respectively. Note GLVis must be compiled with MFEM
+  configured with the associated libraries.
+
 - Fixed a bug where discrete textures would not repeat.
 
 - Added support for 1D/2D data (mesh and grid function) using scalar finite
@@ -30,13 +37,6 @@ Version 4.3.3 (development)
 
 - Added support for 1D/2D vector finite elements with 3 range dimensions
   (requires MFEM v4.8).
-
-- Added loading of data collections (VisIt, Sidre, FMS and Conduit) through
-  parameters '-visit', '-sidre', '-fms' and '-conduit' respectively. The name
-  of the field can be specified through '-g' or '-q' for a quadrature field.
-  Optionally, the cycle and protocol can be provided through 'dc-cycle' and
-  'dc-prot' parameters respectively. Note GLVis must be compiled with MFEM
-  configured with the associated libraries.
 
 
 Version 4.3.2 released on Sep 27, 2024

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1027,9 +1027,15 @@ struct Session
       , reader(state)
    { }
 
+   Session(Session &&s)
+      : input_streams(std::move(s.input_streams))
+      , state(std::move(s.state))
+      , reader(state) //no move constructor
+      , handler(std::move(s.handler))
+   { }
+
    ~Session() = default;
 
-   Session(Session&& from) = default;
    Session& operator= (Session&& from) = default;
 
    void StartSession()

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -483,7 +483,9 @@ int ScriptReadDataColl(istream &scr, DataState &state, bool mesh_only = true,
 
    DataCollectionReader reader(state);
    if (dc_protocol != string_default)
+   {
       reader.SetProtocol(dc_protocol.c_str());
+   }
 
    if (mesh_only)
       err_read = reader.ReadSerial((DataCollectionReader::CollType)type,

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1718,7 +1718,7 @@ void SetGridFunction(StreamState& state)
 {
    if (gf_component != -1)
    {
-      if (gf_component < 0 || gf_component >= state.grid_f->VectorDim())
+      if (gf_component < 0 || gf_component >= state.grid_f->FESpace()->GetVDim())
       {
          cerr << "Invalid component " << gf_component << '.' << endl;
          exit(1);

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1077,7 +1077,7 @@ public:
    {
       StreamReader reader(state);
       int ierr = reader.ReadStream(*stream, data_type);
-      if (!ierr) { return ierr; }
+      if (ierr) { return ierr; }
       input_streams.emplace_back(std::move(stream));
       input_streams = std::move(input_streams);
 
@@ -1089,7 +1089,7 @@ public:
    {
       StreamReader reader(state);
       int ierr = reader.ReadStreams(input_streams);
-      if (!ierr) { return ierr; }
+      if (ierr) { return ierr; }
       input_streams = streams;
 
       StartSession();

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -138,7 +138,7 @@ bool GLVisInitVis(StreamState::FieldType field_type,
    if (input_streams.size() > 0)
    {
       GetAppWindow()->setOnKeyDown(SDLK_SPACE, ThreadsPauseFunc);
-      glvis_command = new GLVisCommand(&vs, stream_state, &stream_state.keep_attr);
+      glvis_command = new GLVisCommand(&vs, stream_state);
       comm_thread = new communication_thread(std::move(input_streams), glvis_command);
    }
 

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1079,7 +1079,6 @@ public:
       int ierr = reader.ReadStream(*stream, data_type);
       if (ierr) { return ierr; }
       input_streams.emplace_back(std::move(stream));
-      input_streams = std::move(input_streams);
 
       StartSession();
       return 0;
@@ -1088,9 +1087,9 @@ public:
    int StartStreamSession(StreamCollection &&streams)
    {
       StreamReader reader(state);
-      int ierr = reader.ReadStreams(input_streams);
+      int ierr = reader.ReadStreams(streams);
       if (ierr) { return ierr; }
-      input_streams = streams;
+      input_streams = std::move(streams);
 
       StartSession();
       return 0;

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1923,10 +1923,8 @@ int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
       state.SetGridFunction(NULL);
    }
 
-   Array<Mesh *> mesh_array(np);
-   Array<QuadratureFunction *> qf_array(np);
-   mesh_array = NULL;
-   qf_array = NULL;
+   std::vector<Mesh*> mesh_array(np);
+   std::vector<QuadratureFunction*> qf_array(np);
 
    int read_err = 0;
    for (int p = 0; p < np; p++)
@@ -1984,10 +1982,10 @@ int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
    if (!read_err)
    {
       // create the combined mesh and gf
-      state.SetMesh(new Mesh(mesh_array, np));
+      state.SetMesh(new Mesh(mesh_array.data(), np));
       if (sol_prefix)
       {
-         state.CollectQuadratures(qf_array, np);
+         state.SetQuadFunction(qf_array);
       }
    }
 

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1824,6 +1824,7 @@ int main (int argc, char *argv[])
          }
 
          DataCollectionReader reader(stream_state);
+         reader.SetPadDigits(pad_digits);
          if (dc_protocol != string_default)
          {
             reader.SetProtocol(dc_protocol.c_str());

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND SOURCES
   gl/shader.cpp
   gl/types.cpp
   aux_vis.cpp
+  coll_reader.cpp
   data_state.cpp
   file_reader.cpp
   font.cpp
@@ -41,6 +42,7 @@ list(APPEND HEADERS
   gl/shader.hpp
   gl/types.hpp
   aux_vis.hpp
+  coll_reader.hpp
   data_state.hpp
   file_reader.hpp
   font.hpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,8 @@ list(APPEND SOURCES
   gl/shader.cpp
   gl/types.cpp
   aux_vis.cpp
+  data_state.cpp
+  file_reader.cpp
   font.cpp
   gltf.cpp
   material.cpp
@@ -39,6 +41,8 @@ list(APPEND HEADERS
   gl/shader.hpp
   gl/types.hpp
   aux_vis.hpp
+  data_state.hpp
+  file_reader.hpp
   font.hpp
   geom_utils.hpp
   gltf.hpp

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -33,7 +33,7 @@ static VisualizationSceneScalarData * vs = nullptr;
 // either bitmap data or png bytes
 std::vector<unsigned char> * screen_state = nullptr;
 
-StreamState stream_state;
+DataState stream_state;
 
 int last_stream_nproc = 1;
 
@@ -44,17 +44,11 @@ namespace js
 
 using namespace mfem;
 
-// switch representation of the quadrature function
+/// Switch representation of the quadrature function
 void SwitchQuadSolution();
 
-//
-// display a new stream
-// field_type: 0 - scalar data, 1 - vector data, 2 - mesh only, (-1) - unknown
-//
-StreamState::FieldType display(const StreamState::FieldType field_type,
-                               std::stringstream & commands,
-                               const int w,
-                               const int h)
+/// Display a new stream
+void display(std::stringstream & commands, const int w, const int h)
 {
    // reset antialiasing
    GetAppWindow()->getRenderer().setAntialiasing(0);
@@ -79,16 +73,17 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
       }
    }
 
-   // If unknown, default to vector field_type
-   if (field_type <= StreamState::FieldType::MIN
-       || field_type >= StreamState::FieldType::MAX)
+   DataState::FieldType field_type = stream_state.GetType();
+
+   if (field_type <= DataState::FieldType::MIN
+       || field_type >= DataState::FieldType::MAX)
    {
-      return StreamState::FieldType::VECTOR;
+      return;
    }
 
    if (InitVisualization("glvis", 0, 0, w, h))
    {
-      return StreamState::FieldType::VECTOR;
+      return;
    }
 
    delete vs;
@@ -100,8 +95,8 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
    }
 
    double mesh_range = -1.0;
-   if (field_type == StreamState::FieldType::SCALAR
-       || field_type == StreamState::FieldType::MESH)
+   if (field_type == DataState::FieldType::SCALAR
+       || field_type == DataState::FieldType::MESH)
    {
       if (stream_state.grid_f)
       {
@@ -124,7 +119,7 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
          {
             vss->SetGridFunction(*stream_state.grid_f);
          }
-         if (field_type == StreamState::FieldType::MESH)
+         if (field_type == DataState::FieldType::MESH)
          {
             vs->OrthogonalProjection = 1;
             vs->SetLight(0);
@@ -143,7 +138,7 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
          {
             vss->SetGridFunction(stream_state.grid_f.get());
          }
-         if (field_type == StreamState::FieldType::MESH)
+         if (field_type == DataState::FieldType::MESH)
          {
             if (stream_state.mesh->Dimension() == 3)
             {
@@ -162,7 +157,7 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
             vss->ToggleDrawMesh();
          }
       }
-      if (field_type == StreamState::FieldType::MESH)
+      if (field_type == DataState::FieldType::MESH)
       {
          if (stream_state.grid_f)
          {
@@ -174,7 +169,7 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
          }
       }
    }
-   else if (field_type == StreamState::FieldType::VECTOR)
+   else if (field_type == DataState::FieldType::VECTOR)
    {
       if (stream_state.mesh->SpaceDimension() == 2)
       {
@@ -219,7 +214,7 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
          vs->SetAutoscale(0);
       }
       if (stream_state.mesh->SpaceDimension() == 2 &&
-          field_type == StreamState::FieldType::MESH)
+          field_type == DataState::FieldType::MESH)
       {
          SetVisualizationScene(vs, 2);
       }
@@ -237,20 +232,19 @@ StreamState::FieldType display(const StreamState::FieldType field_type,
    }
 
    SendExposeEvent();
-   return StreamState::FieldType::SCALAR;
 }
 
 //
-// StreamState::ReadStream requires a list of unique_ptr to istream and since
+// StreamReader::ReadStream requires a list of unique_ptr to istream and since
 // we cannot directly pass a list of string we need to repack the strings into
 // a new list.
 //
 // each string in streams must start with `parallel <nproc> <rank>'
 //
 using StringArray = std::vector<std::string>;
-StreamState::FieldType processParallelStreams(StreamState & state,
-                                              const StringArray & streams,
-                                              std::stringstream * commands = nullptr)
+void processParallelStreams(DataState & state,
+                            const StringArray & streams,
+                            std::stringstream * commands = nullptr)
 {
    // std::cerr << "got " << streams.size() << " streams" << std::endl;
    // HACK: match unique_ptr<istream> interface for ReadStreams:
@@ -267,7 +261,8 @@ StreamState::FieldType processParallelStreams(StreamState & state,
       istreams[i] = std::unique_ptr<std::istream>(&sstreams[i]);
    }
 
-   const StreamState::FieldType field_type = state.ReadStreams(istreams);
+   StreamReader reader(state);
+   reader.ReadStreams(istreams);
 
    if (commands)
    {
@@ -281,36 +276,33 @@ StreamState::FieldType processParallelStreams(StreamState & state,
    }
 
    last_stream_nproc = streams.size();
-
-   return field_type;
 }
 
-StreamState::FieldType displayParallelStreams(const StringArray & streams,
-                                              const int w,
-                                              const int h)
+void displayParallelStreams(const StringArray & streams, const int w,
+                            const int h)
 {
    std::stringstream commands(streams[0]);
-   const StreamState::FieldType field_type = processParallelStreams(stream_state,
-                                                                    streams, &commands);
-   return display(field_type, commands, w, h);
+   processParallelStreams(stream_state, streams, &commands);
+
+   display(commands, w, h);
 }
 
-StreamState::FieldType displayStream(const std::string & stream, const int w,
-                                     const int h)
+void displayStream(const std::string & stream, const int w, const int h)
 {
    std::stringstream ss(stream);
    std::string data_type;
    ss >> data_type;
-   const StreamState::FieldType field_type = stream_state.ReadStream(ss,
-                                                                     data_type);
 
-   return display(field_type, ss, w, h);
+   StreamReader reader(stream_state);
+   reader.ReadStream(ss, data_type);
+
+   display(ss, w, h);
 }
 
 //
 // update the existing stream
 //
-int update(StreamState & new_state)
+int update(DataState & new_state)
 {
    double mesh_range = -1.0;
 
@@ -338,8 +330,9 @@ int updateStream(std::string stream)
    std::string data_type;
    ss >> data_type;
 
-   StreamState new_state;
-   new_state.ReadStream(ss, data_type);
+   DataState new_state;
+   StreamReader reader(new_state);
+   reader.ReadStream(ss, data_type);
 
    return update(new_state);
 }
@@ -353,7 +346,7 @@ int updateParallelStreams(const StringArray & streams)
                 streams.size() << " != " << last_stream_nproc << std::endl;
       return 1;
    }
-   StreamState new_state;
+   DataState new_state;
    processParallelStreams(new_state, streams);
 
    return update(new_state);
@@ -473,8 +466,8 @@ em::val getScreenBuffer(bool flip_y=false)
 void SwitchQuadSolution()
 {
    int iqs = ((int)stream_state.GetQuadSolution()+1)
-             % ((int)StreamState::QuadSolution::MAX);
-   stream_state.SwitchQuadSolution((StreamState::QuadSolution)iqs, vs);
+             % ((int)DataState::QuadSolution::MAX);
+   stream_state.SwitchQuadSolution((DataState::QuadSolution)iqs, vs);
    SendExposeEvent();
 }
 
@@ -524,13 +517,13 @@ em::val getPNGByteArray()
 // https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#built-in-type-conversions
 EMSCRIPTEN_BINDINGS(js_funcs)
 {
-   em::enum_<StreamState::FieldType>("FieldType")
-   .value("UNKNOWN", StreamState::FieldType::UNKNOWN)
-   .value("MIN", StreamState::FieldType::MIN)
-   .value("SCALAR", StreamState::FieldType::SCALAR)
-   .value("VECTOR", StreamState::FieldType::VECTOR)
-   .value("MESH", StreamState::FieldType::MESH)
-   .value("MAX", StreamState::FieldType::MAX)
+   em::enum_<DataState::FieldType>("FieldType")
+   .value("UNKNOWN", DataState::FieldType::UNKNOWN)
+   .value("MIN", DataState::FieldType::MIN)
+   .value("MESH", DataState::FieldType::MESH)
+   .value("SCALAR", DataState::FieldType::SCALAR)
+   .value("VECTOR", DataState::FieldType::VECTOR)
+   .value("MAX", DataState::FieldType::MAX)
    ;
    em::function("displayStream", &js::displayStream);
    em::function("displayParallelStreams", &js::displayParallelStreams);

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -121,7 +121,6 @@ void CallKeySequence(const char *seq);
 
 void SetUseTexture(int ut);
 int GetUseTexture();
-void Set_Texture_Image();
 int GetMultisample();
 void SetMultisample(int m);
 

--- a/lib/coll_reader.cpp
+++ b/lib/coll_reader.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "coll_reader.hpp"
+
+#include <vector>
+
+using namespace std;
+using namespace mfem;
+
+int DataCollectionReader::ReadSerial(CollType ct, const char *coll_file,
+                                     int ti, const char *field, bool quad, int component)
+{
+   switch (ct)
+   {
+      case CollType::VISIT:
+         data.SetDataCollectionField(new VisItDataCollection(coll_file), ti, field,
+                                     quad, component);
+         break;
+      case CollType::PARAVIEW:
+         data.SetDataCollectionField(new ParaViewDataCollection(coll_file), ti, field,
+                                     quad, component);
+         break;
+#ifdef MFEM_USE_SIDRE
+      case CollType::SIDRE:
+         data.SetDataCollectionField(new SidreDataCollection(coll_file), ti, field,
+                                     quad, component);
+         break;
+#endif // MFEM_USE_SIDRE
+#ifdef MFEM_USE_FMS
+      case CollType::FMS:
+      {
+         auto dc = new FMSDataCollection(coll_file);
+         dc->SetProtocol(protocol);
+         data.SetDataCollectionField(dc, ti, field, quad, component);
+      }
+      break;
+#endif // MFEM_USE_FMS
+#ifdef MFEM_USE_CONDUIT
+      case CollType::CONDUIT:
+      {
+         auto dc = new ConduitDataCollection(coll_file);
+         dc->SetProtocol(protocol);
+         data.SetDataCollectionField(dc, ti, field, quad, component);
+      }
+      break;
+#endif // MFEM_USE_CONDUIT
+#ifdef MFEM_USE_ADIOS2
+      case CollType::ADIOS2:
+         data.SetDataCollectionField(new ADIOS2DataCollection(coll_file), ti, field,
+                                     quad, component);
+         break;
+#endif // MFEM_USE_ADIOS2
+      default:
+         cerr << "Unknown collection type. Exit" << endl;
+         exit(1);
+   }
+
+   data.ExtrudeMeshAndSolution();
+   return 0;
+}

--- a/lib/coll_reader.cpp
+++ b/lib/coll_reader.cpp
@@ -22,23 +22,30 @@ int DataCollectionReader::ReadSerial(CollType ct, const char *coll_file,
    switch (ct)
    {
       case CollType::VISIT:
-         data.SetDataCollectionField(new VisItDataCollection(coll_file), ti, field,
-                                     quad, component);
-         break;
+      {
+         auto dc = new VisItDataCollection(coll_file);
+         dc->SetPadDigits(pad_digits);
+         data.SetDataCollectionField(dc, ti, field, quad, component);
+      }
+      break;
          //case CollType::PARAVIEW: // reader not implemented
          //   data.SetDataCollectionField(new ParaViewDataCollection(coll_file), ti, field,
          //                               quad, component);
          //   break;
 #ifdef MFEM_USE_SIDRE
       case CollType::SIDRE:
-         data.SetDataCollectionField(new SidreDataCollection(coll_file), ti, field,
-                                     quad, component);
-         break;
+      {
+         auto dc = new SidreDataCollection(coll_file);
+         dc->SetPadDigits(pad_digits);
+         data.SetDataCollectionField(dc, ti, field, quad, component);
+      }
+      break;
 #endif // MFEM_USE_SIDRE
 #ifdef MFEM_USE_FMS
       case CollType::FMS:
       {
          auto dc = new FMSDataCollection(coll_file);
+         dc->SetPadDigits(pad_digits);
          dc->SetProtocol(protocol);
          data.SetDataCollectionField(dc, ti, field, quad, component);
       }
@@ -48,6 +55,7 @@ int DataCollectionReader::ReadSerial(CollType ct, const char *coll_file,
       case CollType::CONDUIT:
       {
          auto dc = new ConduitDataCollection(coll_file);
+         dc->SetPadDigits(pad_digits);
          dc->SetProtocol(protocol);
          data.SetDataCollectionField(dc, ti, field, quad, component);
       }

--- a/lib/coll_reader.cpp
+++ b/lib/coll_reader.cpp
@@ -25,10 +25,10 @@ int DataCollectionReader::ReadSerial(CollType ct, const char *coll_file,
          data.SetDataCollectionField(new VisItDataCollection(coll_file), ti, field,
                                      quad, component);
          break;
-      case CollType::PARAVIEW:
-         data.SetDataCollectionField(new ParaViewDataCollection(coll_file), ti, field,
-                                     quad, component);
-         break;
+         //case CollType::PARAVIEW: // reader not implemented
+         //   data.SetDataCollectionField(new ParaViewDataCollection(coll_file), ti, field,
+         //                               quad, component);
+         //   break;
 #ifdef MFEM_USE_SIDRE
       case CollType::SIDRE:
          data.SetDataCollectionField(new SidreDataCollection(coll_file), ti, field,
@@ -54,10 +54,10 @@ int DataCollectionReader::ReadSerial(CollType ct, const char *coll_file,
       break;
 #endif // MFEM_USE_CONDUIT
 #ifdef MFEM_USE_ADIOS2
-      case CollType::ADIOS2:
-         data.SetDataCollectionField(new ADIOS2DataCollection(coll_file), ti, field,
-                                     quad, component);
-         break;
+         //case CollType::ADIOS2: // reader not implemented
+         //   data.SetDataCollectionField(new ADIOS2DataCollection(coll_file), ti, field,
+         //                               quad, component);
+         //   break;
 #endif // MFEM_USE_ADIOS2
       default:
          cerr << "Unknown collection type. Exit" << endl;

--- a/lib/coll_reader.cpp
+++ b/lib/coll_reader.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/coll_reader.hpp
+++ b/lib/coll_reader.hpp
@@ -19,6 +19,7 @@
 class DataCollectionReader
 {
    DataState &data;
+   int pad_digits;
    std::string protocol;
 
 public:
@@ -33,6 +34,9 @@ public:
    };
 
    DataCollectionReader(DataState &data_) : data(data_) { }
+
+   /// Set the padding digits
+   void SetPadDigits(int digits) { pad_digits = digits; }
 
    /// Set the I/O protocol to for loading of collections
    void SetProtocol(const char *protocol_) { protocol = protocol_; }

--- a/lib/coll_reader.hpp
+++ b/lib/coll_reader.hpp
@@ -37,8 +37,16 @@ public:
    /// Set the I/O protocol to for loading of collections
    void SetProtocol(const char *protocol_) { protocol = protocol_; }
 
-   /// Read the mesh from a file and solution from a collection
-   int ReadSerial(CollType ct, const char *collection, int ti,
+   /// Load the mesh and solution from a collection
+   /** Loads the mesh and optionally a grid or quadrature function from the
+       provided data collection.
+       @param ct        collection type
+       @param dc        data collection
+       @param ti        cycle to load
+       @param field     name of the (Q-)field to load (NULL for mesh only)
+       @param quad      if true, Q-field is loaded, otherwise a regular field
+       @param component component of the field (-1 means all components) */
+   int ReadSerial(CollType ct, const char *dc, int ti,
                   const char *field = NULL, bool quad = false, int component = -1);
 };
 

--- a/lib/coll_reader.hpp
+++ b/lib/coll_reader.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/coll_reader.hpp
+++ b/lib/coll_reader.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_COLL_READER_HPP
+#define GLVIS_COLL_READER_HPP
+
+#include <iostream>
+#include "mfem.hpp"
+#include "data_state.hpp"
+
+class DataCollectionReader
+{
+   DataState &data;
+   std::string protocol;
+
+public:
+   enum class CollType
+   {
+      VISIT,
+      PARAVIEW,
+      SIDRE,
+      FMS,
+      CONDUIT,
+      ADIOS2,
+   };
+
+   DataCollectionReader(DataState &data_) : data(data_) { }
+
+   /// Set the I/O protocol to for loading of collections
+   void SetProtocol(const char *protocol_) { protocol = protocol_; }
+
+   /// Read the mesh from a file and solution from a collection
+   int ReadSerial(CollType ct, const char *collection, int ti,
+                  const char *field = NULL, bool quad = false, int component = -1);
+};
+
+#endif // GLVIS_COLL_READER_HPP

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -122,8 +122,9 @@ void DataState::SetDataCollectionField(mfem::DataCollection *dc, int ti,
 {
    internal.data_coll.reset(dc);
    data_coll->Load(ti);
-   Mesh *mesh = data_coll->GetMesh();
-   SetMesh(new Mesh(*mesh, false));
+   Mesh *dc_mesh = data_coll->GetMesh();
+   SetMesh(new Mesh(*dc_mesh, false));
+
    if (field)
    {
       if (!quad)

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -335,7 +335,7 @@ void DataState::SetQuadFunctionSolution(int qf_component)
    SetQuadSolution();
 }
 
-void DataState::SetQuadSolution(QuadSolution type)
+void DataState::SetQuadSolution(QuadSolution quad_type)
 {
    // assume identical order
    const int order = quad_f->GetIntRule(0).GetOrder()/2; // <-- Gauss-Legendre
@@ -347,7 +347,7 @@ void DataState::SetQuadSolution(QuadSolution type)
    }
 
    // check for tensor-product basis
-   if (order > 0 && type != QuadSolution::HO_L2_projected)
+   if (order > 0 && quad_type != QuadSolution::HO_L2_projected)
    {
       Array<Geometry::Type> geoms;
       mesh->GetGeometries(mesh->Dimension(), geoms);
@@ -362,7 +362,7 @@ void DataState::SetQuadSolution(QuadSolution type)
          }
    }
 
-   switch (type)
+   switch (quad_type)
    {
       case QuadSolution::LOR_ClosedGL:
       {
@@ -445,10 +445,10 @@ void DataState::SetQuadSolution(QuadSolution type)
          return;
    }
 
-   quad_sol = type;
+   quad_sol = quad_type;
 }
 
-void DataState::SwitchQuadSolution(QuadSolution type, VisualizationScene *vs)
+void DataState::SwitchQuadSolution(QuadSolution quad_type, VisualizationScene *vs)
 {
    unique_ptr<Mesh> old_mesh;
    // we must backup the refined mesh to prevent its deleting
@@ -457,7 +457,7 @@ void DataState::SwitchQuadSolution(QuadSolution type, VisualizationScene *vs)
       internal.mesh.swap(internal.mesh_quad);
       internal.mesh_quad.swap(old_mesh);
    }
-   SetQuadSolution(type);
+   SetQuadSolution(quad_type);
    ExtrudeMeshAndSolution();
    ResetMeshAndSolution(*this, vs);
 }

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -1,0 +1,580 @@
+// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "data_state.hpp"
+#include "visual.hpp"
+
+#include <cstdlib>
+
+using namespace std;
+using namespace mfem;
+
+/// Helper function for extrusion of 1D quadrature functions to 2D
+QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
+                                          QuadratureFunction *qf, int ny);
+
+DataState &DataState::operator=(DataState &&ss)
+{
+   internal = std::move(ss.internal);
+
+   type = ss.type;
+   quad_sol = ss.quad_sol;
+
+   sol = std::move(ss.sol);
+   solu = std::move(ss.solu);
+   solv = std::move(ss.solv);
+   solw = std::move(ss.solw);
+   normals = std::move(ss.normals);
+   keys = std::move(ss.keys);
+
+   fix_elem_orient = ss.fix_elem_orient;
+   save_coloring = ss.save_coloring;
+   keep_attr = ss.keep_attr;
+
+   return *this;
+}
+
+void DataState::SetMesh(mfem::Mesh *mesh_)
+{
+   internal.mesh.reset(mesh_);
+   SetMesh(std::move(internal.mesh));
+}
+
+void DataState::SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh)
+{
+   internal.mesh = std::move(pmesh);
+   internal.mesh_quad.reset();
+   if (grid_f && grid_f->FESpace()->GetMesh() != mesh.get()) { SetGridFunction(NULL); }
+   if (quad_f && quad_f->GetSpace()->GetMesh() != mesh.get()) { SetQuadFunction(NULL); }
+}
+
+void DataState::SetGridFunction(mfem::GridFunction *gf, int component)
+{
+   internal.grid_f.reset(gf);
+   SetGridFunction(std::move(internal.grid_f), component);
+}
+
+void DataState::SetGridFunction(
+   std::unique_ptr<mfem::GridFunction> &&pgf, int component)
+{
+   internal.grid_f = std::move(pgf);
+   internal.quad_f.reset();
+   quad_sol = QuadSolution::NONE;
+   SetGridFunctionSolution(component);
+}
+
+void DataState::SetQuadFunction(mfem::QuadratureFunction *qf, int component)
+{
+   if (quad_f.get() != qf)
+   {
+      internal.grid_f.reset();
+      quad_sol = QuadSolution::NONE;
+   }
+   internal.quad_f.reset(qf);
+   SetQuadFunctionSolution(component);
+}
+
+void DataState::SetQuadFunction(
+   std::unique_ptr<mfem::QuadratureFunction> &&pqf, int component)
+{
+   if (quad_f.get() != pqf.get())
+   {
+      internal.grid_f.reset();
+      quad_sol = QuadSolution::NONE;
+   }
+   internal.quad_f = std::move(pqf);
+   SetQuadFunctionSolution(component);
+}
+
+void DataState::SetQuadFunction(
+   const std::vector<QuadratureFunction*> &qf_array, int component)
+{
+   // assume the same vdim
+   const int vdim = qf_array[0]->GetVDim();
+   // assume the same quadrature rule
+   QuadratureSpace *qspace = new QuadratureSpace(*mesh,
+                                                 qf_array[0]->GetIntRule(0));
+   QuadratureFunction *qf = new QuadratureFunction(qspace, vdim);
+   qf->SetOwnsSpace(true);
+   real_t *g_data = qf->GetData();
+   for (QuadratureFunction *qf_piece : qf_array)
+   {
+      const real_t *l_data = qf_piece->GetData();
+      const int l_size = qf_piece->Size();
+      MFEM_ASSERT(g_data + l_size <= qf->GetData() + qf->Size(),
+                  "Local parts do not fit to the global quadrature function!");
+      memcpy(g_data, l_data, l_size * sizeof(real_t));
+      g_data += l_size;
+   }
+   SetQuadFunction(qf, component);
+}
+
+void DataState::ExtrudeMeshAndSolution()
+{
+   Extrude1DMeshAndSolution();
+   Extrude2D3VMeshAndSolution();
+}
+
+void DataState::Extrude1DMeshAndSolution()
+{
+   if (mesh->Dimension() != 1 || mesh->SpaceDimension() != 1)
+   {
+      return;
+   }
+
+   // find xmin and xmax over the vertices of the 1D mesh
+   double xmin = numeric_limits<double>::infinity();
+   double xmax = -xmin;
+   for (int i = 0; i < mesh->GetNV(); i++)
+   {
+      const double x = mesh->GetVertex(i)[0];
+      if (x < xmin)
+      {
+         xmin = x;
+      }
+      if (x > xmax)
+      {
+         xmax = x;
+      }
+   }
+
+   Mesh *mesh2d = Extrude1D(mesh.get(), 1, 0.1*(xmax - xmin));
+
+   if (grid_f)
+   {
+      GridFunction *grid_f_2d =
+         Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
+
+      internal.grid_f.reset(grid_f_2d);
+   }
+   else if (sol.Size() == mesh->GetNV())
+   {
+      Vector sol2d(mesh2d->GetNV());
+      for (int i = 0; i < mesh->GetNV(); i++)
+      {
+         sol2d(2*i+0) = sol2d(2*i+1) = sol(i);
+      }
+      sol = sol2d;
+   }
+
+   if (!mesh_quad) { internal.mesh.swap(internal.mesh_quad); }
+   internal.mesh.reset(mesh2d);
+}
+
+void DataState::Extrude2D3VMeshAndSolution()
+{
+   if (mesh->SpaceDimension() == 3 || !grid_f || grid_f->VectorDim() < 3) { return; }
+
+   // not all vector elements can be embedded in 3D, so conversion to L2 elements
+   // is performed already here
+   ProjectVectorFEGridFunction();
+
+   Mesh *mesh3d = new Mesh(*mesh);
+   const FiniteElementSpace *fesx = mesh->GetNodalFESpace();
+   const FiniteElementCollection *fecx = (fesx)?(fesx->FEColl()):(NULL);
+   if (fecx)
+   {
+      mesh3d->SetCurvature(fecx->GetOrder(),
+                           fecx->GetContType() == FiniteElementCollection::DISCONTINUOUS,
+                           3);
+   }
+   else
+   {
+      mesh3d->SetCurvature(1, false, 3);
+   }
+
+   FiniteElementSpace *fes2d = grid_f->FESpace();
+   FiniteElementSpace *fes3d = new FiniteElementSpace(*fes2d, mesh3d);
+   GridFunction *gf3d = new GridFunction(fes3d);
+   *gf3d = *grid_f;
+   grid_f->MakeOwner(NULL);
+   gf3d->MakeOwner(const_cast<FiniteElementCollection*>(fes2d->FEColl()));
+
+   SetGridFunction(gf3d);
+   delete fes2d;
+   SetMesh(mesh3d);
+}
+
+void DataState::SetMeshSolution()
+{
+   if (1) // checkerboard solution
+   {
+      FiniteElementCollection *cfec;
+      if (mesh->Dimension() == 1)
+      {
+         cfec = new L2_FECollection(0, 1);
+      }
+      else if (mesh->Dimension() == 2)
+      {
+         cfec = new Const2DFECollection;
+      }
+      else
+      {
+         cfec = new Const3DFECollection;
+      }
+      FiniteElementSpace *cfes = new FiniteElementSpace(mesh.get(), cfec);
+      SetGridFunction(new GridFunction(cfes));
+      grid_f->MakeOwner(cfec);
+      {
+         Array<int> coloring;
+         srand(time(0));
+         double a = double(rand()) / (double(RAND_MAX) + 1.);
+         int el0 = (int)floor(a * mesh->GetNE());
+         cout << "Generating coloring starting with element " << el0+1
+              << " / " << mesh->GetNE() << endl;
+         mesh->GetElementColoring(coloring, el0);
+         for (int i = 0; i < coloring.Size(); i++)
+         {
+            (*grid_f)(i) = coloring[i];
+         }
+         cout << "Number of colors: " << grid_f->Max() + 1 << endl;
+      }
+      grid_f->GetNodalValues(sol);
+      if (save_coloring)
+      {
+         const char col_fname[] = "GLVis_coloring.gf";
+         ofstream fgrid(col_fname);
+         cout << "Saving the coloring function -> " << flush;
+         grid_f->Save(fgrid);
+         cout << col_fname << endl;
+      }
+   }
+   else // zero solution
+   {
+      sol.SetSize (mesh -> GetNV());
+      sol = 0.0;
+   }
+   type = FieldType::MESH;
+}
+
+void DataState::SetGridFunctionSolution(int gf_component)
+{
+   if (!grid_f)
+   {
+      type = (mesh)?(FieldType::MESH):(FieldType::UNKNOWN);
+      return;
+   }
+
+   if (gf_component != -1)
+   {
+      if (gf_component < 0 || gf_component >= grid_f->FESpace()->GetVDim())
+      {
+         cerr << "Invalid component " << gf_component << '.' << endl;
+         exit(1);
+      }
+      FiniteElementSpace *ofes = grid_f->FESpace();
+      FiniteElementCollection *fec =
+         FiniteElementCollection::New(ofes->FEColl()->Name());
+      FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec);
+      GridFunction *new_gf = new GridFunction(fes);
+      new_gf->MakeOwner(fec);
+      for (int i = 0; i < new_gf->Size(); i++)
+      {
+         (*new_gf)(i) = (*grid_f)(ofes->DofToVDof(i, gf_component));
+      }
+      SetGridFunction(new_gf);
+      return;
+   }
+
+   if (grid_f->VectorDim() == 1)
+   {
+      grid_f->GetNodalValues(sol);
+      type = FieldType::SCALAR;
+   }
+   else
+   {
+      type = FieldType::VECTOR;
+   }
+}
+
+void DataState::SetQuadFunctionSolution(int qf_component)
+{
+   if (!quad_f)
+   {
+      type = (mesh)?(FieldType::MESH):(FieldType::UNKNOWN);
+      return;
+   }
+
+   const int vdim = quad_f->GetVDim();
+   if (qf_component != -1)
+   {
+      if (qf_component < 0 || qf_component >= vdim)
+      {
+         cerr << "Invalid component " << qf_component << '.' << endl;
+         exit(1);
+      }
+      QuadratureSpaceBase *qspace = quad_f->GetSpace();
+      QuadratureFunction *new_qf = new QuadratureFunction(qspace);
+      for (int i = 0; i < new_qf->Size(); i++)
+      {
+         (*new_qf)(i) = (*quad_f)(i * vdim + qf_component);
+      }
+      quad_f->SetOwnsSpace(false);
+      new_qf->SetOwnsSpace(true);
+      SetQuadFunction(new_qf);
+      return;
+   }
+
+   if (vdim == 1)
+   {
+      type = FieldType::SCALAR;
+   }
+   else
+   {
+      type = FieldType::VECTOR;
+   }
+
+   SetQuadSolution();
+}
+
+void DataState::SetQuadSolution(QuadSolution type)
+{
+   // assume identical order
+   const int order = quad_f->GetIntRule(0).GetOrder()/2; // <-- Gauss-Legendre
+   // use the original mesh when available
+   if (mesh_quad.get())
+   {
+      internal.mesh.swap(internal.mesh_quad);
+      internal.mesh_quad.reset();
+   }
+
+   // check for tensor-product basis
+   if (order > 0 && type != QuadSolution::HO_L2_projected)
+   {
+      Array<Geometry::Type> geoms;
+      mesh->GetGeometries(mesh->Dimension(), geoms);
+      for (auto geom : geoms)
+         if (!Geometry::IsTensorProduct(geom))
+         {
+            cout << "High-order quadrature data are supported only for "
+                 << "tensor-product finite elements with this representation"
+                 << endl;
+            SetQuadSolution(QuadSolution::HO_L2_projected);
+            return;
+         }
+   }
+
+   switch (type)
+   {
+      case QuadSolution::LOR_ClosedGL:
+      {
+         const int ref_factor = order + 1;
+         if (ref_factor <= 1)
+         {
+            SetQuadSolution(QuadSolution::HO_L2_collocated); // low-order
+            return;
+         }
+         Mesh *mesh_lor = new Mesh(Mesh::MakeRefined(*mesh, ref_factor,
+                                                     BasisType::ClosedGL));
+         FiniteElementCollection *fec = new L2_FECollection(0, mesh->Dimension());
+         FiniteElementSpace *fes = new FiniteElementSpace(mesh_lor, fec,
+                                                          quad_f->GetVDim(), Ordering::byVDIM);
+         MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
+         cout << "Representing quadrature data by piecewise-constant function on mesh refined "
+              << ref_factor << " times" << endl;
+         GridFunction *gf = new GridFunction(fes, *quad_f, 0);
+         gf->MakeOwner(fec);
+         internal.grid_f.reset(gf);
+         internal.mesh.swap(internal.mesh_quad);
+         internal.mesh.reset(mesh_lor);
+      }
+      break;
+      case QuadSolution::HO_L2_collocated:
+      {
+         FiniteElementCollection *fec = new L2_FECollection(order, mesh->Dimension());
+         FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
+                                                          quad_f->GetVDim(), Ordering::byVDIM);
+         MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
+         cout << "Representing quadrature data by grid function of order "
+              << order << endl;
+         GridFunction *gf = new GridFunction(fes, *quad_f, 0);
+         gf->MakeOwner(fec);
+         internal.grid_f.reset(gf);
+      }
+      break;
+      case QuadSolution::HO_L2_projected:
+      {
+         FiniteElementCollection *fec = new L2_FECollection(order, mesh->Dimension());
+         FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
+                                                          quad_f->GetVDim(), Ordering::byVDIM);
+         cout << "Projecting quadrature data to grid function of order "
+              << order << endl;
+         GridFunction *gf = new GridFunction(fes);
+         gf->MakeOwner(fec);
+
+         VectorQuadratureFunctionCoefficient coeff_qf(*quad_f);
+         VectorDomainLFIntegrator bi(coeff_qf);
+         VectorMassIntegrator Mi;
+         Mi.SetVDim(quad_f->GetVDim());
+
+         DenseMatrix M_i;
+         Vector x_i, b_i;
+         DenseMatrixInverse M_i_inv;
+         Array<int> vdofs;
+
+         for (int i = 0; i < mesh->GetNE(); i++)
+         {
+            const FiniteElement *fe = fes->GetFE(i);
+            ElementTransformation *Tr = mesh->GetElementTransformation(i);
+            Mi.AssembleElementMatrix(*fe, *Tr, M_i);
+            M_i_inv.Factor(M_i);
+
+            bi.SetIntRule(&quad_f->GetIntRule(i));
+            bi.AssembleRHSElementVect(*fe, *Tr, b_i);
+
+            x_i.SetSize(b_i.Size());
+            M_i_inv.Mult(b_i, x_i);
+
+            fes->GetElementVDofs(i, vdofs);
+            gf->SetSubVector(vdofs, x_i);
+         }
+
+         internal.grid_f.reset(gf);
+      }
+      break;
+      default:
+         cout << "Unknown quadrature data representation" << endl;
+         return;
+   }
+
+   quad_sol = type;
+}
+
+void DataState::SwitchQuadSolution(QuadSolution type, VisualizationScene *vs)
+{
+   unique_ptr<Mesh> old_mesh;
+   // we must backup the refined mesh to prevent its deleting
+   if (mesh_quad.get())
+   {
+      internal.mesh.swap(internal.mesh_quad);
+      internal.mesh_quad.swap(old_mesh);
+   }
+   SetQuadSolution(type);
+   ExtrudeMeshAndSolution();
+   ResetMeshAndSolution(*this, vs);
+}
+
+// Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec
+// or Raviart-Thomas space) with a discontinuous piece-wise polynomial Cartesian
+// product vector grid function of the same order.
+std::unique_ptr<GridFunction>
+DataState::ProjectVectorFEGridFunction(std::unique_ptr<GridFunction> gf)
+{
+   if ((gf->VectorDim() == 3) && (gf->FESpace()->GetVDim() == 1))
+   {
+      int p = gf->FESpace()->GetOrder(0);
+      cout << "Switching to order " << p
+           << " discontinuous vector grid function..." << endl;
+      int dim = gf->FESpace()->GetMesh()->Dimension();
+      FiniteElementCollection *d_fec =
+         (p == 1 && dim == 3) ?
+         (FiniteElementCollection*)new LinearDiscont3DFECollection :
+         (FiniteElementCollection*)new L2_FECollection(p, dim, 1);
+      FiniteElementSpace *d_fespace =
+         new FiniteElementSpace(gf->FESpace()->GetMesh(), d_fec, 3);
+      GridFunction *d_gf = new GridFunction(d_fespace);
+      d_gf->MakeOwner(d_fec);
+      gf->ProjectVectorFieldOn(*d_gf);
+      gf.reset(d_gf);
+   }
+   return gf;
+}
+
+bool DataState::SetNewMeshAndSolution(DataState new_state,
+                                      VisualizationScene* vs)
+{
+   if (new_state.mesh->SpaceDimension() == mesh->SpaceDimension() &&
+       new_state.grid_f->VectorDim() == grid_f->VectorDim())
+   {
+      ResetMeshAndSolution(new_state, vs);
+
+      internal.grid_f = std::move(new_state.internal.grid_f);
+      internal.mesh = std::move(new_state.internal.mesh);
+      internal.quad_f = std::move(new_state.internal.quad_f);
+      internal.mesh_quad = std::move(new_state.internal.mesh_quad);
+
+      return true;
+   }
+   else
+   {
+      return false;
+   }
+}
+
+void DataState::ResetMeshAndSolution(DataState &ss, VisualizationScene* vs)
+{
+   if (ss.mesh->SpaceDimension() == 2)
+   {
+      if (ss.grid_f->VectorDim() == 1)
+      {
+         VisualizationSceneSolution *vss =
+            dynamic_cast<VisualizationSceneSolution *>(vs);
+         ss.grid_f->GetNodalValues(ss.sol);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
+                                 ss.grid_f.get());
+      }
+      else
+      {
+         VisualizationSceneVector *vsv =
+            dynamic_cast<VisualizationSceneVector *>(vs);
+         vsv->NewMeshAndSolution(*ss.grid_f, ss.mesh_quad.get());
+      }
+   }
+   else
+   {
+      if (ss.grid_f->VectorDim() == 1)
+      {
+         VisualizationSceneSolution3d *vss =
+            dynamic_cast<VisualizationSceneSolution3d *>(vs);
+         ss.grid_f->GetNodalValues(ss.sol);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
+                                 ss.grid_f.get());
+      }
+      else
+      {
+         ss.ProjectVectorFEGridFunction();
+
+         VisualizationSceneVector3d *vss =
+            dynamic_cast<VisualizationSceneVector3d *>(vs);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), ss.grid_f.get());
+      }
+   }
+}
+
+QuadratureFunction *Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
+                                          QuadratureFunction *qf, int ny)
+{
+   // assume identical orders
+   const int order = qf->GetIntRule(0).GetOrder();
+   const int vdim = qf->GetVDim();
+   QuadratureSpace *qspace2d = new QuadratureSpace(mesh2d, order);
+   QuadratureFunction *qf2d = new QuadratureFunction(qspace2d);
+   qf2d->SetOwnsSpace(true);
+
+   DenseMatrix vals, vals2d;
+   for (int ix = 0; ix < mesh->GetNE(); ix++)
+   {
+      qf->GetValues(ix, vals);
+      const int nq = vals.Width();
+      for (int iy = 0; iy < ny; iy++)
+      {
+         qf2d->GetValues(ix*ny+iy, vals2d);
+         for (int qx = 0; qx < nq; qx++)
+            for (int qy = 0; qy < nq; qy++)
+               for (int d = 0; d < vdim; d++)
+               {
+                  vals2d(d, qy*nq+qx) = vals(d, qx);
+               }
+      }
+   }
+
+   return qf2d;
+}

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_DATA_STATE_HPP
+#define GLVIS_DATA_STATE_HPP
+
+#include <string>
+#include <vector>
+#include <memory>
+#include "mfem.hpp"
+#include "openglvis.hpp"
+
+struct DataState
+{
+   enum class FieldType
+   {
+      UNKNOWN = -1,
+      MIN = -1,
+      //----------
+      MESH,
+      SCALAR,
+      VECTOR,
+      //----------
+      MAX
+   };
+
+   enum class QuadSolution
+   {
+      NONE = -1,
+      MIN = -1,
+      //----------
+      LOR_ClosedGL,
+      HO_L2_collocated,
+      HO_L2_projected,
+      //----------
+      MAX
+   };
+
+private:
+   friend class StreamReader;
+   friend class FileReader;
+   struct
+   {
+      std::unique_ptr<mfem::Mesh> mesh;
+      std::unique_ptr<mfem::Mesh> mesh_quad;
+      std::unique_ptr<mfem::GridFunction> grid_f;
+      std::unique_ptr<mfem::QuadratureFunction> quad_f;
+   } internal;
+
+   FieldType type {FieldType::UNKNOWN};
+   QuadSolution quad_sol {QuadSolution::NONE};
+
+   void SetGridFunctionSolution(int component = -1);
+   void SetQuadFunctionSolution(int component = -1);
+
+public:
+   mfem::Vector sol, solu, solv, solw, normals;
+   const std::unique_ptr<mfem::Mesh> &mesh{internal.mesh};
+   const std::unique_ptr<mfem::Mesh> &mesh_quad{internal.mesh_quad};
+   const std::unique_ptr<mfem::GridFunction> &grid_f{internal.grid_f};
+   const std::unique_ptr<mfem::QuadratureFunction> &quad_f{internal.quad_f};
+
+   std::string keys;
+   bool fix_elem_orient{false};
+   bool save_coloring{false};
+   bool keep_attr{false};
+
+   DataState() = default;
+   DataState(DataState &&ss) { *this = std::move(ss); }
+   DataState& operator=(DataState &&ss);
+
+   inline FieldType GetType() const { return type; }
+
+   void SetMesh(mfem::Mesh *mesh);
+   void SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh);
+
+   void SetGridFunction(mfem::GridFunction *gf, int component = -1);
+   void SetGridFunction(std::unique_ptr<mfem::GridFunction> &&pgf,
+                        int component = -1);
+
+   void SetQuadFunction(mfem::QuadratureFunction *qf, int component = -1);
+   void SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction> &&pqf,
+                        int component = -1);
+   void SetQuadFunction(const std::vector<mfem::QuadratureFunction*> &qf_array,
+                        int component = -1);
+
+   /// Helper function for visualizing 1D or 2D3V data
+   void ExtrudeMeshAndSolution();
+
+   /// Helper function for visualizing 1D data
+   void Extrude1DMeshAndSolution();
+
+   /// Helper function for visualization of 2D3V data
+   void Extrude2D3VMeshAndSolution();
+
+   /// Helper function to build the quadrature function from pieces
+
+   /// Set a (checkerboard) solution when only the mesh is given
+   void SetMeshSolution();
+
+   /// Set the quadrature function representation producing a proxy grid function
+   void SetQuadSolution(QuadSolution type = QuadSolution::LOR_ClosedGL);
+
+   /// Switch the quadrature function representation and update the visualization
+   void SwitchQuadSolution(QuadSolution type, VisualizationScene* vs);
+
+   /// Get the current representation of quadrature solution
+   inline QuadSolution GetQuadSolution() const { return quad_sol; }
+
+   // Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec
+   // or Raviart-Thomas space) with a discontinuous piece-wise polynomial Cartesian
+   // product vector grid function of the same order.
+   static std::unique_ptr<mfem::GridFunction>
+   ProjectVectorFEGridFunction(std::unique_ptr<mfem::GridFunction> gf);
+
+   void ProjectVectorFEGridFunction()
+   { internal.grid_f = ProjectVectorFEGridFunction(std::move(internal.grid_f)); }
+
+   /// Sets a new mesh and solution from another DataState object, and
+   /// updates the given VisualizationScene pointer with the new data.
+   ///
+   /// Mesh space and grid function dimensions must both match the original
+   /// dimensions of the current DataState. If there is a mismatch in either
+   /// value, the function will return false, and the mesh/solution will not be
+   /// updated.
+   bool SetNewMeshAndSolution(DataState new_state,
+                              VisualizationScene* vs);
+
+   /// Updates the given VisualizationScene pointer with the new data
+   /// of the given DataState object.
+   /// @note: Use with caution when the update is compatible
+   /// @see SetNewMeshAndSolution()
+   static void ResetMeshAndSolution(DataState &ss, VisualizationScene* vs);
+};
+
+#endif // GLVIS_DATA_STATE_HPP

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -53,6 +53,7 @@ private:
       std::unique_ptr<mfem::Mesh> mesh_quad;
       std::unique_ptr<mfem::GridFunction> grid_f;
       std::unique_ptr<mfem::QuadratureFunction> quad_f;
+      std::unique_ptr<mfem::DataCollection> data_coll;
    } internal;
 
    FieldType type {FieldType::UNKNOWN};
@@ -67,6 +68,7 @@ public:
    const std::unique_ptr<mfem::Mesh> &mesh_quad{internal.mesh_quad};
    const std::unique_ptr<mfem::GridFunction> &grid_f{internal.grid_f};
    const std::unique_ptr<mfem::QuadratureFunction> &quad_f{internal.quad_f};
+   const std::unique_ptr<mfem::DataCollection> &data_coll{internal.data_coll};
 
    std::string keys;
    bool fix_elem_orient{false};
@@ -91,6 +93,9 @@ public:
                         int component = -1);
    void SetQuadFunction(const std::vector<mfem::QuadratureFunction*> &qf_array,
                         int component = -1);
+
+   void SetDataCollectionField(mfem::DataCollection *dc, int ti,
+                               const char *field = NULL, bool quad = false, int component = -1);
 
    /// Helper function for visualizing 1D or 2D3V data
    void ExtrudeMeshAndSolution();

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -79,21 +79,53 @@ public:
    DataState(DataState &&ss) { *this = std::move(ss); }
    DataState& operator=(DataState &&ss);
 
+   /// Get type of the contained data
    inline FieldType GetType() const { return type; }
 
+   /// Set a mesh (plain pointer version)
+   /** Note that ownership is passed from the caller.
+       @see SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh) */
    void SetMesh(mfem::Mesh *mesh);
+
+   /// Set a mesh (unqiue pointer version)
+   /** Sets the mesh and resets grid/quadrature functions if they do not use
+       the same one. */
    void SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh);
 
+   /// Set a grid function (plain pointer version)
+   /** Note that ownership is passed from the caller.
+       @see SetGridFunction(std::unique_ptr<mfem::GridFunction> &&, int ) */
    void SetGridFunction(mfem::GridFunction *gf, int component = -1);
+
+   /// Set a grid function (unique pointer version)
+   /** Sets the grid function or its component (-1 means all components). */
    void SetGridFunction(std::unique_ptr<mfem::GridFunction> &&pgf,
                         int component = -1);
 
+   /// Set a quadrature function (plain pointer version)
+   /** Note that ownership is passed from the caller.
+       @see SetQuadFunction(std::unique_ptr<mfem::QuadFunction> &&, int ) */
    void SetQuadFunction(mfem::QuadratureFunction *qf, int component = -1);
+
+   /// Set a quadrature function (unique pointer version)
+   /** Sets the quadrature function or its component (-1 means all components). */
    void SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction> &&pqf,
                         int component = -1);
+
+   /// Set a quadrature function from pieces
+   /** Serializes the pieces of a quadrature function and sets it or its
+       component (-1 means all components) */
    void SetQuadFunction(const std::vector<mfem::QuadratureFunction*> &qf_array,
                         int component = -1);
 
+   /// Set a data collection field
+   /** Sets the mesh and optionally a grid or quadrature function from the
+       provided data collection.
+       @param dc        data collection
+       @param ti        cycle to load
+       @param field     name of the (Q-)field to load (NULL for mesh only)
+       @param quad      if true, Q-field is loaded, otherwise a regular field
+       @param component component of the field (-1 means all components) */
    void SetDataCollectionField(mfem::DataCollection *dc, int ti,
                                const char *field = NULL, bool quad = false, int component = -1);
 
@@ -105,8 +137,6 @@ public:
 
    /// Helper function for visualization of 2D3V data
    void Extrude2D3VMeshAndSolution();
-
-   /// Helper function to build the quadrature function from pieces
 
    /// Set a (checkerboard) solution when only the mesh is given
    void SetMeshSolution();

--- a/lib/file_reader.cpp
+++ b/lib/file_reader.cpp
@@ -1,0 +1,310 @@
+// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#include "file_reader.hpp"
+
+#include <vector>
+
+using namespace std;
+using namespace mfem;
+
+int FileReader::ReadSerial(FileReader::FileType ft, const char *mesh_file,
+                           const char *sol_file, int component)
+{
+   // get the mesh from a file
+   named_ifgzstream meshin(mesh_file);
+   if (!meshin)
+   {
+      cerr << "Can not open mesh file " << mesh_file << ". Exit.\n";
+      return 1;
+   }
+
+   data.SetMesh(new Mesh(meshin, 1, 0, data.fix_elem_orient));
+
+   if (ft == FileType::MESH)
+   {
+      data.SetMeshSolution();
+   }
+   else
+   {
+      // get the solution from file
+      bool freesolin = false;
+      ifgzstream *solin = NULL;
+      if (!strcmp(mesh_file, sol_file))
+      {
+         solin = &meshin;
+      }
+      else
+      {
+         solin = new ifgzstream(sol_file);
+         freesolin = true;
+         if (!(*solin))
+         {
+            cerr << "Can not open solution file " << sol_file << ". Exit.\n";
+            return 2;
+         }
+      }
+
+      switch (ft)
+      {
+         case FileType::GRID_FUNC:
+            data.SetGridFunction(new GridFunction(data.mesh.get(), *solin), component);
+            break;
+         case FileType::QUAD_FUNC:
+            data.SetQuadFunction(new QuadratureFunction(data.mesh.get(), *solin),
+                                 component);
+            break;
+         case FileType::SCALAR_SOL:
+         {
+            // get rid of NetGen's info line
+            char buff[128];
+            solin->getline(buff,128);
+            data.sol.Load(*solin, data.mesh->GetNV());
+            data.type = DataState::FieldType::SCALAR;
+         }
+         break;
+         case FileType::VECTOR_SOL:
+            data.solu.Load(*solin, data.mesh->GetNV());
+            data.solv.Load(*solin, data.mesh->GetNV());
+            if (data.mesh->SpaceDimension() == 3)
+            {
+               data.solw.Load(*solin, data.mesh->GetNV());
+            }
+            data.type = DataState::FieldType::VECTOR;
+            break;
+         default:
+            cerr << "Unknown file type. Exit" << endl;
+            exit(1);
+      }
+
+      if (freesolin)
+      {
+         delete solin;
+      }
+   }
+
+   data.ExtrudeMeshAndSolution();
+   return 0;
+}
+
+int FileReader::ReadParallel(int np, FileType ft, const char *mesh_file,
+                             const char *sol_file, int component)
+{
+   int read_err;
+
+   switch (ft)
+   {
+      case FileType::MESH:
+         read_err = ReadParMeshAndGridFunction(np, mesh_file, NULL);
+         break;
+      case FileType::GRID_FUNC:
+         read_err = ReadParMeshAndGridFunction(np, mesh_file, sol_file, component);
+         break;
+      case FileType::QUAD_FUNC:
+         read_err = ReadParMeshAndQuadFunction(np, mesh_file, sol_file, component);
+         break;
+      default:
+         cerr << "Unknown file type. Exit" << endl;
+         exit(1);
+   }
+
+   if (!read_err)
+   {
+      data.ExtrudeMeshAndSolution();
+   }
+
+   return read_err;
+}
+
+int FileReader::ReadParMeshAndGridFunction(int np, const char *mesh_prefix,
+                                           const char *sol_prefix, int component)
+{
+   data.SetMesh(NULL);
+
+   // are the solutions bundled together with the mesh files?
+   bool same_file = false;
+   if (sol_prefix)
+   {
+      same_file = !strcmp(sol_prefix, mesh_prefix);
+      data.SetGridFunction(NULL);
+   }
+
+   std::vector<Mesh *> mesh_array(np);
+   std::vector<GridFunction *> gf_array(np);
+
+   int read_err = 0;
+   for (int p = 0; p < np; p++)
+   {
+      ostringstream fname;
+      fname << mesh_prefix << '.' << setfill('0') << setw(pad_digits) << p;
+      named_ifgzstream meshfile(fname.str().c_str());
+      if (!meshfile)
+      {
+         cerr << "Could not open mesh file: " << fname.str() << '!' << endl;
+         read_err = 1;
+         break;
+      }
+
+      mesh_array[p] = new Mesh(meshfile, 1, 0, data.fix_elem_orient);
+
+      if (!data.keep_attr)
+      {
+         // set element and boundary attributes to be the processor number + 1
+         for (int i = 0; i < mesh_array[p]->GetNE(); i++)
+         {
+            mesh_array[p]->GetElement(i)->SetAttribute(p+1);
+         }
+         for (int i = 0; i < mesh_array[p]->GetNBE(); i++)
+         {
+            mesh_array[p]->GetBdrElement(i)->SetAttribute(p+1);
+         }
+      }
+
+      // read the solution
+      if (sol_prefix)
+      {
+         if (!same_file)
+         {
+            ostringstream sol_fname;
+            sol_fname << sol_prefix << '.' << setfill('0') << setw(pad_digits) << p;
+            ifgzstream solfile(sol_fname.str().c_str());
+            if (!solfile)
+            {
+               cerr << "Could not open solution file "
+                    << sol_fname.str() << '!' << endl;
+               read_err = 2;
+               break;
+            }
+
+            gf_array[p] = new GridFunction(mesh_array[p], solfile);
+         }
+         else  // mesh and solution in the same file
+         {
+            gf_array[p] = new GridFunction(mesh_array[p], meshfile);
+         }
+      }
+   }
+
+   if (!read_err)
+   {
+      // create the combined mesh and gf
+      data.SetMesh(new Mesh(mesh_array.data(), np));
+      if (sol_prefix)
+      {
+         data.SetGridFunction(new GridFunction(data.mesh.get(), gf_array.data(), np),
+                              component);
+      }
+      else
+      {
+         data.SetMeshSolution();
+      }
+   }
+
+   for (int p = 0; p < np; p++)
+   {
+      delete gf_array[np-1-p];
+      delete mesh_array[np-1-p];
+   }
+
+   return read_err;
+}
+
+int FileReader::ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
+                                           const char *sol_prefix, int component)
+{
+   data.SetMesh(NULL);
+
+   // are the solutions bundled together with the mesh files?
+   bool same_file = false;
+   if (sol_prefix)
+   {
+      same_file = !strcmp(sol_prefix, mesh_prefix);
+      data.SetGridFunction(NULL);
+   }
+
+   std::vector<Mesh*> mesh_array(np);
+   std::vector<QuadratureFunction*> qf_array(np);
+
+   int read_err = 0;
+   for (int p = 0; p < np; p++)
+   {
+      ostringstream fname;
+      fname << mesh_prefix << '.' << setfill('0') << setw(pad_digits) << p;
+      named_ifgzstream meshfile(fname.str().c_str());
+      if (!meshfile)
+      {
+         cerr << "Could not open mesh file: " << fname.str() << '!' << endl;
+         read_err = 1;
+         break;
+      }
+
+      mesh_array[p] = new Mesh(meshfile, 1, 0, data.fix_elem_orient);
+
+      if (!data.keep_attr)
+      {
+         // set element and boundary attributes to be the processor number + 1
+         for (int i = 0; i < mesh_array[p]->GetNE(); i++)
+         {
+            mesh_array[p]->GetElement(i)->SetAttribute(p+1);
+         }
+         for (int i = 0; i < mesh_array[p]->GetNBE(); i++)
+         {
+            mesh_array[p]->GetBdrElement(i)->SetAttribute(p+1);
+         }
+      }
+
+      // read the solution
+      if (sol_prefix)
+      {
+         if (!same_file)
+         {
+            ostringstream sol_fname;
+            sol_fname << sol_prefix << '.' << setfill('0') << setw(pad_digits) << p;
+            ifgzstream solfile(sol_fname.str().c_str());
+            if (!solfile)
+            {
+               cerr << "Could not open solution file "
+                    << sol_fname.str() << '!' << endl;
+               read_err = 2;
+               break;
+            }
+
+            qf_array[p] = new QuadratureFunction(mesh_array[p], solfile);
+         }
+         else  // mesh and solution in the same file
+         {
+            qf_array[p] = new QuadratureFunction(mesh_array[p], meshfile);
+         }
+      }
+   }
+
+   if (!read_err)
+   {
+      // create the combined mesh and gf
+      data.SetMesh(new Mesh(mesh_array.data(), np));
+      if (sol_prefix)
+      {
+         data.SetQuadFunction(qf_array, component);
+      }
+      else
+      {
+         data.SetMeshSolution();
+      }
+   }
+
+   for (int p = 0; p < np; p++)
+   {
+      delete qf_array[np-1-p];
+      delete mesh_array[np-1-p];
+   }
+
+   return read_err;
+}

--- a/lib/file_reader.cpp
+++ b/lib/file_reader.cpp
@@ -36,16 +36,14 @@ int FileReader::ReadSerial(FileReader::FileType ft, const char *mesh_file,
    else
    {
       // get the solution from file
-      bool freesolin = false;
-      ifgzstream *solin = NULL;
+      shared_ptr<ifgzstream> solin;
       if (!strcmp(mesh_file, sol_file))
       {
-         solin = &meshin;
+         solin.reset(&meshin, [](ifgzstream*) {}); // no op deleter
       }
       else
       {
-         solin = new ifgzstream(sol_file);
-         freesolin = true;
+         solin.reset(new ifgzstream(sol_file));
          if (!(*solin))
          {
             cerr << "Can not open solution file " << sol_file << ". Exit.\n";
@@ -83,11 +81,6 @@ int FileReader::ReadSerial(FileReader::FileType ft, const char *mesh_file,
          default:
             cerr << "Unknown file type. Exit" << endl;
             exit(1);
-      }
-
-      if (freesolin)
-      {
-         delete solin;
       }
    }
 

--- a/lib/file_reader.cpp
+++ b/lib/file_reader.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/file_reader.hpp
+++ b/lib/file_reader.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+// LICENSE and NOTICE for details. LLNL-CODE-443271.
+//
+// This file is part of the GLVis visualization tool and library. For more
+// information and source code availability see https://glvis.org.
+//
+// GLVis is free software; you can redistribute it and/or modify it under the
+// terms of the BSD-3 license. We welcome feedback and contributions, see file
+// CONTRIBUTING.md for details.
+
+#ifndef GLVIS_FILE_READER_HPP
+#define GLVIS_FILE_READER_HPP
+
+#include <iostream>
+#include "mfem.hpp"
+#include "data_state.hpp"
+
+class FileReader
+{
+   DataState &data;
+   int pad_digits;
+
+   int ReadParMeshAndGridFunction(int np, const char *mesh_prefix,
+                                  const char *sol_prefix, int component = -1);
+   int ReadParMeshAndQuadFunction(int np, const char *mesh_prefix,
+                                  const char *sol_prefix, int component = -1);
+
+public:
+   enum class FileType
+   {
+      MESH,
+      SCALAR_SOL,
+      VECTOR_SOL,
+      GRID_FUNC,
+      QUAD_FUNC,
+   };
+
+   FileReader(DataState &data_, int pad_digits_ = 6)
+      : data(data_), pad_digits(pad_digits_) { }
+
+   /// Read the mesh and the solution from a file
+   int ReadSerial(FileType ft, const char *mesh_file, const char *sol_file,
+                  int component = -1);
+
+   /// Read the mesh and the solution from multiple files
+   int ReadParallel(int np, FileType ft, const char *mesh_file,
+                    const char *sol_file, int component = -1);
+};
+
+#endif // GLVIS_FILE_READER_HPP

--- a/lib/file_reader.hpp
+++ b/lib/file_reader.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024, Lawrence Livermore National Security, LLC. Produced
+// Copyright (c) 2010-2025, Lawrence Livermore National Security, LLC. Produced
 // at the Lawrence Livermore National Laboratory. All Rights reserved. See files
 // LICENSE and NOTICE for details. LLNL-CODE-443271.
 //

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -32,8 +32,6 @@ StreamState &StreamState::operator=(StreamState &&ss)
    normals = std::move(ss.normals);
    keys = std::move(ss.keys);
 
-   is_gf = ss.is_gf;
-   is_qf = ss.is_qf;
    fix_elem_orient = ss.fix_elem_orient;
    save_coloring = ss.save_coloring;
    keep_attr = ss.keep_attr;
@@ -234,7 +232,6 @@ void StreamState::SetMeshSolution()
          cout << "Number of colors: " << grid_f->Max() + 1 << endl;
       }
       grid_f->GetNodalValues(sol);
-      is_gf = 1;
       if (save_coloring)
       {
          const char col_fname[] = "GLVis_coloring.gf";

--- a/lib/stream_reader.cpp
+++ b/lib/stream_reader.cpp
@@ -10,466 +10,102 @@
 // CONTRIBUTING.md for details.
 
 #include "stream_reader.hpp"
-#include "visual.hpp"
-
-#include <cstdlib>
 
 using namespace std;
 using namespace mfem;
 
-/// Helper function for extrusion of 1D quadrature functions to 2D
-QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
-                                          QuadratureFunction *qf, int ny);
-
-StreamState &StreamState::operator=(StreamState &&ss)
+int StreamReader::ReadStream(
+   istream &is, const string &data_type)
 {
-   internal = std::move(ss.internal);
+   data.SetMesh(NULL);
+   data.keys.clear();
 
-   sol = std::move(ss.sol);
-   solu = std::move(ss.solu);
-   solv = std::move(ss.solv);
-   solw = std::move(ss.solw);
-   normals = std::move(ss.normals);
-   keys = std::move(ss.keys);
-
-   fix_elem_orient = ss.fix_elem_orient;
-   save_coloring = ss.save_coloring;
-   keep_attr = ss.keep_attr;
-
-   quad_sol = ss.quad_sol;
-
-   return *this;
-}
-
-void StreamState::SetMesh(mfem::Mesh *mesh_)
-{
-   internal.mesh.reset(mesh_);
-   SetMesh(std::move(internal.mesh));
-}
-
-void StreamState::SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh)
-{
-   internal.mesh = std::move(pmesh);
-   internal.mesh_quad.reset();
-   if (grid_f && grid_f->FESpace()->GetMesh() != mesh.get()) { SetGridFunction(NULL); }
-   if (quad_f && quad_f->GetSpace()->GetMesh() != mesh.get()) { SetQuadFunction(NULL); }
-}
-
-void StreamState::SetGridFunction(mfem::GridFunction *gf)
-{
-   internal.grid_f.reset(gf);
-   SetGridFunction(std::move(internal.grid_f));
-}
-
-void StreamState::SetGridFunction(std::unique_ptr<mfem::GridFunction> &&pgf)
-{
-   internal.grid_f = std::move(pgf);
-   internal.quad_f.reset();
-   quad_sol = QuadSolution::NONE;
-}
-
-void StreamState::SetQuadFunction(mfem::QuadratureFunction *qf)
-{
-   if (quad_f.get() != qf)
-   {
-      internal.grid_f.reset();
-      quad_sol = QuadSolution::NONE;
-   }
-   internal.quad_f.reset(qf);
-}
-
-void StreamState::SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction>
-                                  &&pqf)
-{
-   if (quad_f.get() != pqf.get())
-   {
-      internal.grid_f.reset();
-      quad_sol = QuadSolution::NONE;
-   }
-   internal.quad_f = std::move(pqf);
-}
-
-void StreamState::SetQuadFunction(
-   const std::vector<QuadratureFunction*> &qf_array)
-{
-   // assume the same vdim
-   const int vdim = qf_array[0]->GetVDim();
-   // assume the same quadrature rule
-   QuadratureSpace *qspace = new QuadratureSpace(*mesh,
-                                                 qf_array[0]->GetIntRule(0));
-   SetQuadFunction(new QuadratureFunction(qspace, vdim));
-   quad_f->SetOwnsSpace(true);
-   real_t *g_data = quad_f->GetData();
-   for (const QuadratureFunction *qf_piece : qf_array)
-   {
-      const real_t *l_data = qf_piece->GetData();
-      const int l_size = qf_piece->Size();
-      MFEM_ASSERT(g_data + l_size <= quad_f->GetData() + quad_f->Size(),
-                  "Local parts do not fit to the global quadrature function!");
-      memcpy(g_data, l_data, l_size * sizeof(real_t));
-      g_data += l_size;
-   }
-}
-
-void StreamState::ExtrudeMeshAndSolution()
-{
-   Extrude1DMeshAndSolution();
-   Extrude2D3VMeshAndSolution();
-}
-
-void StreamState::Extrude1DMeshAndSolution()
-{
-   if (mesh->Dimension() != 1 || mesh->SpaceDimension() != 1)
-   {
-      return;
-   }
-
-   // find xmin and xmax over the vertices of the 1D mesh
-   double xmin = numeric_limits<double>::infinity();
-   double xmax = -xmin;
-   for (int i = 0; i < mesh->GetNV(); i++)
-   {
-      const double x = mesh->GetVertex(i)[0];
-      if (x < xmin)
-      {
-         xmin = x;
-      }
-      if (x > xmax)
-      {
-         xmax = x;
-      }
-   }
-
-   Mesh *mesh2d = Extrude1D(mesh.get(), 1, 0.1*(xmax - xmin));
-
-   if (grid_f)
-   {
-      GridFunction *grid_f_2d =
-         Extrude1DGridFunction(mesh.get(), mesh2d, grid_f.get(), 1);
-
-      internal.grid_f.reset(grid_f_2d);
-   }
-   else if (sol.Size() == mesh->GetNV())
-   {
-      Vector sol2d(mesh2d->GetNV());
-      for (int i = 0; i < mesh->GetNV(); i++)
-      {
-         sol2d(2*i+0) = sol2d(2*i+1) = sol(i);
-      }
-      sol = sol2d;
-   }
-
-   if (!mesh_quad) { internal.mesh.swap(internal.mesh_quad); }
-   internal.mesh.reset(mesh2d);
-}
-
-void StreamState::Extrude2D3VMeshAndSolution()
-{
-   if (mesh->SpaceDimension() == 3 || !grid_f || grid_f->VectorDim() < 3) { return; }
-
-   // not all vector elements can be embedded in 3D, so conversion to L2 elements
-   // is performed already here
-   ProjectVectorFEGridFunction();
-
-   Mesh *mesh3d = new Mesh(*mesh);
-   const FiniteElementSpace *fesx = mesh->GetNodalFESpace();
-   const FiniteElementCollection *fecx = (fesx)?(fesx->FEColl()):(NULL);
-   if (fecx)
-   {
-      mesh3d->SetCurvature(fecx->GetOrder(),
-                           fecx->GetContType() == FiniteElementCollection::DISCONTINUOUS,
-                           3);
-   }
-   else
-   {
-      mesh3d->SetCurvature(1, false, 3);
-   }
-
-   FiniteElementSpace *fes2d = grid_f->FESpace();
-   FiniteElementSpace *fes3d = new FiniteElementSpace(*fes2d, mesh3d);
-   GridFunction *gf3d = new GridFunction(fes3d);
-   *gf3d = *grid_f;
-   grid_f->MakeOwner(NULL);
-   gf3d->MakeOwner(const_cast<FiniteElementCollection*>(fes2d->FEColl()));
-
-   SetGridFunction(gf3d);
-   delete fes2d;
-   SetMesh(mesh3d);
-}
-
-void StreamState::SetMeshSolution()
-{
-   if (1) // checkerboard solution
-   {
-      FiniteElementCollection *cfec;
-      if (mesh->Dimension() == 1)
-      {
-         cfec = new L2_FECollection(0, 1);
-      }
-      else if (mesh->Dimension() == 2)
-      {
-         cfec = new Const2DFECollection;
-      }
-      else
-      {
-         cfec = new Const3DFECollection;
-      }
-      FiniteElementSpace *cfes = new FiniteElementSpace(mesh.get(), cfec);
-      SetGridFunction(new GridFunction(cfes));
-      grid_f->MakeOwner(cfec);
-      {
-         Array<int> coloring;
-         srand(time(0));
-         double a = double(rand()) / (double(RAND_MAX) + 1.);
-         int el0 = (int)floor(a * mesh->GetNE());
-         cout << "Generating coloring starting with element " << el0+1
-              << " / " << mesh->GetNE() << endl;
-         mesh->GetElementColoring(coloring, el0);
-         for (int i = 0; i < coloring.Size(); i++)
-         {
-            (*grid_f)(i) = coloring[i];
-         }
-         cout << "Number of colors: " << grid_f->Max() + 1 << endl;
-      }
-      grid_f->GetNodalValues(sol);
-      if (save_coloring)
-      {
-         const char col_fname[] = "GLVis_coloring.gf";
-         ofstream fgrid(col_fname);
-         cout << "Saving the coloring function -> " << flush;
-         grid_f->Save(fgrid);
-         cout << col_fname << endl;
-      }
-   }
-   else // zero solution
-   {
-      sol.SetSize (mesh -> GetNV());
-      sol = 0.0;
-   }
-}
-
-void StreamState::SetQuadSolution(QuadSolution type)
-{
-   // assume identical order
-   const int order = quad_f->GetIntRule(0).GetOrder()/2; // <-- Gauss-Legendre
-   // use the original mesh when available
-   if (mesh_quad.get())
-   {
-      internal.mesh.swap(internal.mesh_quad);
-      internal.mesh_quad.reset();
-   }
-
-   // check for tensor-product basis
-   if (order > 0 && type != QuadSolution::HO_L2_projected)
-   {
-      Array<Geometry::Type> geoms;
-      mesh->GetGeometries(mesh->Dimension(), geoms);
-      for (auto geom : geoms)
-         if (!Geometry::IsTensorProduct(geom))
-         {
-            cout << "High-order quadrature data are supported only for "
-                 << "tensor-product finite elements with this representation"
-                 << endl;
-            SetQuadSolution(QuadSolution::HO_L2_projected);
-            return;
-         }
-   }
-
-   switch (type)
-   {
-      case QuadSolution::LOR_ClosedGL:
-      {
-         const int ref_factor = order + 1;
-         if (ref_factor <= 1)
-         {
-            SetQuadSolution(QuadSolution::HO_L2_collocated); // low-order
-            return;
-         }
-         Mesh *mesh_lor = new Mesh(Mesh::MakeRefined(*mesh, ref_factor,
-                                                     BasisType::ClosedGL));
-         FiniteElementCollection *fec = new L2_FECollection(0, mesh->Dimension());
-         FiniteElementSpace *fes = new FiniteElementSpace(mesh_lor, fec,
-                                                          quad_f->GetVDim(), Ordering::byVDIM);
-         MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
-         cout << "Representing quadrature data by piecewise-constant function on mesh refined "
-              << ref_factor << " times" << endl;
-         GridFunction *gf = new GridFunction(fes, *quad_f, 0);
-         gf->MakeOwner(fec);
-         internal.grid_f.reset(gf);
-         internal.mesh.swap(internal.mesh_quad);
-         internal.mesh.reset(mesh_lor);
-      }
-      break;
-      case QuadSolution::HO_L2_collocated:
-      {
-         FiniteElementCollection *fec = new L2_FECollection(order, mesh->Dimension());
-         FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
-                                                          quad_f->GetVDim(), Ordering::byVDIM);
-         MFEM_ASSERT(quad_f->Size() == fes->GetVSize(), "Size mismatch");
-         cout << "Representing quadrature data by grid function of order "
-              << order << endl;
-         GridFunction *gf = new GridFunction(fes, *quad_f, 0);
-         gf->MakeOwner(fec);
-         internal.grid_f.reset(gf);
-      }
-      break;
-      case QuadSolution::HO_L2_projected:
-      {
-         FiniteElementCollection *fec = new L2_FECollection(order, mesh->Dimension());
-         FiniteElementSpace *fes = new FiniteElementSpace(mesh.get(), fec,
-                                                          quad_f->GetVDim(), Ordering::byVDIM);
-         cout << "Projecting quadrature data to grid function of order "
-              << order << endl;
-         GridFunction *gf = new GridFunction(fes);
-         gf->MakeOwner(fec);
-
-         VectorQuadratureFunctionCoefficient coeff_qf(*quad_f);
-         VectorDomainLFIntegrator bi(coeff_qf);
-         VectorMassIntegrator Mi;
-         Mi.SetVDim(quad_f->GetVDim());
-
-         DenseMatrix M_i;
-         Vector x_i, b_i;
-         DenseMatrixInverse M_i_inv;
-         Array<int> vdofs;
-
-         for (int i = 0; i < mesh->GetNE(); i++)
-         {
-            const FiniteElement *fe = fes->GetFE(i);
-            ElementTransformation *Tr = mesh->GetElementTransformation(i);
-            Mi.AssembleElementMatrix(*fe, *Tr, M_i);
-            M_i_inv.Factor(M_i);
-
-            bi.SetIntRule(&quad_f->GetIntRule(i));
-            bi.AssembleRHSElementVect(*fe, *Tr, b_i);
-
-            x_i.SetSize(b_i.Size());
-            M_i_inv.Mult(b_i, x_i);
-
-            fes->GetElementVDofs(i, vdofs);
-            gf->SetSubVector(vdofs, x_i);
-         }
-
-         internal.grid_f.reset(gf);
-      }
-      break;
-      default:
-         cout << "Unknown quadrature data representation" << endl;
-         return;
-   }
-
-   quad_sol = type;
-}
-
-void StreamState::SwitchQuadSolution(QuadSolution type, VisualizationScene *vs)
-{
-   unique_ptr<Mesh> old_mesh;
-   // we must backup the refined mesh to prevent its deleting
-   if (mesh_quad.get())
-   {
-      internal.mesh.swap(internal.mesh_quad);
-      internal.mesh_quad.swap(old_mesh);
-   }
-   SetQuadSolution(type);
-   ExtrudeMeshAndSolution();
-   ResetMeshAndSolution(*this, vs);
-}
-
-// Read the content of an input stream (e.g. from socket/file)
-StreamState::FieldType StreamState::ReadStream(istream &is,
-                                               const string &data_type)
-{
-   FieldType field_type = FieldType::SCALAR;
-   keys.clear();
    if (data_type == "fem2d_data")
    {
-      SetMesh(new Mesh(is, 0, 0, fix_elem_orient));
-      sol.Load(is, mesh->GetNV());
+      data.type = DataState::FieldType::SCALAR;
+      data.SetMesh(new Mesh(is, 0, 0, data.save_coloring));
+      data.sol.Load(is, data.mesh->GetNV());
    }
    else if (data_type == "vfem2d_data" || data_type == "vfem2d_data_keys")
    {
-      field_type = FieldType::VECTOR;
-      SetMesh(new Mesh(is, 0, 0, fix_elem_orient));
-      solu.Load(is, mesh->GetNV());
-      solv.Load(is, mesh->GetNV());
+      data.type = DataState::FieldType::VECTOR;
+      data.SetMesh(new Mesh(is, 0, 0, data.save_coloring));
+      data.solu.Load(is, data.mesh->GetNV());
+      data.solv.Load(is, data.mesh->GetNV());
       if (data_type == "vfem2d_data_keys")
       {
-         is >> keys;
+         is >> data.keys;
       }
    }
    else if (data_type == "fem3d_data")
    {
-      SetMesh(new Mesh(is, 0, 0, fix_elem_orient));
-      sol.Load(is, mesh->GetNV());
+      data.type = DataState::FieldType::SCALAR;
+      data.SetMesh(new Mesh(is, 0, 0, data.save_coloring));
+      data.sol.Load(is, data.mesh->GetNV());
    }
    else if (data_type == "vfem3d_data" || data_type == "vfem3d_data_keys")
    {
-      field_type = FieldType::VECTOR;
-      SetMesh(new Mesh(is, 0, 0, fix_elem_orient));
-      solu.Load(is, mesh->GetNV());
-      solv.Load(is, mesh->GetNV());
-      solw.Load(is, mesh->GetNV());
+      data.type = DataState::FieldType::VECTOR;
+      data.SetMesh(new Mesh(is, 0, 0, data.save_coloring));
+      data.solu.Load(is, data.mesh->GetNV());
+      data.solv.Load(is, data.mesh->GetNV());
+      data.solw.Load(is, data.mesh->GetNV());
       if (data_type == "vfem3d_data_keys")
       {
-         is >> keys;
+         is >> data.keys;
       }
    }
    else if (data_type == "fem2d_gf_data" || data_type == "fem2d_gf_data_keys")
    {
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetGridFunction(new GridFunction(mesh.get(), is));
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetGridFunction(new GridFunction(data.mesh.get(), is));
       if (data_type == "fem2d_gf_data_keys")
       {
-         is >> keys;
+         is >> data.keys;
       }
    }
    else if (data_type == "vfem2d_gf_data" || data_type == "vfem2d_gf_data_keys")
    {
-      field_type = FieldType::VECTOR;
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetGridFunction(new GridFunction(mesh.get(), is));
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetGridFunction(new GridFunction(data.mesh.get(), is));
       if (data_type == "vfem2d_gf_data_keys")
       {
-         is >> keys;
+         is >> data.keys;
       }
    }
    else if (data_type == "fem3d_gf_data" || data_type == "fem3d_gf_data_keys")
    {
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetGridFunction(new GridFunction(mesh.get(), is));
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetGridFunction(new GridFunction(data.mesh.get(), is));
       if (data_type == "fem3d_gf_data_keys")
       {
-         is >> keys;
+         is >> data.keys;
       }
    }
    else if (data_type == "vfem3d_gf_data" || data_type == "vfem3d_gf_data_keys")
    {
-      field_type = FieldType::VECTOR;
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetGridFunction(new GridFunction(mesh.get(), is));
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetGridFunction(new GridFunction(data.mesh.get(), is));
       if (data_type == "vfem3d_gf_data_keys")
       {
-         is >> keys;
+         is >> data.keys;
       }
    }
    else if (data_type == "solution")
    {
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetGridFunction(new GridFunction(mesh.get(), is));
-      field_type = (grid_f->VectorDim() == 1) ? FieldType::SCALAR : FieldType::VECTOR;
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetGridFunction(new GridFunction(data.mesh.get(), is));
    }
    else if (data_type == "quadrature")
    {
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetQuadFunction(new QuadratureFunction(mesh.get(), is));
-      SetQuadSolution();
-      field_type = (quad_f->GetVDim() == 1) ? FieldType::SCALAR : FieldType::VECTOR;
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetQuadFunction(new QuadratureFunction(data.mesh.get(), is));
+      data.SetQuadSolution();
    }
    else if (data_type == "mesh")
    {
-      SetMesh(new Mesh(is, 1, 0, fix_elem_orient));
-      SetMeshSolution();
-      field_type = FieldType::MESH;
+      data.SetMesh(new Mesh(is, 1, 0, data.save_coloring));
+      data.SetMeshSolution();
    }
    else if (data_type == "raw_scalar_2d")
    {
@@ -526,9 +162,9 @@ StreamState::FieldType StreamState::ReadStream(istream &is,
          tot_num_elem += num_elem;
       }
 
-      SetMesh(new Mesh(2, tot_num_vert, tot_num_elem, 0));
-      sol.SetSize(tot_num_vert);
-      normals.SetSize(3*tot_num_vert);
+      data.SetMesh(new Mesh(2, tot_num_vert, tot_num_elem, 0));
+      data.sol.SetSize(tot_num_vert);
+      data.normals.SetSize(3*tot_num_vert);
 
       int v_off = 0;
       for (int i = 0; i < num_patches; i++)
@@ -537,11 +173,11 @@ StreamState::FieldType StreamState::ReadStream(istream &is,
          num_vert = verts.Size()/6;
          for (int j = 0; j < num_vert; j++)
          {
-            mesh->AddVertex(&verts[6*j]);
-            sol(v_off) = verts[6*j+2];
-            normals(3*v_off+0) = verts[6*j+3];
-            normals(3*v_off+1) = verts[6*j+4];
-            normals(3*v_off+2) = verts[6*j+5];
+            data.mesh->AddVertex(&verts[6*j]);
+            data.sol(v_off) = verts[6*j+2];
+            data.normals(3*v_off+0) = verts[6*j+3];
+            data.normals(3*v_off+1) = verts[6*j+4];
+            data.normals(3*v_off+2) = verts[6*j+5];
             v_off++;
          }
 
@@ -553,29 +189,29 @@ StreamState::FieldType StreamState::ReadStream(istream &is,
          if (n == 3)
             for (int j = 0; j < num_elem; j++)
             {
-               mesh->AddTriangle(&elems[3*j], attr);
+               data.mesh->AddTriangle(&elems[3*j], attr);
             }
          else
             for (int j = 0; j < num_elem; j++)
             {
-               mesh->AddQuad(&elems[4*j], attr);
+               data.mesh->AddQuad(&elems[4*j], attr);
             }
       }
 
       if (mesh_type == 1)
       {
-         mesh->FinalizeTriMesh(1, 0, fix_elem_orient);
+         data.mesh->FinalizeTriMesh(1, 0, data.save_coloring);
       }
       else if (mesh_type == 2)
       {
-         mesh->FinalizeQuadMesh(1, 0, fix_elem_orient);
+         data.mesh->FinalizeQuadMesh(1, 0, data.save_coloring);
       }
       else
       {
          mfem_error("Input data contains mixture of triangles and quads!");
       }
 
-      mesh->GenerateBoundaryElements();
+      data.mesh->GenerateBoundaryElements();
 
       for (int i = num_patches; i > 0; )
       {
@@ -584,25 +220,20 @@ StreamState::FieldType StreamState::ReadStream(istream &is,
          delete vertices[i];
       }
 
-      field_type = FieldType::SCALAR;
+      data.type = DataState::FieldType::SCALAR;
    }
    else
    {
-      field_type = FieldType::UNKNOWN;
       cerr << "Unknown data format" << endl;
       cerr << data_type << endl;
+      return 1;
    }
 
-   if (field_type > FieldType::MIN && field_type < FieldType::MAX)
-   {
-      ExtrudeMeshAndSolution();
-   }
-
-   return field_type;
+   data.ExtrudeMeshAndSolution();
+   return 0;
 }
 
-StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
-                                                input_streams)
+int StreamReader::ReadStreams(const StreamCollection &input_streams)
 {
    const int nproc = input_streams.size();
    std::vector<Mesh*> mesh_array(nproc);
@@ -613,7 +244,6 @@ StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
 
    int gf_count = 0;
    int qf_count = 0;
-   FieldType field_type = FieldType::SCALAR;
 
    for (int p = 0; p < nproc; p++)
    {
@@ -626,8 +256,8 @@ StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
 #ifdef GLVIS_DEBUG
       cout << " type " << data_type << " ... " << flush;
 #endif
-      mesh_array[p] = new Mesh(isock, 1, 0, fix_elem_orient);
-      if (!keep_attr)
+      mesh_array[p] = new Mesh(isock, 1, 0, data.save_coloring);
+      if (!data.keep_attr)
       {
          // set element and boundary attributes to proc+1
          for (int i = 0; i < mesh_array[p]->GetNE(); i++)
@@ -661,22 +291,18 @@ StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
       mfem_error("Input streams contain a mixture of data types!");
    }
 
-   SetMesh(new Mesh(mesh_array.data(), nproc));
+   data.SetMesh(new Mesh(mesh_array.data(), nproc));
    if (gf_count > 0)
    {
-      SetGridFunction(new GridFunction(mesh.get(), gf_array.data(), nproc));
-      field_type = (grid_f->VectorDim() == 1) ? FieldType::SCALAR : FieldType::VECTOR;
+      data.SetGridFunction(new GridFunction(data.mesh.get(), gf_array.data(), nproc));
    }
    else if (qf_count > 0)
    {
-      SetQuadFunction(qf_array);
-      SetQuadSolution();
-      field_type = (quad_f->GetVDim() == 1) ? FieldType::SCALAR : FieldType::VECTOR;
+      data.SetQuadFunction(qf_array);
    }
    else
    {
-      SetMeshSolution();
-      field_type = FieldType::MESH;
+      data.SetMeshSolution();
    }
 
    for (int p = 0; p < nproc; p++)
@@ -685,148 +311,31 @@ StreamState::FieldType StreamState::ReadStreams(const StreamCollection&
       delete gf_array[nproc-1-p];
    }
 
-   ExtrudeMeshAndSolution();
+   data.ExtrudeMeshAndSolution();
 
-   return field_type;
+   return 0;
 }
 
-void StreamState::WriteStream(std::ostream &os)
+void StreamReader::WriteStream(std::ostream &os)
 {
    os.precision(8);
-   if (quad_f)
+   if (data.quad_f)
    {
       os << "quadrature\n";
-      if (mesh_quad.get())
+      if (data.mesh_quad.get())
       {
-         mesh_quad->Print(os);
+         data.mesh_quad->Print(os);
       }
       else
       {
-         mesh->Print(os);
+         data.mesh->Print(os);
       }
-      quad_f->Save(os);
+      data.quad_f->Save(os);
    }
-   else if (grid_f)
+   else if (data.grid_f)
    {
       os << "solution\n";
-      mesh->Print(os);
-      grid_f->Save(os);
+      data.mesh->Print(os);
+      data.grid_f->Save(os);
    }
-}
-
-// Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec
-// or Raviart-Thomas space) with a discontinuous piece-wise polynomial Cartesian
-// product vector grid function of the same order.
-std::unique_ptr<GridFunction>
-StreamState::ProjectVectorFEGridFunction(std::unique_ptr<GridFunction> gf)
-{
-   if ((gf->VectorDim() == 3) && (gf->FESpace()->GetVDim() == 1))
-   {
-      int p = gf->FESpace()->GetOrder(0);
-      cout << "Switching to order " << p
-           << " discontinuous vector grid function..." << endl;
-      int dim = gf->FESpace()->GetMesh()->Dimension();
-      FiniteElementCollection *d_fec =
-         (p == 1 && dim == 3) ?
-         (FiniteElementCollection*)new LinearDiscont3DFECollection :
-         (FiniteElementCollection*)new L2_FECollection(p, dim, 1);
-      FiniteElementSpace *d_fespace =
-         new FiniteElementSpace(gf->FESpace()->GetMesh(), d_fec, 3);
-      GridFunction *d_gf = new GridFunction(d_fespace);
-      d_gf->MakeOwner(d_fec);
-      gf->ProjectVectorFieldOn(*d_gf);
-      gf.reset(d_gf);
-   }
-   return gf;
-}
-
-bool StreamState::SetNewMeshAndSolution(StreamState new_state,
-                                        VisualizationScene* vs)
-{
-   if (new_state.mesh->SpaceDimension() == mesh->SpaceDimension() &&
-       new_state.grid_f->VectorDim() == grid_f->VectorDim())
-   {
-      ResetMeshAndSolution(new_state, vs);
-
-      internal.grid_f = std::move(new_state.internal.grid_f);
-      internal.mesh = std::move(new_state.internal.mesh);
-      internal.quad_f = std::move(new_state.internal.quad_f);
-      internal.mesh_quad = std::move(new_state.internal.mesh_quad);
-
-      return true;
-   }
-   else
-   {
-      return false;
-   }
-}
-
-void StreamState::ResetMeshAndSolution(StreamState &ss, VisualizationScene* vs)
-{
-   if (ss.mesh->SpaceDimension() == 2)
-   {
-      if (ss.grid_f->VectorDim() == 1)
-      {
-         VisualizationSceneSolution *vss =
-            dynamic_cast<VisualizationSceneSolution *>(vs);
-         ss.grid_f->GetNodalValues(ss.sol);
-         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
-                                 ss.grid_f.get());
-      }
-      else
-      {
-         VisualizationSceneVector *vsv =
-            dynamic_cast<VisualizationSceneVector *>(vs);
-         vsv->NewMeshAndSolution(*ss.grid_f, ss.mesh_quad.get());
-      }
-   }
-   else
-   {
-      if (ss.grid_f->VectorDim() == 1)
-      {
-         VisualizationSceneSolution3d *vss =
-            dynamic_cast<VisualizationSceneSolution3d *>(vs);
-         ss.grid_f->GetNodalValues(ss.sol);
-         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
-                                 ss.grid_f.get());
-      }
-      else
-      {
-         ss.ProjectVectorFEGridFunction();
-
-         VisualizationSceneVector3d *vss =
-            dynamic_cast<VisualizationSceneVector3d *>(vs);
-         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), ss.grid_f.get());
-      }
-   }
-}
-
-QuadratureFunction *Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
-                                          QuadratureFunction *qf, int ny)
-{
-   // assume identical orders
-   const int order = qf->GetIntRule(0).GetOrder();
-   const int vdim = qf->GetVDim();
-   QuadratureSpace *qspace2d = new QuadratureSpace(mesh2d, order);
-   QuadratureFunction *qf2d = new QuadratureFunction(qspace2d);
-   qf2d->SetOwnsSpace(true);
-
-   DenseMatrix vals, vals2d;
-   for (int ix = 0; ix < mesh->GetNE(); ix++)
-   {
-      qf->GetValues(ix, vals);
-      const int nq = vals.Width();
-      for (int iy = 0; iy < ny; iy++)
-      {
-         qf2d->GetValues(ix*ny+iy, vals2d);
-         for (int qx = 0; qx < nq; qx++)
-            for (int qy = 0; qy < nq; qy++)
-               for (int d = 0; d < vdim; d++)
-               {
-                  vals2d(d, qy*nq+qx) = vals(d, qx);
-               }
-      }
-   }
-
-   return qf2d;
 }

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -79,6 +79,7 @@ public:
 
    void SetQuadFunction(mfem::QuadratureFunction *qf);
    void SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction> &&pqf);
+   void SetQuadFunction(const std::vector<mfem::QuadratureFunction*> &qf_array);
 
    /// Helper function for visualizing 1D or 2D3V data
    void ExtrudeMeshAndSolution();
@@ -88,9 +89,6 @@ public:
 
    /// Helper function for visualization of 2D3V data
    void Extrude2D3VMeshAndSolution();
-
-   /// Helper function to build the quadrature function from pieces
-   void CollectQuadratures(mfem::QuadratureFunction *qf_array[], int npieces);
 
    /// Set a (checkerboard) solution when only the mesh is given
    void SetMeshSolution();

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -17,121 +17,25 @@
 #include <iostream>
 #include <memory>
 #include "mfem.hpp"
-#include "openglvis.hpp"
+#include "data_state.hpp"
 
 using StreamCollection = std::vector<std::unique_ptr<std::istream>>;
 
-struct StreamState
+class StreamReader
 {
-private:
-   struct
-   {
-      std::unique_ptr<mfem::Mesh> mesh;
-      std::unique_ptr<mfem::Mesh> mesh_quad;
-      std::unique_ptr<mfem::GridFunction> grid_f;
-      std::unique_ptr<mfem::QuadratureFunction> quad_f;
-   } internal;
+   DataState &data;
 
 public:
-   mfem::Vector sol, solu, solv, solw, normals;
-   std::string keys;
-   const std::unique_ptr<mfem::Mesh> &mesh{internal.mesh};
-   const std::unique_ptr<mfem::Mesh> &mesh_quad{internal.mesh_quad};
-   const std::unique_ptr<mfem::GridFunction> &grid_f{internal.grid_f};
-   const std::unique_ptr<mfem::QuadratureFunction> &quad_f{internal.quad_f};
-   bool fix_elem_orient{false};
-   bool save_coloring{false};
-   bool keep_attr{false};
+   StreamReader(DataState &data_) : data(data_) { }
 
-   enum class FieldType
-   {
-      UNKNOWN = -1,
-      MIN = -1,
-      //----------
-      SCALAR,
-      VECTOR,
-      MESH,
-      //----------
-      MAX
-   };
+   /// Read the content of an input stream (e.g. from socket/file)
+   int ReadStream(std::istream &is, const std::string &data_type);
 
-   enum class QuadSolution
-   {
-      NONE = -1,
-      MIN = -1,
-      //----------
-      LOR_ClosedGL,
-      HO_L2_collocated,
-      HO_L2_projected,
-      //----------
-      MAX
-   } quad_sol {QuadSolution::NONE};
+   /// Read the content of an input streams (e.g. from sockets/files)
+   int ReadStreams(const StreamCollection& input_streams);
 
-   StreamState() = default;
-   StreamState(StreamState &&ss) { *this = std::move(ss); }
-   StreamState& operator=(StreamState &&ss);
-
-   void SetMesh(mfem::Mesh *mesh);
-   void SetMesh(std::unique_ptr<mfem::Mesh> &&pmesh);
-
-   void SetGridFunction(mfem::GridFunction *gf);
-   void SetGridFunction(std::unique_ptr<mfem::GridFunction> &&pgf);
-
-   void SetQuadFunction(mfem::QuadratureFunction *qf);
-   void SetQuadFunction(std::unique_ptr<mfem::QuadratureFunction> &&pqf);
-   void SetQuadFunction(const std::vector<mfem::QuadratureFunction*> &qf_array);
-
-   /// Helper function for visualizing 1D or 2D3V data
-   void ExtrudeMeshAndSolution();
-
-   /// Helper function for visualizing 1D data
-   void Extrude1DMeshAndSolution();
-
-   /// Helper function for visualization of 2D3V data
-   void Extrude2D3VMeshAndSolution();
-
-   /// Set a (checkerboard) solution when only the mesh is given
-   void SetMeshSolution();
-
-   /// Set the quadrature function representation producing a proxy grid function
-   void SetQuadSolution(QuadSolution type = QuadSolution::LOR_ClosedGL);
-
-   /// Switch the quadrature function representation and update the visualization
-   void SwitchQuadSolution(QuadSolution type, VisualizationScene* vs);
-
-   /// Get the current representation of quadrature solution
-   inline QuadSolution GetQuadSolution() const { return quad_sol; }
-
-   FieldType ReadStream(std::istream &is, const std::string &data_type);
-
-   FieldType ReadStreams(const StreamCollection& input_streams);
-
+   /// Write the state to a stream (e.g. to socket/file)
    void WriteStream(std::ostream &os);
-
-   // Replace a given VectorFiniteElement-based grid function (e.g. from a Nedelec
-   // or Raviart-Thomas space) with a discontinuous piece-wise polynomial Cartesian
-   // product vector grid function of the same order.
-   static std::unique_ptr<mfem::GridFunction>
-   ProjectVectorFEGridFunction(std::unique_ptr<mfem::GridFunction> gf);
-
-   void ProjectVectorFEGridFunction()
-   { internal.grid_f = ProjectVectorFEGridFunction(std::move(internal.grid_f)); }
-
-   /// Sets a new mesh and solution from another StreamState object, and
-   /// updates the given VisualizationScene pointer with the new data.
-   ///
-   /// Mesh space and grid function dimensions must both match the original
-   /// dimensions of the current StreamState. If there is a mismatch in either
-   /// value, the function will return false, and the mesh/solution will not be
-   /// updated.
-   bool SetNewMeshAndSolution(StreamState new_state,
-                              VisualizationScene* vs);
-
-   /// Updates the given VisualizationScene pointer with the new data
-   /// of the given StreamState object.
-   /// @note: Use with caution when the update is compatible
-   /// @see SetNewMeshAndSolution()
-   static void ResetMeshAndSolution(StreamState &ss, VisualizationScene* vs);
 };
 
 #endif // GLVIS_STREAM_READER_HPP

--- a/lib/stream_reader.hpp
+++ b/lib/stream_reader.hpp
@@ -39,8 +39,6 @@ public:
    const std::unique_ptr<mfem::Mesh> &mesh_quad{internal.mesh_quad};
    const std::unique_ptr<mfem::GridFunction> &grid_f{internal.grid_f};
    const std::unique_ptr<mfem::QuadratureFunction> &quad_f{internal.quad_f};
-   int is_gf{0};
-   int is_qf{0};
    bool fix_elem_orient{false};
    bool save_coloring{false};
    bool keep_attr{false};

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -19,7 +19,7 @@ extern const char *strings_off_on[]; // defined in vsdata.cpp
 
 
 GLVisCommand::GLVisCommand(
-   VisualizationSceneScalarData **_vs, StreamState& state)
+   VisualizationSceneScalarData **_vs, DataState& state)
    : curr_state(state)
 {
    vs        = _vs;
@@ -79,7 +79,7 @@ void GLVisCommand::unlock()
    }
 }
 
-int GLVisCommand::NewMeshAndSolution(StreamState &&ss)
+int GLVisCommand::NewMeshAndSolution(DataState &&ss)
 {
    if (lock() < 0)
    {
@@ -464,7 +464,7 @@ int GLVisCommand::Execute()
             else
             {
                auto qs = curr_state.GetQuadSolution();
-               if (qs != StreamState::QuadSolution::NONE)
+               if (qs != DataState::QuadSolution::NONE)
                {
                   new_state.SetQuadSolution(qs);
                }
@@ -838,7 +838,7 @@ void communication_thread::execute()
           ident == "quadrature" || ident == "parallel")
       {
          bool fix_elem_orient = glvis_command->FixElementOrientations();
-         StreamState tmp;
+         DataState tmp;
          if (ident == "mesh")
          {
             tmp.SetMesh(new Mesh(*is[0], 1, 0, fix_elem_orient));

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -11,6 +11,7 @@
 
 #include "visual.hpp"
 #include "palettes.hpp"
+#include <vector>
 
 using namespace std;
 
@@ -875,9 +876,9 @@ void communication_thread::execute()
          }
          else if (ident == "parallel")
          {
-            Array<Mesh *> mesh_array;
-            Array<GridFunction *> gf_array;
-            Array<QuadratureFunction *> qf_array;
+            std::vector<Mesh*> mesh_array;
+            std::vector<GridFunction*> gf_array;
+            std::vector<QuadratureFunction*> qf_array;
             int proc, nproc, np = 0;
             bool keep_attr = glvis_command->KeepAttrib();
             do
@@ -889,7 +890,7 @@ void communication_thread::execute()
                     << proc << endl;
 #endif
                isock >> ident >> ws;
-               mesh_array.SetSize(nproc);
+               mesh_array.resize(nproc);
                mesh_array[proc] = new Mesh(isock, 1, 0, fix_elem_orient);
                if (!keep_attr)
                {
@@ -905,12 +906,12 @@ void communication_thread::execute()
                }
                if (ident == "solution")
                {
-                  gf_array.SetSize(nproc);
+                  gf_array.resize(nproc);
                   gf_array[proc] = new GridFunction(mesh_array[proc], isock);
                }
                else if (ident == "quadrature")
                {
-                  qf_array.SetSize(nproc);
+                  qf_array.resize(nproc);
                   qf_array[proc] = new QuadratureFunction(mesh_array[proc], isock);
                }
                else
@@ -926,31 +927,31 @@ void communication_thread::execute()
             }
             while (1);
 
-            tmp.SetMesh(new Mesh(mesh_array, nproc));
-            if (gf_array.Size() > 0)
+            tmp.SetMesh(new Mesh(mesh_array.data(), nproc));
+            if (gf_array.size() > 0)
             {
-               tmp.SetGridFunction(new GridFunction(tmp.mesh.get(), gf_array, nproc));
+               tmp.SetGridFunction(new GridFunction(tmp.mesh.get(), gf_array.data(), nproc));
             }
-            else if (qf_array.Size() > 0)
+            else if (qf_array.size() > 0)
             {
-               tmp.CollectQuadratures(qf_array, nproc);
+               tmp.SetQuadFunction(qf_array);
             }
 
             for (int p = 0; p < nproc; p++)
             {
-               if (gf_array.Size() > 0)
+               if (gf_array.size() > 0)
                {
                   delete gf_array[nproc-1-p];
                }
-               if (qf_array.Size() > 0)
+               if (qf_array.size() > 0)
                {
                   delete qf_array[nproc-1-p];
                }
                delete mesh_array[nproc-1-p];
             }
-            gf_array.DeleteAll();
-            qf_array.DeleteAll();
-            mesh_array.DeleteAll();
+            gf_array.clear();
+            qf_array.clear();
+            mesh_array.clear();
          }
 
          // cout << "Stream: new solution" << endl;

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -18,11 +18,10 @@ extern const char *strings_off_on[]; // defined in vsdata.cpp
 
 
 GLVisCommand::GLVisCommand(
-   VisualizationSceneScalarData **_vs, StreamState& state, bool *_keep_attr)
+   VisualizationSceneScalarData **_vs, StreamState& state)
    : curr_state(state)
 {
    vs        = _vs;
-   keep_attr = _keep_attr;
    // should be set in this thread by a call to InitVisualization()
    thread_wnd = GetAppWindow();
 

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -25,7 +25,6 @@ private:
    // Pointers to global GLVis data
    VisualizationSceneScalarData **vs;
    StreamState&         curr_state;
-   bool                 *keep_attr;
    SdlWindow            *thread_wnd;
 
    std::mutex glvis_mutex;
@@ -103,10 +102,10 @@ private:
 public:
    // called by the main execution thread
    GLVisCommand(VisualizationSceneScalarData **_vs,
-                StreamState& thread_state, bool *_keep_attr);
+                StreamState& thread_state);
 
    // to be used by worker threads
-   bool KeepAttrib() { return *keep_attr; } // may need to sync this
+   bool KeepAttrib() { return curr_state.keep_attr; } // may need to sync this
    bool FixElementOrientations() { return curr_state.fix_elem_orient; }
 
    // called by worker threads

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -13,7 +13,7 @@
 #define GLVIS_THREADS_HPP
 
 #include "vsdata.hpp"
-#include "stream_reader.hpp"
+#include "data_state.hpp"
 #include <mfem.hpp>
 #include <thread>
 #include <atomic>
@@ -24,7 +24,7 @@ class GLVisCommand
 private:
    // Pointers to global GLVis data
    VisualizationSceneScalarData **vs;
-   StreamState&         curr_state;
+   DataState&           curr_state;
    SdlWindow            *thread_wnd;
 
    std::mutex glvis_mutex;
@@ -67,7 +67,7 @@ private:
    int command;
 
    // command arguments
-   StreamState   new_state;
+   DataState     new_state;
    std::string   screenshot_filename;
    std::string   key_commands;
    int           window_x, window_y;
@@ -102,14 +102,14 @@ private:
 public:
    // called by the main execution thread
    GLVisCommand(VisualizationSceneScalarData **_vs,
-                StreamState& thread_state);
+                DataState& thread_state);
 
    // to be used by worker threads
    bool KeepAttrib() { return curr_state.keep_attr; } // may need to sync this
    bool FixElementOrientations() { return curr_state.fix_elem_orient; }
 
    // called by worker threads
-   int NewMeshAndSolution(StreamState &&ss);
+   int NewMeshAndSolution(DataState &&ss);
    int Screenshot(const char *filename);
    int KeyCommands(const char *keys);
    int WindowSize(int w, int h);

--- a/makefile
+++ b/makefile
@@ -252,11 +252,11 @@ Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 ALL_SOURCE_FILES = \
  lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp \
  lib/gl/shader.cpp lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp \
- lib/data_state.cpp lib/file_reader.cpp lib/font.cpp lib/gl2ps.c lib/gltf.cpp \
- lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/palettes_base.cpp \
- lib/sdl.cpp lib/sdl_helper.cpp lib/sdl_main.cpp lib/stream_reader.cpp \
- lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp lib/vssolution3d.cpp \
- lib/vsvector.cpp lib/vsvector3d.cpp
+ lib/coll_reader.cpp lib/data_state.cpp lib/file_reader.cpp lib/font.cpp \
+ lib/gl2ps.c lib/gltf.cpp lib/material.cpp lib/openglvis.cpp lib/palettes.cpp \
+ lib/palettes_base.cpp lib/sdl.cpp lib/sdl_helper.cpp lib/sdl_main.cpp \
+ lib/stream_reader.cpp lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp \
+ lib/vssolution3d.cpp lib/vsvector.cpp lib/vsvector3d.cpp
 OBJC_SOURCE_FILES = $(if $(NOTMAC),,lib/sdl_mac.mm)
 DESKTOP_ONLY_SOURCE_FILES = \
  lib/gl/renderer_ff.cpp lib/threads.cpp lib/gl2ps.c lib/sdl_x11.cpp
@@ -270,12 +270,13 @@ COMMON_SOURCE_FILES = $(filter-out \
 HEADER_FILES = \
  lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp \
  lib/gl/shader.hpp lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp \
- lib/gl/types.hpp lib/aux_vis.hpp lib/data_state.hpp lib/file_reader.hpp \
- lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h lib/logo.hpp lib/material.hpp \
- lib/openglvis.hpp lib/palettes.hpp lib/palettes_base.hpp lib/sdl.hpp \
- lib/sdl_helper.hpp lib/sdl_mac.hpp lib/sdl_main.hpp lib/sdl_x11.hpp \
- lib/stream_reader.hpp lib/threads.hpp lib/visual.hpp lib/vsdata.hpp \
- lib/vssolution.hpp lib/vssolution3d.hpp lib/vsvector.hpp lib/vsvector3d.hpp
+ lib/gl/types.hpp lib/aux_vis.hpp lib/coll_reader.hpp lib/data_state.hpp \
+ lib/file_reader.hpp lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h \
+ lib/logo.hpp lib/material.hpp lib/openglvis.hpp lib/palettes.hpp \
+ lib/palettes_base.hpp lib/sdl.hpp lib/sdl_helper.hpp lib/sdl_mac.hpp \
+ lib/sdl_main.hpp lib/sdl_x11.hpp lib/stream_reader.hpp lib/threads.hpp \
+ lib/visual.hpp lib/vsdata.hpp lib/vssolution.hpp lib/vssolution3d.hpp \
+  lib/vsvector.hpp lib/vsvector3d.hpp
 
 DESKTOP_SOURCE_FILES = $(COMMON_SOURCE_FILES) $(DESKTOP_ONLY_SOURCE_FILES) $(LOGO_FILE_CPP)
 WEB_SOURCE_FILES     = $(COMMON_SOURCE_FILES) $(WEB_ONLY_SOURCE_FILES)

--- a/makefile
+++ b/makefile
@@ -252,10 +252,11 @@ Ccc  = $(strip $(CC) $(CFLAGS) $(GL_OPTS))
 ALL_SOURCE_FILES = \
  lib/gl/renderer.cpp lib/gl/renderer_core.cpp lib/gl/renderer_ff.cpp \
  lib/gl/shader.cpp lib/gl/types.cpp lib/aux_js.cpp lib/aux_vis.cpp \
- lib/font.cpp lib/gl2ps.c lib/gltf.cpp lib/material.cpp lib/openglvis.cpp \
- lib/palettes.cpp lib/palettes_base.cpp lib/sdl.cpp lib/sdl_helper.cpp lib/sdl_main.cpp \
- lib/stream_reader.cpp lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp \
- lib/vssolution3d.cpp lib/vsvector.cpp lib/vsvector3d.cpp
+ lib/data_state.cpp lib/file_reader.cpp lib/font.cpp lib/gl2ps.c lib/gltf.cpp \
+ lib/material.cpp lib/openglvis.cpp lib/palettes.cpp lib/palettes_base.cpp \
+ lib/sdl.cpp lib/sdl_helper.cpp lib/sdl_main.cpp lib/stream_reader.cpp \
+ lib/threads.cpp lib/vsdata.cpp lib/vssolution.cpp lib/vssolution3d.cpp \
+ lib/vsvector.cpp lib/vsvector3d.cpp
 OBJC_SOURCE_FILES = $(if $(NOTMAC),,lib/sdl_mac.mm)
 DESKTOP_ONLY_SOURCE_FILES = \
  lib/gl/renderer_ff.cpp lib/threads.cpp lib/gl2ps.c lib/sdl_x11.cpp
@@ -269,9 +270,10 @@ COMMON_SOURCE_FILES = $(filter-out \
 HEADER_FILES = \
  lib/gl/attr_traits.hpp lib/gl/platform_gl.hpp lib/gl/renderer.hpp \
  lib/gl/shader.hpp lib/gl/renderer_core.hpp lib/gl/renderer_ff.hpp \
- lib/gl/types.hpp lib/aux_vis.hpp lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h \
- lib/logo.hpp lib/material.hpp lib/openglvis.hpp lib/palettes.hpp lib/palettes_base.hpp \
- lib/sdl.hpp lib/sdl_helper.hpp lib/sdl_mac.hpp lib/sdl_main.hpp lib/sdl_x11.hpp \
+ lib/gl/types.hpp lib/aux_vis.hpp lib/data_state.hpp lib/file_reader.hpp \
+ lib/font.hpp lib/geom_utils.hpp lib/gl2ps.h lib/logo.hpp lib/material.hpp \
+ lib/openglvis.hpp lib/palettes.hpp lib/palettes_base.hpp lib/sdl.hpp \
+ lib/sdl_helper.hpp lib/sdl_mac.hpp lib/sdl_main.hpp lib/sdl_x11.hpp \
  lib/stream_reader.hpp lib/threads.hpp lib/visual.hpp lib/vsdata.hpp \
  lib/vssolution.hpp lib/vssolution3d.hpp lib/vsvector.hpp lib/vsvector3d.hpp
 


### PR DESCRIPTION
This PR introduces loading of data collections following #325 and refactors the codebase. All collections with implemented readers in MFEM are supported, i.e., VisIt, Sidre, FMS, Conduit. The path to the collection is specified by `-visit/-sidre/-fms/-conduit` parameter and the name of the field through `-g` or q-field through `-q`. Optionally, the cycle and protocol can be specified through `dc-cycle` and `dc-prot` respectively.

Alternatively, scripts can be used for loading. The commands are `data_coll_mesh/field/quad`, where the first parameter is the integer corresponding to the type of the collection matching `DataCollectionReader::CollType`. The cycle and protocol can be preset by `data_coll_cycle/protocol`.

Corresponding website update: https://github.com/GLVis/web/pull/18