### PR TITLE
Non-persistent mode for server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,9 @@ Version 4.4.1 (development)
   end the visualization in this mode. Note GLVis must be compiled with with EGL
   (see INSTALL).
 
+- Added non-persistent mode of the server, when the server terminates after all
+  visualization windows are closed.
+
 
 Version 4.4 released on May 1, 2025
 ===================================

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -380,6 +380,7 @@ int main (int argc, char *argv[])
    const char *palette_file  = string_none;
    const char *font_name     = string_default;
    int         portnum       = 19916;
+   bool        persistent    = true;
    int         multisample   = GetMultisample();
    double      line_width    = GetLineWidth();
    double      ms_line_width = GetLineWidthMS();
@@ -448,6 +449,9 @@ int main (int argc, char *argv[])
                   "Save the mesh coloring generated when opening only a mesh.");
    args.AddOption(&portnum, "-p", "--listen-port",
                   "Specify the port number on which to accept connections.");
+   args.AddOption(&persistent, "-pr", "--persistent",
+                  "-no-pr", "--no-persistent",
+                  "Keep server running after all windows are closed.");
    args.AddOption(&secure, "-sec", "--secure-sockets",
                   "-no-sec", "--standard-sockets",
                   "Enable or disable GnuTLS secure sockets.");
@@ -677,7 +681,7 @@ int main (int argc, char *argv[])
                                win.plot_caption, win.headless};
 
       // Start message loop in main thread
-      MainThreadLoop(win.headless, true);
+      MainThreadLoop(win.headless, persistent);
       serverThread.detach();
    }
    else  // input != 1, non-server mode


### PR DESCRIPTION
An optional small addition to #336 introducing non-persistent mode of server. It means the server is terminated after all visualization windows are closed. This is useful when you have a single application keeping streams open until it ends and a headless server, which should stop after the data are processed.
For example, when the `pause` is commented out in `ex9.cpp` and the visualization output is changed to:
```cpp
sout << "solution\n" << mesh << u << "\n"
     << "screenshot " << "ex9_" << ti << ".png"
     << endl;
```
The example can be run like this:
```sh
./glvis -hl -no-pr &> log.txt &
./ex9 <parameters...>
```
producing a screenshot for every visualization step and closing the server afterwards.