### PR TITLE
Fixed resetting of scalar data

### DIFF
--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -572,7 +572,8 @@ bool DataState::SetNewMeshAndSolution(DataState new_state,
    {
       ResetMeshAndSolution(new_state, vs);
 
-      *this = std::move(new_state);
+      // do not sol vector as it is updated directly
+      internal = std::move(new_state.internal);
 
       return true;
    }

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -572,7 +572,7 @@ bool DataState::SetNewMeshAndSolution(DataState new_state,
    {
       ResetMeshAndSolution(new_state, vs);
 
-      // do not sol vector as it is updated directly
+      // do not move 'sol' vector as it is updated directly
       internal = std::move(new_state.internal);
 
       return true;

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -572,10 +572,7 @@ bool DataState::SetNewMeshAndSolution(DataState new_state,
    {
       ResetMeshAndSolution(new_state, vs);
 
-      internal.grid_f = std::move(new_state.internal.grid_f);
-      internal.mesh = std::move(new_state.internal.mesh);
-      internal.quad_f = std::move(new_state.internal.quad_f);
-      internal.mesh_quad = std::move(new_state.internal.mesh_quad);
+      *this = std::move(new_state);
 
       return true;
    }
@@ -593,8 +590,9 @@ void DataState::ResetMeshAndSolution(DataState &ss, VisualizationScene* vs)
       {
          VisualizationSceneSolution *vss =
             dynamic_cast<VisualizationSceneSolution *>(vs);
-         ss.grid_f->GetNodalValues(ss.sol);
-         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
+         // use the local vector as pointer is invalid after the move
+         ss.grid_f->GetNodalValues(sol);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &sol,
                                  ss.grid_f.get());
       }
       else
@@ -610,8 +608,9 @@ void DataState::ResetMeshAndSolution(DataState &ss, VisualizationScene* vs)
       {
          VisualizationSceneSolution3d *vss =
             dynamic_cast<VisualizationSceneSolution3d *>(vs);
-         ss.grid_f->GetNodalValues(ss.sol);
-         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &ss.sol,
+         // use the local vector as pointer is invalid after the move
+         ss.grid_f->GetNodalValues(sol);
+         vss->NewMeshAndSolution(ss.mesh.get(), ss.mesh_quad.get(), &sol,
                                  ss.grid_f.get());
       }
       else

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -62,6 +62,12 @@ private:
    void SetGridFunctionSolution(int component = -1);
    void SetQuadFunctionSolution(int component = -1);
 
+   /// Updates the given VisualizationScene pointer with the new data
+   /// of the given DataState object.
+   /// @note: Use with caution when the update is compatible
+   /// @see SetNewMeshAndSolution()
+   void ResetMeshAndSolution(DataState &ss, VisualizationScene* vs);
+
 public:
    mfem::Vector sol, solu, solv, solw, normals;
    const std::unique_ptr<mfem::Mesh> &mesh{internal.mesh};
@@ -168,12 +174,6 @@ public:
    /// updated.
    bool SetNewMeshAndSolution(DataState new_state,
                               VisualizationScene* vs);
-
-   /// Updates the given VisualizationScene pointer with the new data
-   /// of the given DataState object.
-   /// @note: Use with caution when the update is compatible
-   /// @see SetNewMeshAndSolution()
-   static void ResetMeshAndSolution(DataState &ss, VisualizationScene* vs);
 };
 
 #endif // GLVIS_DATA_STATE_HPP


### PR DESCRIPTION
Fixed reset of `sol*` vectors for visualization scene, which caused crashes like in #341 .