### PR TITLE
Palette cli

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -1471,7 +1471,7 @@ int main (int argc, char *argv[])
                   "Run a GLVis script file.");
    args.AddOption(&palette_file, "-pfile", "--palette-file",
                   "Palette file.");
-   args.AddOption(&palette_init, "-pal", "--palette-init",
+   args.AddOption(&palette_init, "-pal", "--palette",
                   "Initial palette.");
    args.AddOption(&arg_keys, "-k", "--keys",
                   "Execute key shortcut commands in the GLVis window.");

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -169,7 +169,7 @@ bool GLVisInitVis(StreamCollection input_streams)
             vs->Zoom(1.8);
             // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
             // the 'jet-like' palette is used in 2D, see vssolution.cpp).
-            vs->palette.SetIndex(4);
+            vs->palette.SetFallbackIndex(4);
          }
       }
       else if (stream_state.mesh->SpaceDimension() == 3)
@@ -186,13 +186,13 @@ bool GLVisInitVis(StreamCollection input_streams)
             if (stream_state.mesh->Dimension() == 3)
             {
                // Use the 'white' palette when visualizing a 3D volume mesh only
-               vss->palette.SetIndex(11);
+               vss->palette.SetFallbackIndex(11);
                vss->SetLightMatIdx(4);
             }
             else
             {
                // Use the 'bone' palette when visualizing a surface mesh only
-               vss->palette.SetIndex(4);
+               vss->palette.SetFallbackIndex(4);
             }
             // Otherwise, the 'vivid' palette is used in 3D see vssolution3d.cpp
             vss->ToggleDrawAxes();
@@ -1417,6 +1417,7 @@ int main (int argc, char *argv[])
    const char *stream_file   = string_none;
    const char *script_file   = string_none;
    const char *palette_file  = string_none;
+   const char *palette_init  = string_none;
    const char *font_name     = string_default;
    int         portnum       = 19916;
    int         multisample   = GetMultisample();
@@ -1468,8 +1469,10 @@ int main (int argc, char *argv[])
                   "Number of digits used for processor ranks in file names.");
    args.AddOption(&script_file, "-run", "--run-script",
                   "Run a GLVis script file.");
-   args.AddOption(&palette_file, "-pal", "--palettes",
+   args.AddOption(&palette_file, "-pfile", "--palette-file",
                   "Palette file.");
+   args.AddOption(&palette_init, "-pal", "--palette-init",
+                  "Initial palette.");
    args.AddOption(&arg_keys, "-k", "--keys",
                   "Execute key shortcut commands in the GLVis window.");
    args.AddOption(&stream_state.fix_elem_orient, "-fo", "--fix-orientations",
@@ -1625,6 +1628,11 @@ int main (int argc, char *argv[])
    if (palette_file != string_none)
    {
       BasePalettes.Load(palette_file);
+   }
+
+   if (palette_init != string_none)
+   {
+      BasePalettes.SetDefault(palette_init);
    }
 
    GLVisGeometryRefiner.SetType(geom_ref_type);

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -126,7 +126,7 @@ void display(std::stringstream & commands, const int w, const int h)
             vs->Zoom(1.8);
             // Use the 'bone' palette when visualizing a 2D mesh only (otherwise
             // the 'jet-like' palette is used in 2D, see vssolution.cpp).
-            vs->palette.SetIndex(4);
+            vs->palette.SetFallbackIndex(4);
          }
       }
       else if (stream_state.mesh->SpaceDimension() == 3)
@@ -143,13 +143,13 @@ void display(std::stringstream & commands, const int w, const int h)
             if (stream_state.mesh->Dimension() == 3)
             {
                // Use the 'white' palette when visualizing a 3D volume mesh only
-               vs->palette.SetIndex(11);
+               vs->palette.SetFallbackIndex(11);
                vss->SetLightMatIdx(4);
             }
             else
             {
                // Use the 'bone' palette when visualizing a surface mesh only
-               vs->palette.SetIndex(4);
+               vs->palette.SetFallbackIndex(4);
             }
             // Otherwise, the 'vivid' palette is used in 3D see vssolution3d.cpp
 

--- a/lib/palettes.cpp
+++ b/lib/palettes.cpp
@@ -171,6 +171,18 @@ void PaletteState::SetIndex(int num)
    cout << "Palette: " << num << ") " << Palettes->Get(curr_palette)->name << endl;
 }
 
+bool PaletteState::UseDefaultIndex()
+{
+   int num = Palettes->GetDefault();
+   if (num >= 0 || num < Palettes->NumPalettes())
+   {
+      curr_palette = num;
+      cout << "Palette: " << num << ") " << Palettes->Get(curr_palette)->name << endl;
+      return true;
+   }
+   return false;
+}
+
 void PaletteState::NextIndex()
 {
    SetIndex((curr_palette + 1) % Palettes->NumPalettes());

--- a/lib/palettes.hpp
+++ b/lib/palettes.hpp
@@ -29,6 +29,11 @@ public:
    int GetSmoothSetting() { return use_smooth; }
    /// Sets the palette texture to bind.
    void SetIndex(int num);
+   /// Use the default index if set
+   bool UseDefaultIndex();
+   /// If default index is not set, sets to this index.
+   /// Used for setting recommend palettes
+   void SetFallbackIndex(int idx) { if (!UseDefaultIndex()) { SetIndex(idx); } };
    int GetCurrIndex() const { return curr_palette; }
    void NextIndex();
    void PrevIndex();

--- a/lib/palettes_base.cpp
+++ b/lib/palettes_base.cpp
@@ -392,6 +392,23 @@ Palette* PaletteRegistry::Get(const string& name) const
    return palettes.back().get();
 }
 
+void PaletteRegistry::SetDefault(const string& name)
+{
+   const int idx = GetIndexByName(name);
+   if (idx < 0)
+   {
+      cout << "Palette (name = " << name << ") not found. Available palettes:"
+           << endl;
+      PrintSummary();
+   }
+   else
+   {
+      default_palette = idx;
+      cout << "Default palette set to: " << default_palette << ") "
+            << Get(default_palette)->name << endl;
+   }
+}
+
 void PaletteRegistry::PrintSummary(ostream& os) const
 {
    for (int i = 0; i < NumPalettes(); i++)

--- a/lib/palettes_base.cpp
+++ b/lib/palettes_base.cpp
@@ -405,7 +405,7 @@ void PaletteRegistry::SetDefault(const string& name)
    {
       default_palette = idx;
       cout << "Default palette set to: " << default_palette << ") "
-            << Get(default_palette)->name << endl;
+           << Get(default_palette)->name << endl;
    }
 }
 

--- a/lib/palettes_base.hpp
+++ b/lib/palettes_base.hpp
@@ -177,6 +177,7 @@ private:
 
    /// Find the index of a palette by name
    int GetIndexByName(const string& name) const;
+   int default_palette = -1; // index of the default palette
 
 public:
    /// Empty constructor
@@ -200,6 +201,12 @@ public:
 
    /// Get a palette pointer by name; if not found, returns last palette
    Palette* Get(const string& name) const;
+
+   /// Set the index of the default palette by name
+   void SetDefault(const string& name);
+
+   /// Get the index of the default palette
+   int GetDefault() const { return default_palette; };
 
    /// Prints a summary (index + name) of all palettes
    void PrintSummary(ostream& os = cout) const;

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -467,7 +467,7 @@ void VisualizationSceneSolution::Init()
 
    VisualizationSceneScalarData::Init();  // Calls FindNewBox() !!!
 
-   palette.SetIndex(2); // use the 'jet-like' palette in 2D
+   palette.SetFallbackIndex(2); // use the 'jet-like' palette in 2D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
    CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*bb.x[0]+(0.5+eps)*bb.x[1]);

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -751,7 +751,7 @@ void VisualizationSceneSolution3d::Init()
 
    node_pos = new double[mesh->GetNV()];
 
-   palette.SetIndex(12); // use the 'vivid' palette in 3D
+   palette.SetFallbackIndex(12); // use the 'vivid' palette in 3D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
    CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*bb.x[0]+(0.5+eps)*bb.x[1]);


### PR DESCRIPTION
- Adds the option to specify a palette using CLI arg `-pal` or `-palette`
- CLI arg for specifying extra palettes via file is now `-pfile` or `-palette-file`
- Internally, use `PaletteState.SetFallbackIndex()` over `PaletteState.SetIndex()` to specify a fallback index if the default is not specified (implementation would have been more invasive via `PaletteState` so it is done through the global `BasePalettes`)