### PR TITLE
:warning: :robot: Runtime selectible line width

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,19 @@
                              https://glvis.org
 
 
+Version 4.5.1 (development)
+===========================
+- Added configurable line width for mesh edges and element boundaries when MSAA
+  is enabled. Line width can be adjusted at runtime using ';' (decrease) and '''
+  (increase) keys in 0.25 pixel increments (minimum 0.25, no maximum). Default
+  line width now is 1.5 pixels.
+
+- Without antialiasing, the original GL_LINES rendering is still used. With
+  antialiasing, lines are rendered using shader-expanded triangles and hardware
+  MSAA with fragment shader techniques. The line rendering format switches
+  automatically when toggling MSAA with the 'A' key.
+
+
 Version 4.5 released on Feb 6, 2026
 ===================================
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ Version 4.5.1 (development)
 - Added configurable line width for mesh edges and element boundaries when MSAA
   is enabled. Line width can be adjusted at runtime using ';' (decrease) and '''
   (increase) keys in 0.25 pixel increments (minimum 0.25, no maximum). Default
-  line width now is 1.5 pixels.
+  line width is platform-dependent (1.5 pixels on macOS, 1.4 pixels elsewhere).
 
 - Without antialiasing, the original GL_LINES rendering is still used. With
   antialiasing, lines are rendered using shader-expanded triangles and hardware

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Key commands
 - <kbd>*</kbd> / <kbd>/</kbd> – Zoom in/out
 - <kbd>+</kbd> / <kbd>-</kbd> – Stretch/compress in `z`-direction
 - <kbd>[</kbd> / <kbd>]</kbd> – Shrink/enlarge the bounding box (relative to the colorbar)
+- <kbd>;</kbd> / <kbd>'</kbd> – Decrease/increase line width
 - <kbd>(</kbd> / <kbd>)</kbd> – Shrink/enlarge the visualization window
 - <kbd>.</kbd> – Start/stop `z`-spinning (speed/direction can be controlled with <kbd>0</kbd> / <kbd>Enter</kbd>)
 - <kbd>←</kbd>, <kbd>→</kbd>, <kbd>↑</kbd>, <kbd>↓</kbd> – Manual rotation

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -258,6 +258,8 @@ GLWindow* InitVisualization(const char name[], int x, int y, int w, int h,
 
    wnd->setOnKeyDown (SDLK_LEFTBRACKET, ScaleDown);
    wnd->setOnKeyDown (SDLK_RIGHTBRACKET, ScaleUp);
+   wnd->setOnKeyDown (SDLK_SEMICOLON, DecreaseLineWidth);
+   wnd->setOnKeyDown (SDLK_QUOTE, IncreaseLineWidth);
    wnd->setOnKeyDown (SDLK_AT, LookAt);
 
 #ifndef __EMSCRIPTEN__
@@ -1647,6 +1649,26 @@ void ScaleUp()
 void ScaleDown()
 {
    locscene->Scale(1.0/1.025);
+   SendExposeEvent();
+}
+
+void IncreaseLineWidth()
+{
+   float new_w = GetLineWidth() + 0.25f;
+   float new_w_aa = GetLineWidthMS() + 0.25f;
+   SetLineWidth(new_w);
+   SetLineWidthMS(new_w_aa);
+   cout << "Line width: " << new_w << " (antialiased: " << new_w_aa << ")" << endl;
+   SendExposeEvent();
+}
+
+void DecreaseLineWidth()
+{
+   float new_w = std::max(0.25f, GetLineWidth() - 0.25f);
+   float new_w_aa = std::max(0.25f, GetLineWidthMS() - 0.25f);
+   SetLineWidth(new_w);
+   SetLineWidthMS(new_w_aa);
+   cout << "Line width: " << new_w << " (antialiased: " << new_w_aa << ")" << endl;
    SendExposeEvent();
 }
 

--- a/lib/aux_vis.cpp
+++ b/lib/aux_vis.cpp
@@ -9,6 +9,7 @@
 // terms of the BSD-3 license. We welcome feedback and contributions, see file
 // CONTRIBUTING.md for details.
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <cmath>

--- a/lib/aux_vis.hpp
+++ b/lib/aux_vis.hpp
@@ -104,6 +104,8 @@ void ScaleDown();
 void LookAt();
 void ShrinkWindow();
 void EnlargeWindow();
+void IncreaseLineWidth();
+void DecreaseLineWidth();
 void MoveResizeWindow(int x, int y, int w, int h);
 void ResizeWindow(int w, int h);
 void SetWindowTitle(const char *title);

--- a/lib/gl/renderer.cpp
+++ b/lib/gl/renderer.cpp
@@ -49,6 +49,11 @@ void MeshRenderer::setAntialiasing(bool aa_status)
    if (msaa_enable != aa_status)
    {
       msaa_enable = aa_status;
+      // Update device's MSAA state for conditional line rendering
+      if (device)
+      {
+         device->setMSAAEnabled(aa_status);
+      }
       if (msaa_enable)
       {
          if (!feat_use_fbo_antialias)
@@ -398,6 +403,9 @@ void MeshRenderer::buffer(GlDrawable* buf)
 
 void GLDevice::init()
 {
+   // Initialize line width
+   line_w = 1.0f;
+   msaa_enabled = false;
    // enable depth testing
    glDepthFunc(GL_LEQUAL);
    glEnable(GL_DEPTH_TEST);

--- a/lib/gl/renderer_core.cpp
+++ b/lib/gl/renderer_core.cpp
@@ -388,7 +388,16 @@ void CoreGLDevice::bufferToDevice(array_layout layout, IVertexBuffer &buf)
       }
       glBindBuffer(GL_ARRAY_BUFFER, vbos[buf.getHandle()].vert_buf);
       glBufferData(GL_ARRAY_BUFFER, 0, nullptr, GL_STATIC_DRAW);
-      if (buf.count() == 0) { return; }
+      if (buf.count() == 0)
+      {
+         vbos[buf.getHandle()].count = 0;
+         if (vbos[buf.getHandle()].elem_buf != 0)
+         {
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbos[buf.getHandle()].elem_buf);
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, 0, nullptr, GL_STATIC_DRAW);
+         }
+         return;
+      }
 
       // Create extended vertex data for generating shader-expanded lines
       if (layout == Vertex::layout)
@@ -703,8 +712,9 @@ void CoreGLDevice::drawDeviceBuffer(int hnd)
    }
    else
    {
-      // Ensure expandLines is disabled for non-line buffers
+      // Ensure expandLines and useLineAA are disabled for non-line buffers
       glUniform1i(uniforms["expandLines"], false);
+      glUniform1i(uniforms["useLineAA"], false);
 
       switch (vbos[hnd].layout)
       {

--- a/lib/gl/renderer_core.hpp
+++ b/lib/gl/renderer_core.hpp
@@ -31,6 +31,9 @@ public:
       ATTR_NORMAL,
       ATTR_COLOR,
       ATTR_TEXCOORD0,
+      ATTR_LINE_ORIENT,
+      ATTR_LINE_PREV,
+      ATTR_LINE_NEXT,
       NUM_ATTRS
    };
 
@@ -40,6 +43,9 @@ public:
       float color[4];
       float clipCoord;
    };
+
+   struct LineVertex;
+   struct LineColorVertex;
 
 private:
    ShaderProgram default_prgm;

--- a/lib/gl/shaders/default.frag
+++ b/lib/gl/shaders/default.frag
@@ -20,6 +20,9 @@ varying vec2 fTexCoord;
 
 uniform bool useClipPlane;
 varying float fClipVal;
+varying float fLineEdgeDist;
+uniform bool useLineAA;
+uniform float lineWidth;
 
 void fragmentClipPlane()
 {
@@ -39,6 +42,122 @@ void main()
 #else
    color.a *= texture2D(alphaTex, vec2(fTexCoord)).r;
 #endif
+
+   // Fragment shader antialiasing for lines (combined with MSAA when enabled)
+   if (useLineAA && abs(fLineEdgeDist) > 0.001)
+   {
+      float dist = abs(fLineEdgeDist);
+      float delta = fwidth(dist);
+
+      // Edge transition with asymmetric smoothing
+      float edge0 = 1.0 - delta * 1.6;
+      float edge1 = 1.0 + delta * 0.6;
+      float t = clamp((dist - edge0) / (edge1 - edge0), 0.0, 1.0);
+
+      // Smootherstep interpolation (C2 continuous)
+      float smootherT = t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+      float alpha = 1.0 - smootherT;
+      alpha = alpha * (1.0 + alpha * 0.03);
+
+      // Dual-ring multi-sampling (8 inner + 4 outer samples)
+      float dx = dFdx(fLineEdgeDist);
+      float dy = dFdy(fLineEdgeDist);
+
+      const float r1 = 0.3535533905932738; // Inner ring: 1/sqrt(8)
+      float s1 = abs(fLineEdgeDist + dx * r1);
+      float s2 = abs(fLineEdgeDist - dx * r1);
+      float s3 = abs(fLineEdgeDist + dy * r1);
+      float s4 = abs(fLineEdgeDist - dy * r1);
+      float s5 = abs(fLineEdgeDist + (dx + dy) * r1 * 0.707);
+      float s6 = abs(fLineEdgeDist + (dx - dy) * r1 * 0.707);
+      float s7 = abs(fLineEdgeDist - (dx + dy) * r1 * 0.707);
+      float s8 = abs(fLineEdgeDist - (dx - dy) * r1 * 0.707);
+
+      const float r2 = 0.5; // Outer ring
+      float s9 = abs(fLineEdgeDist + (dx + dy) * r2);
+      float s10 = abs(fLineEdgeDist + (dx - dy) * r2);
+      float s11 = abs(fLineEdgeDist - (dx + dy) * r2);
+      float s12 = abs(fLineEdgeDist - (dx - dy) * r2);
+
+      // Apply smootherstep to all 12 samples
+      float t1 = clamp((s1 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t2 = clamp((s2 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t3 = clamp((s3 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t4 = clamp((s4 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t5 = clamp((s5 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t6 = clamp((s6 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t7 = clamp((s7 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t8 = clamp((s8 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t9 = clamp((s9 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t10 = clamp((s10 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t11 = clamp((s11 - edge0) / (edge1 - edge0), 0.0, 1.0);
+      float t12 = clamp((s12 - edge0) / (edge1 - edge0), 0.0, 1.0);
+
+      float a1 = 1.0 - t1 * t1 * t1 * (t1 * (t1 * 6.0 - 15.0) + 10.0);
+      float a2 = 1.0 - t2 * t2 * t2 * (t2 * (t2 * 6.0 - 15.0) + 10.0);
+      float a3 = 1.0 - t3 * t3 * t3 * (t3 * (t3 * 6.0 - 15.0) + 10.0);
+      float a4 = 1.0 - t4 * t4 * t4 * (t4 * (t4 * 6.0 - 15.0) + 10.0);
+      float a5 = 1.0 - t5 * t5 * t5 * (t5 * (t5 * 6.0 - 15.0) + 10.0);
+      float a6 = 1.0 - t6 * t6 * t6 * (t6 * (t6 * 6.0 - 15.0) + 10.0);
+      float a7 = 1.0 - t7 * t7 * t7 * (t7 * (t7 * 6.0 - 15.0) + 10.0);
+      float a8 = 1.0 - t8 * t8 * t8 * (t8 * (t8 * 6.0 - 15.0) + 10.0);
+      float a9 = 1.0 - t9 * t9 * t9 * (t9 * (t9 * 6.0 - 15.0) + 10.0);
+      float a10 = 1.0 - t10 * t10 * t10 * (t10 * (t10 * 6.0 - 15.0) + 10.0);
+      float a11 = 1.0 - t11 * t11 * t11 * (t11 * (t11 * 6.0 - 15.0) + 10.0);
+      float a12 = 1.0 - t12 * t12 * t12 * (t12 * (t12 * 6.0 - 15.0) + 10.0);
+
+      // Weighted average: center(3x) + inner_ring(8×1x) + outer_ring(4×0.6x)
+      alpha = (alpha * 3.0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + (a9 + a10 + a11 + a12) * 0.6) / 13.4;
+
+      // Contrast-adaptive sharpening based on sample variance
+      float variance = 0.0;
+      variance += (a1 - alpha) * (a1 - alpha);
+      variance += (a2 - alpha) * (a2 - alpha);
+      variance += (a3 - alpha) * (a3 - alpha);
+      variance += (a4 - alpha) * (a4 - alpha);
+      variance += (a5 - alpha) * (a5 - alpha);
+      variance += (a6 - alpha) * (a6 - alpha);
+      variance += (a7 - alpha) * (a7 - alpha);
+      variance += (a8 - alpha) * (a8 - alpha);
+      variance += (a9 - alpha) * (a9 - alpha);
+      variance += (a10 - alpha) * (a10 - alpha);
+      variance += (a11 - alpha) * (a11 - alpha);
+      variance += (a12 - alpha) * (a12 - alpha);
+      variance /= 12.0;
+
+      float sharpness = smoothstep(0.0, 0.10, variance);
+      float sharpenAmount = sharpness * 0.25;
+      float deviation = alpha - 0.5;
+      alpha = clamp(alpha + deviation * sharpenAmount, 0.0, 1.0);
+
+      // Subtle outer feather for smooth edges
+      if (dist > 0.88 && dist < 1.25)
+      {
+         float featherDist = (dist - 0.88) / 0.37;
+         float featherAlpha = exp(-featherDist * featherDist * 3.5);
+         alpha = alpha * 0.88 + featherAlpha * 0.12;
+      }
+
+      // Sub-pixel coverage correction
+      float pixelWidth = lineWidth * 1000.0;
+      if (pixelWidth < 1.0)
+      {
+         alpha *= mix(pixelWidth, 1.0, pixelWidth * pixelWidth);
+      }
+
+      // Gamma correction for sRGB
+      alpha = pow(clamp(alpha, 0.0, 1.0), 1.0 / 2.2);
+
+      // Dual-frequency dithering to reduce banding
+      vec2 screenPos = gl_FragCoord.xy;
+      float noise1 = fract(52.9829189 * fract(0.06711056 * screenPos.x + 0.00583715 * screenPos.y));
+      float noise2 = fract(31.5491234 * fract(0.09127341 * screenPos.x + 0.04283951 * screenPos.y));
+      float noise = noise1 * 0.6 + noise2 * 0.4;
+      alpha = clamp(alpha + (noise - 0.5) * 0.012, 0.0, 1.0);
+
+      color.a *= alpha;
+   }
+
    gl_FragColor = color;
 }
 )"

--- a/lib/gl/shaders/default.vert
+++ b/lib/gl/shaders/default.vert
@@ -16,7 +16,15 @@ attribute vec4 color;
 attribute vec3 normal;
 attribute vec2 texCoord0;
 
+attribute float line_orientation;
+attribute vec3 line_prev_vtx;
+attribute vec3 line_next_vtx;
+
 uniform bool containsText;
+
+uniform bool expandLines;
+uniform float lineWidth;
+uniform float aspectRatio;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
@@ -31,6 +39,7 @@ varying vec4 fColor;
 varying vec2 fTexCoord;
 
 varying float fClipVal;
+varying float fLineEdgeDist;
 
 void setupClipPlane(in float dist)
 {
@@ -44,6 +53,7 @@ void main()
    fNormal = normalize(normalMatrix * normal);
    fColor = color;
    fTexCoord = texCoord0.xy;
+   fLineEdgeDist = 0.0; // Default: not a line
    setupClipPlane(dot(vec4(pos.xyz, 1.0), clipPlane));
    pos = projectionMatrix * pos;
    gl_Position = pos;
@@ -51,5 +61,84 @@ void main()
    {
       vec4 textOffset = textProjMatrix * vec4(textVertex, 0.0, 0.0);
       gl_Position += vec4((textOffset.xy * pos.w), -0.005, 0.0);
+   }
+   // Line expansion (adapted from: https://github.com/mattdesl/webgl-lines)
+   if (expandLines)
+   {
+      fLineEdgeDist = line_orientation; // ±1 at edges, 0 at center
+
+      // Transform to screen space
+      mat4 mvp = projectionMatrix * modelViewMatrix;
+      vec4 prev_clip = mvp * vec4(line_prev_vtx, 1.0);
+      vec4 next_clip = mvp * vec4(line_next_vtx, 1.0);
+
+      vec2 curr_scrn = pos.xy / pos.w;
+      vec2 prev_scrn = prev_clip.xy / prev_clip.w;
+      vec2 next_scrn = next_clip.xy / next_clip.w;
+
+      curr_scrn.x *= aspectRatio;
+      prev_scrn.x *= aspectRatio;
+      next_scrn.x *= aspectRatio;
+
+      float width = lineWidth;
+
+      // Compute line segment direction
+      float dist_to_prev = distance(vertex, line_prev_vtx);
+      float dist_to_next = distance(vertex, line_next_vtx);
+
+      vec2 dir;
+      vec2 tangent_offset = vec2(0.0);
+
+      if (dist_to_prev < 0.0001)
+      {
+         // Start cap (rounded)
+         dir = normalize(next_scrn - curr_scrn);
+         tangent_offset = -dir * lineWidth * 0.5;
+      }
+      else if (dist_to_next < 0.0001)
+      {
+         // End cap (rounded)
+         dir = normalize(curr_scrn - prev_scrn);
+         tangent_offset = dir * lineWidth * 0.5;
+      }
+      else
+      {
+         // Line join
+         vec2 dirA = normalize(curr_scrn - prev_scrn);
+         vec2 dirB = normalize(next_scrn - curr_scrn);
+
+         float dot_dirs = dot(dirA, dirB);
+         if (dot_dirs > 0.99)
+         {
+            // Nearly straight line
+            dir = normalize(dirA + dirB);
+         }
+         else
+         {
+            // Miter join with bevel fallback for sharp angles
+            vec2 tangent = normalize(dirA + dirB);
+            vec2 miter = vec2(-tangent.y, tangent.x);
+            vec2 normal = vec2(-dirA.y, dirA.x);
+            float miter_length = 1.0 / max(dot(miter, normal), 0.001);
+
+            if (miter_length > 2.5)
+            {
+               // Bevel join for sharp angles (< ~75°)
+               dir = dirA;
+               width = lineWidth;
+            }
+            else
+            {
+               dir = tangent;
+               width = lineWidth * miter_length;
+            }
+         }
+      }
+
+      vec2 line_normal = vec2(-dir.y, dir.x);
+      line_normal.x /= aspectRatio;
+      tangent_offset.x /= aspectRatio;
+      vec4 offset = vec4(line_normal * line_orientation * width * pos.w / 2.0 + tangent_offset * pos.w, 0.0, 0.0);
+      gl_Position += offset;
    }
 })"

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -174,7 +174,9 @@ enum array_layout
    LAYOUT_VTX_TEXTURE0,
    LAYOUT_VTX_NORMAL_COLOR,
    LAYOUT_VTX_NORMAL_TEXTURE0,
-   NUM_LAYOUTS
+   NUM_LAYOUTS,
+   LAYOUT_EXT_LINE_VTX,
+   LAYOUT_EXT_LINE_VTX_COLOR
 };
 
 inline std::array<uint8_t, 4> ColorU8(float rgba[])

--- a/lib/gl/types.hpp
+++ b/lib/gl/types.hpp
@@ -174,7 +174,7 @@ enum array_layout
    LAYOUT_VTX_TEXTURE0,
    LAYOUT_VTX_NORMAL_COLOR,
    LAYOUT_VTX_NORMAL_TEXTURE0,
-   NUM_LAYOUTS,
+   NUM_LAYOUTS, // Only counts drawable layouts; extended layouts must be > NUM_LAYOUTS
    LAYOUT_EXT_LINE_VTX,
    LAYOUT_EXT_LINE_VTX_COLOR
 };

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -937,7 +937,14 @@ void KeyAPressed()
    cout << "Multisampling/Antialiasing: "
         << strings_off_on[!curr_aa ? 1 : 0] << endl;
 
-   // vsdata -> EventUpdateColors();
+   // Force scene update to re-upload buffers with correct line format
+   // (shader-expanded when MSAA on, regular GL_LINES when MSAA off)
+   if (window->vs)
+   {
+      window->vs->PrepareLines();
+      window->vs->Prepare();
+   }
+
    SendExposeEvent();
 }
 

--- a/makefile
+++ b/makefile
@@ -131,7 +131,7 @@ NOTMAC := $(subst Darwin,,$(shell uname -s))
 
 # Default multisampling mode and multisampling line-width
 GLVIS_MULTISAMPLE  ?= 4
-GLVIS_MS_LINEWIDTH ?= $(if $(NOTMAC),1.4,1.0)
+GLVIS_MS_LINEWIDTH ?= $(if $(NOTMAC),1.4,1.5)
 GLVIS_FONT_SIZE ?= 12
 DEFINES = -DGLVIS_MULTISAMPLE=$(GLVIS_MULTISAMPLE)\
  -DGLVIS_MS_LINEWIDTH=$(GLVIS_MS_LINEWIDTH)\


### PR DESCRIPTION
:warning: This PR is a demonstration of what is possible with :robot: coding agents. We have not decided how to handle such PRs yet.

Claude-assisted implementation of https://github.com/GLVis/glvis/pull/232

With antialiasing the line width can be increased/decreased with keys <kbd>;</kbd> / <kbd>'</kbd>

<img width="512" height="494" alt="Screenshot 2026-02-13 at 3 12 00 PM" src="https://github.com/user-attachments/assets/85af77d9-41a1-493a-8d00-9fbb75ffb4d1" />
