### PR TITLE
Removed static variables

### DIFF
--- a/lib/openglvis.hpp
+++ b/lib/openglvis.hpp
@@ -180,7 +180,7 @@ public:
    PaletteState palette;
 
    /// Bounding box.
-   struct
+   struct Box
    {
       double x[2], y[2], z[2];
    } bb;

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -609,10 +609,10 @@ void VisualizationSceneScalarData::PrepareCaption()
    GetFont()->getObjectSize(caption, caption_w, caption_h);
 }
 
-static thread_local VisualizationSceneScalarData *vsdata;
+thread_local VisualizationSceneScalarData *VisualizationSceneScalarData::vsdata;
 static thread_local Window *window;
 
-void KeycPressed(GLenum state)
+void VisualizationSceneScalarData::KeycPressed(GLenum state)
 {
    if (state & KMOD_ALT)
    {
@@ -638,7 +638,7 @@ void KeycPressed(GLenum state)
    }
 }
 
-void KeyCPressed()
+void VisualizationSceneScalarData::KeyCPressed()
 {
    cout << "Enter new caption: " << flush;
    std::getline(cin, window->plot_caption);
@@ -646,19 +646,19 @@ void KeyCPressed()
    SendExposeEvent();
 }
 
-void KeySPressed()
+void VisualizationSceneScalarData::KeySPressed()
 {
    vsdata -> ToggleScaling();
    SendExposeEvent();
 }
 
-void KeyaPressed()
+void VisualizationSceneScalarData::KeyaPressed()
 {
    vsdata -> ToggleDrawAxes();
    SendExposeEvent();
 }
 
-void Key_Mod_a_Pressed(GLenum state)
+void VisualizationSceneScalarData::Key_Mod_a_Pressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -695,47 +695,47 @@ void Key_Mod_a_Pressed(GLenum state)
    }
 }
 
-void KeyHPressed()
+void VisualizationSceneScalarData::KeyHPressed()
 {
    cout << vsdata->GetHelpString() << flush;
 }
 
-void KeylPressed()
+void VisualizationSceneScalarData::KeylPressed()
 {
    vsdata -> ToggleLight();
    SendExposeEvent();
 }
 
-void KeyLPressed()
+void VisualizationSceneScalarData::KeyLPressed()
 {
    vsdata->ToggleLogscale(true);
    SendExposeEvent();
 }
 
-void KeyrPressed()
+void VisualizationSceneScalarData::KeyrPressed()
 {
-   window->vs -> spinning = 0;
+   vsdata -> spinning = 0;
    RemoveIdleFunc(MainLoop);
    vsdata -> CenterObject();
 
-   window->vs -> ViewAngle = 45.0;
-   window->vs -> ViewScale = 1.0;
-   window->vs -> ViewCenterX = 0.0;
-   window->vs -> ViewCenterY = 0.0;
-   window->vs->cam.Reset();
+   vsdata -> ViewAngle = 45.0;
+   vsdata -> ViewScale = 1.0;
+   vsdata -> ViewCenterX = 0.0;
+   vsdata -> ViewCenterY = 0.0;
+   vsdata->cam.Reset();
    vsdata -> key_r_state = 0;
    SendExposeEvent();
 }
 
-void KeyRPressed()
+void VisualizationSceneScalarData::KeyRPressed()
 {
-   window->vs->spinning = 0;
+   vsdata->spinning = 0;
    RemoveIdleFunc(MainLoop);
    vsdata->Toggle2DView();
    SendExposeEvent();
 }
 
-void KeypPressed(GLenum state)
+void VisualizationSceneScalarData::KeypPressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -743,18 +743,18 @@ void KeypPressed(GLenum state)
    }
    else
    {
-      window->vs->palette.NextIndex();
+      vsdata->palette.NextIndex();
       SendExposeEvent();
    }
 }
 
-void KeyPPressed()
+void VisualizationSceneScalarData::KeyPPressed()
 {
-   window->vs->palette.PrevIndex();
+   vsdata->palette.PrevIndex();
    SendExposeEvent();
 }
 
-static void KeyF5Pressed()
+void VisualizationSceneScalarData::KeyF5Pressed()
 {
    int n;
    double min, max;
@@ -772,7 +772,7 @@ static void KeyF5Pressed()
    SendExposeEvent();
 }
 
-void KeyF6Pressed()
+void VisualizationSceneScalarData::KeyF6Pressed()
 {
    int RepeatPaletteTimes = vsdata->palette.GetRepeatTimes();
    cout << "Palette is repeated " << RepeatPaletteTimes << " times.\n"
@@ -808,7 +808,7 @@ void KeyF6Pressed()
    SendExposeEvent();
 }
 
-void KeyF7Pressed(GLenum state)
+void VisualizationSceneScalarData::KeyF7Pressed(GLenum state)
 {
    if (state & KMOD_SHIFT)
    {
@@ -851,7 +851,7 @@ void KeyF7Pressed(GLenum state)
    }
 }
 
-void KeyBackslashPressed()
+void VisualizationSceneScalarData::KeyBackslashPressed()
 {
    float x, y, z, w;
 
@@ -871,7 +871,7 @@ void KeyBackslashPressed()
    SendExposeEvent();
 }
 
-void KeyTPressed()
+void VisualizationSceneScalarData::KeyTPressed()
 {
    int ml;
 
@@ -881,7 +881,7 @@ void KeyTPressed()
    cout << "New material/light : " << ml << endl;
 }
 
-void KeygPressed()
+void VisualizationSceneScalarData::KeygPressed()
 {
    vsdata->ToggleBackground();
    vsdata->PrepareAxes();
@@ -889,17 +889,17 @@ void KeygPressed()
    SendExposeEvent();
 }
 
-void KeyGPressed()
+void VisualizationSceneScalarData::KeyGPressed()
 {
    vsdata->glTF_Export();
 }
 
-void KeyF1Pressed()
+void VisualizationSceneScalarData::KeyF1Pressed()
 {
    vsdata->PrintState();
 }
 
-void KeyF2Pressed()
+void VisualizationSceneScalarData::KeyF2Pressed()
 {
    vsdata -> EventUpdateColors();
    vsdata -> PrepareLines();
@@ -907,29 +907,29 @@ void KeyF2Pressed()
    SendExposeEvent();
 }
 
-void KeykPressed()
+void VisualizationSceneScalarData::KeykPressed()
 {
-   window->vs->matAlpha -= 0.05;
-   if (window->vs->matAlpha < 0.0)
+   vsdata->matAlpha -= 0.05;
+   if (vsdata->matAlpha < 0.0)
    {
-      window->vs->matAlpha = 0.0;
+      vsdata->matAlpha = 0.0;
    }
-   window->vs->GenerateAlphaTexture();
+   vsdata->GenerateAlphaTexture();
    SendExposeEvent();
 }
 
-void KeyKPressed()
+void VisualizationSceneScalarData::KeyKPressed()
 {
-   window->vs->matAlpha += 0.05;
-   if (window->vs->matAlpha > 1.0)
+   vsdata->matAlpha += 0.05;
+   if (vsdata->matAlpha > 1.0)
    {
-      window->vs->matAlpha = 1.0;
+      vsdata->matAlpha = 1.0;
    }
-   window->vs->GenerateAlphaTexture();
+   vsdata->GenerateAlphaTexture();
    SendExposeEvent();
 }
 
-void KeyAPressed()
+void VisualizationSceneScalarData::KeyAPressed()
 {
    bool curr_aa = window->wnd->getRenderer().getAntialiasing();
    window->wnd->getRenderer().setAntialiasing(!curr_aa);
@@ -941,41 +941,41 @@ void KeyAPressed()
    SendExposeEvent();
 }
 
-void KeyCommaPressed()
+void VisualizationSceneScalarData::KeyCommaPressed()
 {
-   window->vs->matAlphaCenter -= 0.25;
+   vsdata->matAlphaCenter -= 0.25;
    // vsdata -> EventUpdateColors();
-   window->vs->GenerateAlphaTexture();
+   vsdata->GenerateAlphaTexture();
    SendExposeEvent();
 #ifdef GLVIS_DEBUG
-   cout << "MatAlphaCenter = " << window->vs->matAlphaCenter << endl;
+   cout << "MatAlphaCenter = " << vsdata->matAlphaCenter << endl;
 #endif
 }
 
-void KeyLessPressed()
+void VisualizationSceneScalarData::KeyLessPressed()
 {
-   window->vs->matAlphaCenter += 0.25;
+   vsdata->matAlphaCenter += 0.25;
    // vsdata -> EventUpdateColors();
-   window->vs->GenerateAlphaTexture();
+   vsdata->GenerateAlphaTexture();
    SendExposeEvent();
 #ifdef GLVIS_DEBUG
-   cout << "MatAlphaCenter = " << window->vs->matAlphaCenter << endl;
+   cout << "MatAlphaCenter = " << vsdata->matAlphaCenter << endl;
 #endif
 }
 
-void KeyGravePressed()
+void VisualizationSceneScalarData::KeyGravePressed()
 {
    vsdata->ToggleRuler();
    SendExposeEvent();
 }
 
-void KeyTildePressed()
+void VisualizationSceneScalarData::KeyTildePressed()
 {
    vsdata->RulerPosition();
    SendExposeEvent();
 }
 
-void KeyToggleTexture()
+void VisualizationSceneScalarData::KeyToggleTexture()
 {
    vsdata->ToggleTexture();
    SendExposeEvent();
@@ -1159,7 +1159,7 @@ void VisualizationSceneScalarData::Toggle2DView()
          break;
    }
 
-   // if (window->vs -> view != 2) // make 'R' work the same in 2D and 3D
+   // if (vsdata -> view != 2) // make 'R' work the same in 2D and 3D
    key_r_state = (key_r_state+1)%6;
 
    rotmat = newrot.mtx;
@@ -1909,9 +1909,9 @@ Plane::Plane(double A,double B,double C,double D)
 
    CartesianToSpherical();
 
-   double x[2] = {vsdata -> bb.x[0], vsdata -> bb.x[1]};
-   double y[2] = {vsdata -> bb.y[0], vsdata -> bb.y[1]};
-   double z[2] = {vsdata -> bb.z[0], vsdata -> bb.z[1]};
+   double x[2] = {window->vs -> bb.x[0], window->vs -> bb.x[1]};
+   double y[2] = {window->vs -> bb.y[0], window->vs -> bb.y[1]};
+   double z[2] = {window->vs -> bb.z[0], window->vs -> bb.z[1]};
    bbox_diam = sqrt ( (x[1]-x[0])*(x[1]-x[0]) +
                       (y[1]-y[0])*(y[1]-y[0]) +
                       (z[1]-z[0])*(z[1]-z[0]) );

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1900,18 +1900,15 @@ void VisualizationSceneScalarData::ComputeElemAttrCenter()
 }
 
 
-Plane::Plane(double A,double B,double C,double D)
+Plane::Plane(const double (&eqn_)[4], const VisualizationScene::Box &bb)
 {
-   eqn[0] = A;
-   eqn[1] = B;
-   eqn[2] = C;
-   eqn[3] = D;
+   for (int i = 0; i < 4; i++) { eqn[i] = eqn_[i]; }
 
    CartesianToSpherical();
 
-   double x[2] = {window->vs -> bb.x[0], window->vs -> bb.x[1]};
-   double y[2] = {window->vs -> bb.y[0], window->vs -> bb.y[1]};
-   double z[2] = {window->vs -> bb.z[0], window->vs -> bb.z[1]};
+   double x[2] = {bb.x[0], bb.x[1]};
+   double y[2] = {bb.y[0], bb.y[1]};
+   double z[2] = {bb.z[0], bb.z[1]};
    bbox_diam = sqrt ( (x[1]-x[0])*(x[1]-x[0]) +
                       (y[1]-y[0])*(y[1]-y[0]) +
                       (z[1]-z[0])*(z[1]-z[0]) );

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -31,7 +31,7 @@ private:
    double phi_step, theta_step, rho_step;
 
 public:
-   Plane(double A,double B,double C,double D);
+   Plane(const double (&eqn_)[4], const VisualizationScene::Box &bb);
    inline double * Equation() { return eqn; }
    inline double Transform(double x, double y, double z)
    { return eqn[0]*x+eqn[1]*y+eqn[2]*z+eqn[3]; }

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -116,6 +116,13 @@ protected:
    int ruler_on;
    double ruler_x, ruler_y, ruler_z;
 
+   Plane *CuttingPlane;
+   /** Shrink factor with respect to the center of each element (2D) or the
+       center of each boundary attribute (3D) */
+   double shrink;
+   /// Shrink factor with respect to the element (material) attributes centers
+   double shrinkmat;
+
    Autoscale autoscale;
 
    bool logscale;
@@ -158,14 +165,41 @@ protected:
 
    void Cone(gl3::GlDrawable& buf, glm::mat4 transform, double cval);
 
-public:
-   Plane *CuttingPlane;
+   // key handlers
+   static thread_local VisualizationSceneScalarData *vsdata;
    int key_r_state;
-   /** Shrink factor with respect to the center of each element (2D) or the
-       center of each boundary attribute (3D) */
-   double shrink;
-   /// Shrink factor with respect to the element (material) attributes centers
-   double shrinkmat;
+
+   static void KeycPressed(GLenum state);
+   static void KeyCPressed();
+   static void KeySPressed();
+   static void KeyaPressed();
+   static void Key_Mod_a_Pressed(GLenum state);
+   static void KeyHPressed();
+   static void KeylPressed();
+   static void KeyLPressed();
+   static void KeyrPressed();
+   static void KeyRPressed();
+   static void KeypPressed(GLenum state);
+   static void KeyPPressed();
+   static void KeyF5Pressed();
+   static void KeyF6Pressed();
+   static void KeyF7Pressed(GLenum state);
+   static void KeyBackslashPressed();
+   static void KeyTPressed();
+   static void KeygPressed();
+   static void KeyGPressed();
+   static void KeyF1Pressed();
+   static void KeyF2Pressed();
+   static void KeykPressed();
+   static void KeyKPressed();
+   static void KeyAPressed();
+   static void KeyCommaPressed();
+   static void KeyLessPressed();
+   static void KeyGravePressed();
+   static void KeyTildePressed();
+   static void KeyToggleTexture();
+
+public:
 
    VisualizationSceneScalarData(Window &win, bool init = true);
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -18,7 +18,7 @@
 using namespace std;
 using namespace mfem;
 
-thread_local VisualizationSceneSolution *vssol;
+thread_local VisualizationSceneSolution *VisualizationSceneSolution::vssol;
 extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 #ifdef GLVIS_ISFINITE
@@ -131,7 +131,7 @@ std::string VisualizationSceneSolution::GetHelpString() const
    return os.str();
 }
 
-static void KeyF8Pressed()
+void VisualizationSceneSolution::KeyF8Pressed()
 {
    int attr;
    Array<int> attr_list(&attr, 1);
@@ -151,9 +151,9 @@ static void KeyF8Pressed()
    SendExposeEvent();
 }
 
-static void SwitchAttribute(int increment, int &attribute,
-                            Array<int> &attribute_marker,
-                            bool bdr)
+void VisualizationSceneSolution::SwitchAttribute(int increment, int &attribute,
+                                                 Array<int> &attribute_marker,
+                                                 bool bdr)
 {
    const char *attr_type = bdr ? "bdr" : "element";
    if (attribute_marker.Size() == 0)
@@ -192,40 +192,40 @@ static void SwitchAttribute(int increment, int &attribute,
    }
    if (bdr)
    {
-      vssol->PrepareBoundary();
+      PrepareBoundary();
    }
    else
    {
-      vssol->PrepareNumbering();
-      vssol->PrepareLines();
-      vssol->Prepare();
+      PrepareNumbering();
+      PrepareLines();
+      Prepare();
    }
    SendExposeEvent();
 }
 
-static void KeyF9Pressed(GLenum state)
+void VisualizationSceneSolution::KeyF9Pressed(GLenum state)
 {
    if (!(state & KMOD_SHIFT))
    {
-      SwitchAttribute(+1, vssol->attr_to_show, vssol->el_attr_to_show, false);
+      vssol->SwitchAttribute(+1, vssol->attr_to_show, vssol->el_attr_to_show, false);
    }
    else
    {
-      SwitchAttribute(+1, vssol->bdr_attr_to_show, vssol->bdr_el_attr_to_show,
-                      true);
+      vssol->SwitchAttribute(+1, vssol->bdr_attr_to_show, vssol->bdr_el_attr_to_show,
+                             true);
    }
 }
 
-static void KeyF10Pressed(GLenum state)
+void VisualizationSceneSolution::KeyF10Pressed(GLenum state)
 {
    if (!(state & KMOD_SHIFT))
    {
-      SwitchAttribute(-1, vssol->attr_to_show, vssol->el_attr_to_show, false);
+      vssol->SwitchAttribute(-1, vssol->attr_to_show, vssol->el_attr_to_show, false);
    }
    else
    {
-      SwitchAttribute(-1, vssol->bdr_attr_to_show, vssol->bdr_el_attr_to_show,
-                      true);
+      vssol->SwitchAttribute(-1, vssol->bdr_attr_to_show, vssol->bdr_el_attr_to_show,
+                             true);
    }
 }
 
@@ -273,19 +273,19 @@ void VisualizationSceneSolution::ToggleDrawBdr()
    }
 }
 
-static void KeyBPressed()
+void VisualizationSceneSolution::KeyBPressed()
 {
    vssol -> ToggleDrawBdr();
    SendExposeEvent();
 }
 
-static void KeyMPressed()
+void VisualizationSceneSolution::KeyMPressed()
 {
    vssol -> ToggleDrawMesh();
    SendExposeEvent();
 }
 
-static void KeyNPressed(GLenum state)
+void VisualizationSceneSolution::KeyNPressed(GLenum state)
 {
    if (state & KMOD_ALT)
    {
@@ -302,7 +302,7 @@ static void KeyNPressed(GLenum state)
    SendExposeEvent();
 }
 
-static void KeyoPressed(GLenum state)
+void VisualizationSceneSolution::KeyoPressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -316,64 +316,64 @@ static void KeyoPressed(GLenum state)
    }
 }
 
-static void KeyOPressed(GLenum state)
+void VisualizationSceneSolution::KeyOPressed(GLenum state)
 {
    (void)state;
    vssol->ToggleRefinementFunction();
 }
 
-static void KeyEPressed()
+void VisualizationSceneSolution::KeyEPressed()
 {
    vssol -> ToggleDrawElems();
    SendExposeEvent();
 }
 
-static void KeyFPressed()
+void VisualizationSceneSolution::KeyFPressed()
 {
    vssol -> ToggleShading();
    SendExposeEvent();
 }
 
-void KeyiPressed()
+void VisualizationSceneSolution::KeyiPressed()
 {
    vssol->ToggleDrawCP();
    SendExposeEvent();
 }
 
-void KeyIPressed()
+void VisualizationSceneSolution::KeyIPressed()
 {
    // no-op, available
 }
 
-static void KeyyPressed()
+void VisualizationSceneSolution::KeyyPressed()
 {
    vssol->CuttingPlane->IncreaseTheta();
    vssol->PrepareCP();
    SendExposeEvent();
 }
 
-static void KeyYPressed()
+void VisualizationSceneSolution::KeyYPressed()
 {
    vssol->CuttingPlane->DecreaseTheta();
    vssol->PrepareCP();
    SendExposeEvent();
 }
 
-static void KeyzPressed()
+void VisualizationSceneSolution::KeyzPressed()
 {
    vssol->CuttingPlane->IncreaseDistance();
    vssol->PrepareCP();
    SendExposeEvent();
 }
 
-static void KeyZPressed()
+void VisualizationSceneSolution::KeyZPressed()
 {
    vssol->CuttingPlane->DecreaseDistance();
    vssol->PrepareCP();
    SendExposeEvent();
 }
 
-static void KeyF3Pressed()
+void VisualizationSceneSolution::KeyF3Pressed()
 {
    if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
@@ -387,7 +387,7 @@ static void KeyF3Pressed()
    }
 }
 
-static void KeyF4Pressed()
+void VisualizationSceneSolution::KeyF4Pressed()
 {
    if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
@@ -400,7 +400,7 @@ static void KeyF4Pressed()
    }
 }
 
-static void KeyF11Pressed()
+void VisualizationSceneSolution::KeyF11Pressed()
 {
    if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {
@@ -418,7 +418,7 @@ static void KeyF11Pressed()
    }
 }
 
-static void KeyF12Pressed()
+void VisualizationSceneSolution::KeyF12Pressed()
 {
    if (vssol->GetShading() == VisualizationSceneScalarData::Shading::Noncomforming)
    {

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -491,7 +491,7 @@ void VisualizationSceneSolution::Init()
    palette.SetFallbackIndex(2); // use the 'jet-like' palette in 2D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
-   CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*bb.x[0]+(0.5+eps)*bb.x[1]);
+   CuttingPlane = new Plane({-1.0,0.0,0.0,(0.5-eps)*bb.x[0]+(0.5+eps)*bb.x[1]},bb);
    draw_cp = 0;
 
    // static int init = 0;

--- a/lib/vssolution.hpp
+++ b/lib/vssolution.hpp
@@ -85,9 +85,37 @@ protected:
    // Used for drawing markers for element and vertex numbering
    double GetElementLengthScale(int k);
 
-public:
+   // key handlers
+   static thread_local VisualizationSceneSolution *vssol;
    int attr_to_show, bdr_attr_to_show;
    mfem::Array<int> el_attr_to_show, bdr_el_attr_to_show;
+
+   static void KeyF8Pressed();
+   static void KeyF9Pressed(GLenum state);
+   static void KeyF10Pressed(GLenum state);
+   static void KeyBPressed();
+   static void KeyMPressed();
+   static void KeyNPressed(GLenum state);
+   static void KeyoPressed(GLenum state);
+   static void KeyOPressed(GLenum state);
+   static void KeyEPressed();
+   static void KeyFPressed();
+   static void KeyiPressed();
+   static void KeyIPressed();
+   static void KeyyPressed();
+   static void KeyYPressed();
+   static void KeyzPressed();
+   static void KeyZPressed();
+   static void KeyF3Pressed();
+   static void KeyF4Pressed();
+   static void KeyF11Pressed();
+   static void KeyF12Pressed();
+
+   void SwitchAttribute(int increment, int &attribute,
+                        mfem::Array<int> &attribute_marker,
+                        bool bdr);
+
+public:
 
    VisualizationSceneSolution(Window &win, bool init = true);
 

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -22,7 +22,8 @@
 using namespace std;
 using namespace mfem;
 
-static thread_local VisualizationSceneSolution3d *vssol3d;
+thread_local VisualizationSceneSolution3d
+*VisualizationSceneSolution3d::vssol3d;
 extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 // Reference geometries with a cut in the middle, based on subdivision of
@@ -132,13 +133,13 @@ std::string VisualizationSceneSolution3d::GetHelpString() const
    return os.str();
 }
 
-static void KeyiPressed()
+void VisualizationSceneSolution3d::KeyiPressed()
 {
    vssol3d -> ToggleCuttingPlane();
    SendExposeEvent();
 }
 
-static void KeyIPressed()
+void VisualizationSceneSolution3d::KeyIPressed()
 {
    vssol3d -> ToggleCPAlgorithm();
    SendExposeEvent();
@@ -273,7 +274,7 @@ void VisualizationSceneSolution3d::CPMoved()
    }
 }
 
-static void KeyxPressed()
+void VisualizationSceneSolution3d::KeyxPressed()
 {
    vssol3d -> CuttingPlane -> IncreasePhi();
    vssol3d -> FindNodePos();
@@ -281,7 +282,7 @@ static void KeyxPressed()
    SendExposeEvent();
 }
 
-static void KeyXPressed()
+void VisualizationSceneSolution3d::KeyXPressed()
 {
    vssol3d -> CuttingPlane -> DecreasePhi();
    vssol3d -> FindNodePos();
@@ -289,7 +290,7 @@ static void KeyXPressed()
    SendExposeEvent();
 }
 
-static void KeyyPressed()
+void VisualizationSceneSolution3d::KeyyPressed()
 {
    vssol3d -> CuttingPlane -> IncreaseTheta();
    vssol3d -> FindNodePos();
@@ -297,7 +298,7 @@ static void KeyyPressed()
    SendExposeEvent();
 }
 
-static void KeyYPressed()
+void VisualizationSceneSolution3d::KeyYPressed()
 {
    vssol3d -> CuttingPlane -> DecreaseTheta();
    vssol3d -> FindNodePos();
@@ -305,7 +306,7 @@ static void KeyYPressed()
    SendExposeEvent();
 }
 
-static void KeyzPressed()
+void VisualizationSceneSolution3d::KeyzPressed()
 {
    vssol3d -> CuttingPlane -> IncreaseDistance();
    vssol3d -> FindNodePos();
@@ -313,7 +314,7 @@ static void KeyzPressed()
    SendExposeEvent();
 }
 
-static void KeyZPressed()
+void VisualizationSceneSolution3d::KeyZPressed()
 {
    vssol3d -> CuttingPlane -> DecreaseDistance();
    vssol3d -> FindNodePos();
@@ -321,37 +322,37 @@ static void KeyZPressed()
    SendExposeEvent();
 }
 
-static void KeymPressed()
+void VisualizationSceneSolution3d::KeymPressed()
 {
    vssol3d -> ToggleDrawMesh();
    SendExposeEvent();
 }
 
-static void KeyePressed()
+void VisualizationSceneSolution3d::KeyePressed()
 {
    vssol3d -> ToggleDrawElems();
    SendExposeEvent();
 }
 
-static void KeyMPressed()
+void VisualizationSceneSolution3d::KeyMPressed()
 {
    vssol3d -> ToggleCPDrawMesh();
    SendExposeEvent();
 }
 
-static void KeyEPressed()
+void VisualizationSceneSolution3d::KeyEPressed()
 {
    vssol3d -> ToggleCPDrawElems();
    SendExposeEvent();
 }
 
-static void KeyFPressed()
+void VisualizationSceneSolution3d::KeyFPressed()
 {
    vssol3d -> ToggleShading();
    SendExposeEvent();
 }
 
-static void KeyoPressed(GLenum state)
+void VisualizationSceneSolution3d::KeyoPressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -378,7 +379,7 @@ static void KeyoPressed(GLenum state)
    }
 }
 
-static void KeyOPressed()
+void VisualizationSceneSolution3d::KeyOPressed()
 {
    if (vssol3d -> TimesToRefine > 1)
    {
@@ -396,7 +397,7 @@ static void KeyOPressed()
    }
 }
 
-static void KeywPressed()
+void VisualizationSceneSolution3d::KeywPressed()
 {
    if (vssol3d -> GetShading() ==
        VisualizationSceneScalarData::Shading::Noncomforming)
@@ -414,7 +415,7 @@ static void KeywPressed()
    }
 }
 
-static void KeyWPressed()
+void VisualizationSceneSolution3d::KeyWPressed()
 {
    if (vssol3d -> GetShading() ==
        VisualizationSceneScalarData::Shading::Noncomforming)
@@ -432,37 +433,36 @@ static void KeyWPressed()
    }
 }
 
-static void KeyuPressed()
+void VisualizationSceneSolution3d::KeyuPressed()
 {
    vssol3d -> MoveLevelSurf(+1);
    SendExposeEvent();
 }
 
-static void KeyUPressed()
+void VisualizationSceneSolution3d::KeyUPressed()
 {
    vssol3d -> MoveLevelSurf(-1);
    SendExposeEvent();
 }
 
-static void KeyvPressed()
+void VisualizationSceneSolution3d::KeyvPressed()
 {
    vssol3d -> NumberOfLevelSurf(+1);
    SendExposeEvent();
 }
 
-static void KeyVPressed()
+void VisualizationSceneSolution3d::KeyVPressed()
 {
    vssol3d -> NumberOfLevelSurf(-1);
    SendExposeEvent();
 }
 
-static int magic_key_pressed = 0;
-void ToggleMagicKey()
+void VisualizationSceneSolution3d::ToggleMagicKey()
 {
-   magic_key_pressed = 1-magic_key_pressed;
+   vssol3d->magic_key_pressed = 1 - vssol3d->magic_key_pressed;
 }
 
-static void KeyF3Pressed(GLenum state)
+void VisualizationSceneSolution3d::KeyF3Pressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -492,7 +492,7 @@ static void KeyF3Pressed(GLenum state)
             vssol3d->ComputeElemAttrCenter();
          }
          vssol3d->shrink *= 0.9;
-         if (magic_key_pressed)
+         if (vssol3d->magic_key_pressed)
          {
             vssol3d -> Scale(1.11111111111111111111111);
          }
@@ -504,7 +504,7 @@ static void KeyF3Pressed(GLenum state)
    }
 }
 
-static void KeyF4Pressed(GLenum state)
+void VisualizationSceneSolution3d::KeyF4Pressed(GLenum state)
 {
    if (state & KMOD_CTRL)
    {
@@ -534,7 +534,7 @@ static void KeyF4Pressed(GLenum state)
             vssol3d->ComputeElemAttrCenter();
          }
          vssol3d->shrink *= 1.11111111111111111111111;
-         if (magic_key_pressed)
+         if (vssol3d->magic_key_pressed)
          {
             vssol3d -> Scale(0.9);
          }
@@ -545,7 +545,7 @@ static void KeyF4Pressed(GLenum state)
    }
 }
 
-static void KeyF11Pressed()
+void VisualizationSceneSolution3d::KeyF11Pressed()
 {
    if (vssol3d->GetShading() ==
        VisualizationSceneScalarData::Shading::Noncomforming)
@@ -555,7 +555,7 @@ static void KeyF11Pressed()
          vssol3d->ComputeElemAttrCenter();
       }
       vssol3d->shrinkmat *= 0.9;
-      if (magic_key_pressed)
+      if (vssol3d->magic_key_pressed)
       {
          vssol3d -> Scale(1.11111111111111111111111);
       }
@@ -565,7 +565,7 @@ static void KeyF11Pressed()
    }
 }
 
-static void KeyF12Pressed()
+void VisualizationSceneSolution3d::KeyF12Pressed()
 {
    if (vssol3d->GetShading() ==
        VisualizationSceneScalarData::Shading::Noncomforming)
@@ -575,7 +575,7 @@ static void KeyF12Pressed()
          vssol3d->ComputeElemAttrCenter();
       }
       vssol3d->shrinkmat *= 1.11111111111111111111111;
-      if (magic_key_pressed)
+      if (vssol3d->magic_key_pressed)
       {
          vssol3d -> Scale(0.9);
       }
@@ -585,7 +585,7 @@ static void KeyF12Pressed()
    }
 }
 
-static void KeyF8Pressed()
+void VisualizationSceneSolution3d::KeyF8Pressed()
 {
    Mesh &mesh = *vssol3d->GetMesh();
    int dim = mesh.Dimension();
@@ -609,7 +609,7 @@ static void KeyF8Pressed()
    SendExposeEvent();
 }
 
-static void KeyF9Pressed()
+void VisualizationSceneSolution3d::KeyF9Pressed()
 {
    Mesh &mesh = *vssol3d->GetMesh();
    int dim = mesh.Dimension();
@@ -654,7 +654,7 @@ static void KeyF9Pressed()
    SendExposeEvent();
 }
 
-static void KeyF10Pressed()
+void VisualizationSceneSolution3d::KeyF10Pressed()
 {
    Mesh &mesh = *vssol3d->GetMesh();
    int dim = mesh.Dimension();
@@ -743,6 +743,7 @@ void VisualizationSceneSolution3d::Init()
 
    TimesToRefine = 1;
    FaceShiftScale = 0.0;
+   magic_key_pressed = 0;
 
    if (mesh->Dimension() == 3)
    {

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -774,7 +774,7 @@ void VisualizationSceneSolution3d::Init()
    palette.SetFallbackIndex(12); // use the 'vivid' palette in 3D
 
    double eps = 1e-6; // move the cutting plane a bit to avoid artifacts
-   CuttingPlane = new Plane(-1.0,0.0,0.0,(0.5-eps)*bb.x[0]+(0.5+eps)*bb.x[1]);
+   CuttingPlane = new Plane({-1.0,0.0,0.0,(0.5-eps)*bb.x[0]+(0.5+eps)*bb.x[1]},bb);
 
    nlevels = 1;
 

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -116,11 +116,44 @@ protected:
       return (n < vertices.Size());
    }
 
-public:
+   // key handlers
+   static thread_local VisualizationSceneSolution3d *vssol3d;
    int TimesToRefine;
    double FaceShiftScale;
-
+   int magic_key_pressed;
    mfem::Array<int> bdr_attr_to_show;
+
+   static void KeyiPressed();
+   static void KeyIPressed();
+   static void KeyxPressed();
+   static void KeyXPressed();
+   static void KeyyPressed();
+   static void KeyYPressed();
+   static void KeyzPressed();
+   static void KeyZPressed();
+   static void KeymPressed();
+   static void KeyePressed();
+   static void KeyMPressed();
+   static void KeyEPressed();
+   static void KeyFPressed();
+   static void KeyoPressed(GLenum state);
+   static void KeyOPressed();
+   static void KeywPressed();
+   static void KeyWPressed();
+   static void KeyuPressed();
+   static void KeyUPressed();
+   static void KeyvPressed();
+   static void KeyVPressed();
+   static void ToggleMagicKey();
+   static void KeyF3Pressed(GLenum state);
+   static void KeyF4Pressed(GLenum state);
+   static void KeyF11Pressed();
+   static void KeyF12Pressed();
+   static void KeyF8Pressed();
+   static void KeyF9Pressed();
+   static void KeyF10Pressed();
+
+public:
 
    VisualizationSceneSolution3d(Window &win, bool init = true);
 

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -115,32 +115,32 @@ std::string VisualizationSceneVector::GetHelpString() const
    return os.str();
 }
 
-static thread_local VisualizationSceneVector  * vsvector;
+thread_local VisualizationSceneVector  *VisualizationSceneVector::vsvector;
 extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
-thread_local int ianim = 0;
-thread_local int ianimmax = 10;
-
-void KeyDPressed()
+void VisualizationSceneVector::KeyDPressed()
 {
-   vsvector -> ToggleDisplacements();
+   vsvector->ToggleDisplacements();
    SendExposeEvent();
 }
 
-void KeyNPressed()
+void VisualizationSceneVector::KeyNPressed()
 {
-   ianim = (ianim + 1) % (ianimmax + 1);
-   vsvector -> NPressed();
+   vsvector->ChangeDisplacement(+1);
+   SendExposeEvent();
 }
 
-void KeyBPressed()
+void VisualizationSceneVector::KeyBPressed()
 {
-   ianim = (ianim + ianimmax) % (ianimmax + 1);
-   vsvector -> NPressed();
+   vsvector->ChangeDisplacement(-1);
+   SendExposeEvent();
 }
 
-void VisualizationSceneVector::NPressed()
+void VisualizationSceneVector::ChangeDisplacement(int idiff)
 {
+   while (idiff < 0) { idiff += ianimmax + 1; }
+   ianim = (ianim + idiff) % (ianimmax + 1);
+
    if (drawdisp == 0)
    {
       drawdisp = 1;
@@ -148,32 +148,28 @@ void VisualizationSceneVector::NPressed()
    }
 
    PrepareDisplacedMesh();
-
-   SendExposeEvent();
 }
 
-void KeyvPressed()
+void VisualizationSceneVector::KeyvPressed()
 {
-   vsvector -> ToggleVectorField();
+   vsvector->ToggleVectorField();
    SendExposeEvent();
 }
 
-void KeyVPressed()
+void VisualizationSceneVector::KeyVPressed()
 {
    cout << "New arrow scale: " << flush;
-   cin >> vsvector -> ArrowScale;
-   cout << "New arrow scale = " << vsvector -> ArrowScale << endl;
-   vsvector -> PrepareVectorField();
+   cin >> vsvector->ArrowScale;
+   cout << "New arrow scale = " << vsvector->ArrowScale << endl;
+   vsvector->PrepareVectorField();
    SendExposeEvent();
 }
 
-int key_u_func = 0;
-
-void KeyuPressed()
+void VisualizationSceneVector::KeyuPressed()
 {
    int update = 1;
 
-   switch (key_u_func)
+   switch (vsvector->key_u_func)
    {
       case 0:
          vsvector->RefineFactor++;
@@ -196,7 +192,7 @@ void KeyuPressed()
          break;
    }
 
-   switch (key_u_func)
+   switch (vsvector->key_u_func)
    {
       case 0:
       case 1:
@@ -215,11 +211,11 @@ void KeyuPressed()
    }
 }
 
-void KeyUPressed()
+void VisualizationSceneVector::KeyUPressed()
 {
-   key_u_func = (key_u_func+1)%3;
+   vsvector->key_u_func = (vsvector->key_u_func + 1) % 3;
    cout << "Key 'u' will: ";
-   switch (key_u_func)
+   switch (vsvector->key_u_func)
    {
       case 0:
          cout << "Increase vector subdivision factor" << endl;
@@ -515,6 +511,10 @@ void VisualizationSceneVector::Init()
    RefineFactor = 1;
    Vec2Scalar = VecLength;
    win.extra_caption = Vec2ScalarNames[0];
+
+   ianim = 0;
+   ianimmax = 10;
+   key_u_func = 0;
 
    for (int i = 0; i < mesh->GetNV(); i++)
    {

--- a/lib/vsvector.hpp
+++ b/lib/vsvector.hpp
@@ -45,11 +45,24 @@ protected:
    void DrawVector(double, double, double, double, double);
 
    double maxlen;
+   double ArrowScale;
 
    mfem::Vector vc0;
    mfem::IsoparametricTransformation T0;
 
    int GetFunctionAutoRefineFactor() override;
+
+   // key handlers
+   static thread_local VisualizationSceneVector  *vsvector;
+   int ianim, ianimmax, key_u_func;
+
+   static void KeyDPressed();
+   static void KeyNPressed();
+   static void KeyBPressed();
+   static void KeyvPressed();
+   static void KeyVPressed();
+   static void KeyuPressed();
+   static void KeyUPressed();
 
 public:
    VisualizationSceneVector(Window &win_);
@@ -63,7 +76,6 @@ public:
 
    std::string GetHelpString() const override;
 
-   void NPressed();
    void PrepareDisplacedMesh();
    void PrepareLines() override
    { VisualizationSceneSolution::PrepareLines(); PrepareDisplacedMesh(); }
@@ -81,6 +93,7 @@ public:
          PrepareDisplacedMesh();
       }
    }
+   void ChangeDisplacement(int idiff);
 
    gl3::SceneInfo GetSceneObjs() override;
 
@@ -90,8 +103,6 @@ public:
 
    // refinement factor for the vectors
    int RefineFactor;
-
-   double ArrowScale;
 
    void CycleVec2Scalar(int print = 0);
 };

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -395,12 +395,13 @@ VisualizationSceneVector3d::VisualizationSceneVector3d(Window &win_)
 
 void VisualizationSceneVector3d::Init()
 {
-   key_r_state = 0;
-
    drawdisp = 0;
    drawvector = 0;
    scal_func = ScalarFunction::Magnitude;
 
+   arrows_nl = -1;
+
+   key_r_state = 0;
    ianim = ianimd = 0;
    ianimmax = 10;
 
@@ -1352,20 +1353,16 @@ void VisualizationSceneVector3d::PrepareDisplacedMesh()
    updated_bufs.emplace_back(&displine_buf);
 }
 
-void ArrowsDrawOrNot (Array<int> l[], int nv, Vector & sol,
-                      int nl, Array<double> & level)
+void VisualizationSceneVector3d::ArrowsDrawOrNot(
+   Array<int> l[], int nv, Vector & sol, int nl, Array<double> & level)
 {
-   static int first_time = 1;
-   static int nll = nl;
-
-   if (!first_time && nll == nl)
+   if (arrows_nl == nl)
    {
       return;
    }
    else
    {
-      first_time = 1;
-      nll = nl;
+      arrows_nl = nl;
    }
 
    int i,j;
@@ -1395,7 +1392,8 @@ void ArrowsDrawOrNot (Array<int> l[], int nv, Vector & sol,
    }
 }
 
-int ArrowDrawOrNot (double v, int nl, Array<double> & level)
+int VisualizationSceneVector3d::ArrowDrawOrNot(
+   double v, int nl, Array<double> & level)
 {
    double eps = (level[nl] - level[0])/10;
    for (int i = 0; i <= nl; i++)
@@ -1417,11 +1415,8 @@ void VisualizationSceneVector3d::DrawVector(gl3::GlDrawable& buf,
                                             double v2, double sx, double sy,
                                             double sz, double s)
 {
-   static int nv = mesh -> GetNV();
-   static double bb_vol = (bb.x[1]-bb.x[0])*(bb.y[1]-bb.y[0])*(bb.z[1]-bb.z[0]);
-   static double volume = std::max(bb_vol, mesh_volume);
-   static double h      = pow(volume/nv, 0.333);
-   static double hh     = pow(volume, 0.333) / 10;
+   const double &h = vector_h;
+   const double &hh = vector_hh;
 
    switch (type)
    {
@@ -1468,6 +1463,11 @@ void VisualizationSceneVector3d::PrepareVectorField()
    double *vertex;
 
    vector_buf.clear();
+
+   const double bb_vol = (bb.x[1]-bb.x[0])*(bb.y[1]-bb.y[0])*(bb.z[1]-bb.z[0]);
+   const double volume = std::max(bb_vol, mesh_volume);
+   vector_h      = pow(volume/nv, 0.333);
+   vector_hh     = pow(volume, 0.333) / 10;
 
    switch (drawvector)
    {

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -127,17 +127,17 @@ std::string VisualizationSceneVector3d::GetHelpString() const
    return os.str();
 }
 
-static thread_local VisualizationSceneVector3d  *vsvector3d;
-static thread_local Window *window;
+thread_local VisualizationSceneVector3d
+*VisualizationSceneVector3d::vsvector3d;
 extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
-static void KeyDPressed()
+void VisualizationSceneVector3d::KeyDPressed()
 {
    vsvector3d -> ToggleDisplacements();
    SendExposeEvent();
 }
 
-static void KeyNPressed()
+void VisualizationSceneVector3d::KeyNPressed()
 {
    if (vsvector3d -> drawdisp)
       vsvector3d -> ianimd =( (vsvector3d ->ianimd + 1) %
@@ -148,7 +148,7 @@ static void KeyNPressed()
    vsvector3d -> NPressed();
 }
 
-static void KeyBPressed()
+void VisualizationSceneVector3d::KeyBPressed()
 {
    if (vsvector3d -> drawdisp)
       vsvector3d ->ianimd = ((vsvector3d ->ianimd +
@@ -161,15 +161,15 @@ static void KeyBPressed()
    vsvector3d -> NPressed();
 }
 
-static void KeyrPressed()
+void VisualizationSceneVector3d::KeyrPressed()
 {
-   window->vs -> spinning = 0;
+   vsvector3d -> spinning = 0;
    RemoveIdleFunc(MainLoop);
    vsvector3d -> CenterObject();
-   window->vs -> ViewAngle = 45.0;
-   window->vs -> ViewScale = 1.0;
-   window->vs -> ViewCenterX = 0.0;
-   window->vs -> ViewCenterY = 0.0;
+   vsvector3d -> ViewAngle = 45.0;
+   vsvector3d -> ViewScale = 1.0;
+   vsvector3d -> ViewCenterX = 0.0;
+   vsvector3d -> ViewCenterY = 0.0;
    vsvector3d -> ianim = vsvector3d -> ianimd = 0;
    vsvector3d -> Prepare();
    vsvector3d -> PrepareLines();
@@ -178,9 +178,9 @@ static void KeyrPressed()
    SendExposeEvent();
 }
 
-static void KeyRPressed()
+void VisualizationSceneVector3d::KeyRPressed()
 {
-   window->vs->spinning = 0;
+   vsvector3d -> spinning = 0;
    RemoveIdleFunc(MainLoop);
    vsvector3d -> ianim = vsvector3d -> ianimd = 0;
    vsvector3d -> Prepare();
@@ -205,13 +205,13 @@ void VisualizationSceneVector3d::NPressed()
    SendExposeEvent();
 }
 
-static void KeyuPressed()
+void VisualizationSceneVector3d::KeyuPressed()
 {
    vsvector3d -> ToggleVectorFieldLevel(+1);
    SendExposeEvent();
 }
 
-static void KeyUPressed()
+void VisualizationSceneVector3d::KeyUPressed()
 {
    vsvector3d -> ToggleVectorFieldLevel(-1);
    SendExposeEvent();
@@ -236,13 +236,13 @@ void VisualizationSceneVector3d::ToggleVectorFieldLevel(int v)
    vsvector3d -> PrepareVectorField();
 }
 
-static void KeywPressed()
+void VisualizationSceneVector3d::KeywPressed()
 {
    vsvector3d -> AddVectorFieldLevel();
    SendExposeEvent();
 }
 
-static void KeyWPressed()
+void VisualizationSceneVector3d::KeyWPressed()
 {
    vsvector3d -> RemoveVectorFieldLevel();
    SendExposeEvent();
@@ -264,19 +264,19 @@ void VisualizationSceneVector3d::RemoveVectorFieldLevel()
    vsvector3d -> PrepareVectorField();
 }
 
-static void KeyvPressed()
+void VisualizationSceneVector3d::KeyvPressed()
 {
    vsvector3d -> ToggleVectorField(1);
    SendExposeEvent();
 }
 
-static void KeyVPressed()
+void VisualizationSceneVector3d::KeyVPressed()
 {
    vsvector3d -> ToggleVectorField(-1);
    SendExposeEvent();
 }
 
-static void VectorKeyFPressed()
+void VisualizationSceneVector3d::VectorKeyFPressed()
 {
    vsvector3d->ToggleScalarFunction();
    SendExposeEvent();
@@ -395,8 +395,6 @@ VisualizationSceneVector3d::VisualizationSceneVector3d(Window &win_)
 
 void VisualizationSceneVector3d::Init()
 {
-   window = &win;
-
    key_r_state = 0;
 
    drawdisp = 0;

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -409,14 +409,7 @@ void VisualizationSceneVector3d::Init()
 
    VisualizationSceneSolution3d::Init();
 
-   mesh_volume = 0.0;
-   if (mesh)
-   {
-      for (int i=0; i<mesh->GetNE(); i++)
-      {
-         mesh_volume += mesh->GetElementVolume(i);
-      }
-   }
+   UpdatedMesh();
 
    PrepareVectorField();
    PrepareDisplacedMesh();
@@ -453,6 +446,18 @@ void VisualizationSceneVector3d::Init()
       wnd->setOnKeyDown('V', KeyVPressed); // VisualizationSceneSolution3d
 
       wnd->setOnKeyDown('F', VectorKeyFPressed);
+   }
+}
+
+void VisualizationSceneVector3d::UpdatedMesh()
+{
+   mesh_volume = 0.0;
+   if (mesh)
+   {
+      for (int i=0; i<mesh->GetNE(); i++)
+      {
+         mesh_volume += mesh->GetElementVolume(i);
+      }
    }
 }
 
@@ -530,6 +535,7 @@ void VisualizationSceneVector3d::NewMeshAndSolution(
       }
    }
 
+   UpdatedMesh();
 
    FindNodePos();
 

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -55,8 +55,26 @@ protected:
 
    int GetFunctionAutoRefineFactor() override;
 
-public:
+   // key handlers
+   static thread_local VisualizationSceneVector3d  *vsvector3d;
    int ianim, ianimd, ianimmax, drawdisp;
+
+   static void KeyDPressed();
+   static void KeyNPressed();
+   static void KeyBPressed();
+   static void KeyrPressed();
+   static void KeyRPressed();
+   static void KeyuPressed();
+   static void KeyUPressed();
+   static void KeywPressed();
+   static void KeyWPressed();
+   static void KeyvPressed();
+   static void KeyVPressed();
+   static void VectorKeyFPressed();
+
+   void NPressed();
+
+public:
 
    VisualizationSceneVector3d(Window &win);
 
@@ -68,7 +86,6 @@ public:
 
    std::string GetHelpString() const override;
 
-   void NPressed();
    void PrepareFlat() override;
    void Prepare() override;
    void PrepareLines() override;

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -48,6 +48,8 @@ protected:
 
    void Init();
 
+   void UpdatedMesh();
+
    void NewMeshAndSolution(mfem::Mesh *new_m, mfem::Mesh *new_mc,
                            mfem::Vector *new_sol_x, mfem::Vector *new_sol_y, mfem::Vector *new_sol_z,
                            mfem::GridFunction *new_u = nullptr);

--- a/lib/vsvector3d.hpp
+++ b/lib/vsvector3d.hpp
@@ -38,6 +38,8 @@ protected:
    static const char *scal_func_name[];
 
    double mesh_volume;
+   double vector_h, vector_hh;
+   int arrows_nl;
    gl3::GlDrawable vector_buf;
    gl3::GlDrawable displine_buf;
 
@@ -54,6 +56,10 @@ protected:
    mfem::Array<double> dvflevel;
 
    int GetFunctionAutoRefineFactor() override;
+
+   void ArrowsDrawOrNot(mfem::Array<int> l[], int nv, mfem::Vector & sol, int nl,
+                        mfem::Array<double> & level);
+   int ArrowDrawOrNot(double v, int nl, mfem::Array<double> & level);
 
    // key handlers
    static thread_local VisualizationSceneVector3d  *vsvector3d;


### PR DESCRIPTION
Refactored code to remove static variables from `VisualizationScene`s, which are fine in the native app when declared as `thread_local` (not always the case), but fail in glvis-js, where a new instance of visualization scene is started (in the same window and thread). Initialization does not happen again and the values are carried over.
Bonus: Changed key handlers and variables to private.