### PR TITLE
Ability to plot user-provided point line 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ Version 4.5.1 (development)
 - Added an optional point line overlay (useful e.g. for reference curves), which
   can be toggled with 'Ctrl+l'. Points can be loaded from a file with the '-pts'
   option, sent via socket with the 'pointline' command, or specified in a GLVis
-  scripts. The overlay appears as a red line connecting the given points. The
+  script. The overlay appears as a red line connecting the given points. The
   points line format is: number of points, followed by x y z coordinates.
 
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,15 @@
                              https://glvis.org
 
 
+Version 4.5.1 (development)
+===========================
+- Added an optional point line overlay (useful e.g. for reference curves), which
+  can be toggled with 'Ctrl+l'. Points can be loaded from a file with the '-pts'
+  option, sent via socket with the 'pointline' command, or specified in a GLVis
+  scripts. The overlay appears as a red line connecting the given points. The
+  points line format is: number of points, followed by x y z coordinates.
+
+
 Version 4.5 released on Feb 6, 2026
 ===================================
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Key commands
   GLVis will use `SDL` to take screenshots in `bmp` format, which it will then
   convert to `png` if ImageMagick's `convert` tool is available.
 - <kbd>G</kbd> – 3D scene export to [glTF format](https://www.khronos.org/gltf)
+- <kbd>Ctrl</kbd> + <kbd>l</kbd> – Toggle point line (see `-pts` option)
 - <kbd>Ctrl</kbd> + <kbd>p</kbd> – Print to a PDF file using `gl2ps`. Other
   vector formats (SVG, EPS) are also possible, but keep in mind that the
   printing takes a while and the generated files are big.

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -207,10 +207,6 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
    if (server.good())
    {
       cout << "Waiting for data on port " << portnum << " ..." << endl;
-      if (!point_coords.empty())
-      {
-         cout << point_coords.size() << " points loaded (Ctrl+l to toggle)" << endl;
-      }
    }
    else
    {

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -12,6 +12,7 @@
 // GLVis - an OpenGL visualization server based on the MFEM library
 
 #include <limits>
+#include <array>
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -157,7 +158,9 @@ public:
 };
 
 void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
-                 bool save_coloring, string plot_caption, bool headless = false)
+                 bool save_coloring, string plot_caption,
+                 std::vector<std::array<double,3>> point_coords,
+                 bool headless = false)
 {
    std::vector<Session> current_sessions;
    string data_type;
@@ -204,6 +207,10 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
    if (server.good())
    {
       cout << "Waiting for data on port " << portnum << " ..." << endl;
+      if (!point_coords.empty())
+      {
+         cout << point_coords.size() << " points loaded (Ctrl+l to toggle)" << endl;
+      }
    }
    else
    {
@@ -308,7 +315,7 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
       }
 
       Session new_session(fix_elem_orient, save_coloring, plot_caption, headless);
-
+      if (!point_coords.empty()) { new_session.GetState().point_coords = point_coords; }
       constexpr int tmp_filename_size = 50;
       char tmp_file[tmp_filename_size];
       if (save_stream)
@@ -383,6 +390,7 @@ int main (int argc, char *argv[])
    const char *palette_name  = string_none;
    const char *window_title  = string_default;
    const char *font_name     = string_default;
+   const char *points_file   = string_none;
    int         portnum       = 19916;
    bool        persistent    = true;
    int         multisample   = GetMultisample();
@@ -493,6 +501,8 @@ int main (int argc, char *argv[])
    args.AddOption(&enable_hidpi, "-hidpi", "--high-dpi",
                   "-nohidpi", "--no-high-dpi",
                   "Enable/disable support for HiDPI at runtime, if supported.");
+   args.AddOption(&points_file, "-pts", "--points-file",
+                  "Points file: number of points, followed by x y z coordinates.");
 
    cout << endl
         << "       _/_/_/  _/      _/      _/  _/"          << endl
@@ -612,6 +622,25 @@ int main (int argc, char *argv[])
 
    GLVisGeometryRefiner.SetType(geom_ref_type);
 
+   // Load points file if specified (Ctrl+l to toggle)
+   if (points_file != string_none)
+   {
+      ifstream ifs(points_file);
+      if (!ifs)
+      {
+         cout << "Cannot open points file: " << points_file << endl;
+      }
+      else
+      {
+         int num_points;
+         ifs >> num_points;
+         num_points = ReadPointLine(ifs, num_points,
+                                    win.data_state.point_coords, cerr);
+         cout << "Loaded " << num_points << " points from " << points_file
+              << endl;
+      }
+   }
+
    string data_type;
 
    // check for saved stream file
@@ -693,7 +722,9 @@ int main (int argc, char *argv[])
       std::thread serverThread{GLVisServer, portnum, save_stream,
                                win.data_state.fix_elem_orient,
                                win.data_state.save_coloring,
-                               win.plot_caption, win.headless};
+                               win.plot_caption,
+                               std::move(win.data_state.point_coords),
+                               win.headless};
 
       // Start message loop in main thread
       MainThreadLoop(win.headless, persistent);

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -632,12 +632,8 @@ int main (int argc, char *argv[])
       }
       else
       {
-         int num_points;
-         ifs >> num_points;
-         num_points = ReadPointLine(ifs, num_points,
-                                    win.data_state.point_coords, cerr);
-         cout << "Loaded " << num_points << " points from " << points_file
-              << endl;
+         int num_points = ReadPointLine(ifs, win.data_state.point_coords, cerr);
+         cout << "Loaded " << num_points << " points from " << points_file << endl;
       }
    }
 

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -160,8 +160,8 @@ public:
 };
 
 void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
-                 bool save_coloring, bool keep_attr, string plot_caption, bool secure,
-                 std::vector<std::array<double,3>> point_coords,
+                 bool save_coloring, bool keep_attr, string plot_caption,
+                 bool secure, std::vector<std::array<double,3>> point_coords,
                  bool headless = false)
 {
    std::vector<Session> current_sessions;
@@ -314,7 +314,8 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
          while (1);
       }
 
-      Session new_session(fix_elem_orient, save_coloring, keep_attr, plot_caption, headless);
+      Session new_session(fix_elem_orient, save_coloring, keep_attr,
+                          plot_caption, headless);
       if (!point_coords.empty()) { new_session.GetState().point_coords = point_coords; }
 
       constexpr int tmp_filename_size = 50;

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -10,6 +10,9 @@
 // CONTRIBUTING.md for details.
 
 #include <cstdlib>
+#include <istream>
+#include <ostream>
+#include <string>
 
 #include "data_state.hpp"
 #include "visual.hpp"
@@ -36,6 +39,50 @@ public:
 QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
                                           QuadratureFunction *qf, int ny);
 
+/// Helper to read a point line file (num_points, followed by x y z coordinates)
+/// that is called in glvis.cpp and the 'pointline' commands in threads.cpp and
+/// script_controller.cpp.
+int ReadPointLine(std::istream &in, int num_points,
+                  std::vector<std::array<double,3>> &points,
+                  std::ostream &warn)
+{
+   points.clear();
+
+   if (num_points > 0)
+   {
+      points.reserve(num_points);
+   }
+
+   for (int j = 0; num_points < 0 || j < num_points; j++)
+   {
+      double x, y, z;
+      if (in >> x >> y >> z)
+      {
+         points.push_back({x, y, z});
+      }
+      else
+      {
+         warn << "Warning: failed reading point " << j << std::endl;
+         break;
+      }
+   }
+
+   const int read_points = (int) points.size();
+   if (read_points < 2)
+   {
+      warn << "Warning: ReadPointLine needs at least 2 points (got "
+           << read_points << ")" << std::endl;
+   }
+   else if (read_points < num_points)
+   {
+      warn << "Warning: ReadPointLine expected " << num_points
+           << " (got " << read_points << ")" << std::endl;
+   }
+
+   return read_points;
+}
+
+
 DataState &DataState::operator=(DataState &&ss)
 {
    internal = std::move(ss.internal);
@@ -49,6 +96,7 @@ DataState &DataState::operator=(DataState &&ss)
    save_coloring = ss.save_coloring;
    keep_attr = ss.keep_attr;
    cmplx_phase = ss.cmplx_phase;
+   point_coords = std::move(ss.point_coords);
 
    return *this;
 }

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -39,14 +39,15 @@ public:
 QuadratureFunction* Extrude1DQuadFunction(Mesh *mesh, Mesh *mesh2d,
                                           QuadratureFunction *qf, int ny);
 
-/// Helper to read a point line file (num_points, followed by x y z coordinates)
-/// that is called in glvis.cpp and the 'pointline' commands in threads.cpp and
-/// script_controller.cpp.
-int ReadPointLine(std::istream &in, int num_points,
+
+int ReadPointLine(std::istream &in,
                   std::vector<std::array<double,3>> &points,
                   std::ostream &warn)
 {
    points.clear();
+
+   int num_points;
+   in >> num_points;
 
    if (num_points > 0)
    {

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -46,15 +46,25 @@ int ReadPointLine(std::istream &in,
 {
    points.clear();
 
-   int num_points;
-   in >> num_points;
+   int num_points = 0;
+   if (!(in >> num_points))
+   {
+      warn << "Warning: ReadPointLine missing number of points" << std::endl;
+      return 0;
+   }
+
+   if (num_points < 2)
+   {
+      warn << "Warning: ReadPointLine needs at least 2 points" << std::endl;
+      return 0;
+   }
 
    if (num_points > 0)
    {
       points.reserve(num_points);
    }
 
-   for (int j = 0; num_points < 0 || j < num_points; j++)
+   for (int j = 0; j < num_points; j++)
    {
       double x, y, z;
       if (in >> x >> y >> z)

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -281,7 +281,10 @@ public:
    { if (cgrid_f) { FindComplexValueRange(minv, maxv, vec2scal, scale); } else { minv = maxv = 0.; } }
 };
 
-int ReadPointLine(std::istream &in, int num_points,
+/// Helper to read a point line file (num_points, followed by x y z coordinates)
+/// that is called in glvis.cpp and the 'pointline' commands in threads.cpp and
+/// script_controller.cpp.
+int ReadPointLine(std::istream &in,
                   std::vector<std::array<double,3>> &points,
                   std::ostream &warn);
 

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -17,7 +17,6 @@
 #include <memory>
 #include <array>
 #include <vector>
-#include <iosfwd>
 #include <utility>
 #include <functional>
 

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -15,7 +15,9 @@
 #include <map>
 #include <string>
 #include <memory>
+#include <array>
 #include <vector>
+#include <iosfwd>
 #include <utility>
 #include <functional>
 
@@ -139,6 +141,7 @@ public:
    bool save_coloring{false};
    bool keep_attr{false};
    double cmplx_phase{0.};
+   std::vector<std::array<double,3>> point_coords; // point line (from -pts)
 
    DataState() = default;
    DataState(DataState &&ss) { *this = std::move(ss); }
@@ -277,5 +280,9 @@ public:
                        std::function<double(double)> scale = {}) const
    { if (cgrid_f) { FindComplexValueRange(minv, maxv, vec2scal, scale); } else { minv = maxv = 0.; } }
 };
+
+int ReadPointLine(std::istream &in, int num_points,
+                  std::vector<std::array<double,3>> &points,
+                  std::ostream &warn);
 
 #endif // GLVIS_DATA_STATE_HPP

--- a/lib/file_reader.cpp
+++ b/lib/file_reader.cpp
@@ -137,18 +137,12 @@ int FileReader::ReadParallel(int np, FileType ft, const char *mesh_file,
 
 bool FileReader::CheckStreamIsComplex(std::istream &solin, bool parallel)
 {
-   string buff;
-   auto pos = solin.tellg();
-   solin >> ws;
-   getline(solin, buff);
-   solin.seekg(pos);
-   if (!buff.empty() && *buff.rbegin() == '\r')
-   {
-      buff.resize(buff.size()-1);
-   }
    const char *header = (parallel)?("ParComplexGridFunction"):
                         ("ComplexGridFunction");
-   return (buff == header);
+   solin >> ws;
+   // Returning characters to ifgzstream is not reliable. The first character
+   // is enough to distinguish complex headers from FiniteElementSpace.
+   return (solin.peek() == header[0]);
 }
 
 int FileReader::ReadParMeshAndGridFunction(int np, const char *mesh_prefix,

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -847,12 +847,7 @@ bool ScriptController::ExecuteScriptCommand()
          break;
          case Command::PointLine:
          {
-            int num_points;
-            scr >> num_points;
-
-            num_points = ReadPointLine(scr, num_points,
-                                       win.data_state.point_coords,
-                                       cerr);
+            int num_points = ReadPointLine(scr, win.data_state.point_coords, cerr);
 
             win.vs->SetPointLineVisible(true);
             win.vs->PreparePointLine();

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -61,6 +61,7 @@ enum class Command
    Scale,
    Translate,
    PlotCaption,
+   PointLine,
    Headless,
    //----------
    Max
@@ -125,6 +126,7 @@ ScriptCommands::ScriptCommands()
    (*this)[Command::Scale]                = {"scale", "<scale>", "Set the scaling factor."};
    (*this)[Command::Translate]            = {"translate", "<x> <y> <z>", "Set the translation coordinates."};
    (*this)[Command::PlotCaption]          = {"plot_caption", "'<caption>'", "Set the plot caption."};
+   (*this)[Command::PointLine]            = {"pointline", "<num_points> <x y z>...", "Set point line overlay coordinates."};
    (*this)[Command::Headless]             = {"headless", "", "Change the session to headless."};
 }
 
@@ -841,6 +843,22 @@ bool ScriptController::ExecuteScriptCommand()
             getline(scr, win.plot_caption, delim);
             win.vs->PrepareCaption(); // turn on or off the caption
             MyExpose();
+         }
+         break;
+         case Command::PointLine:
+         {
+            int num_points;
+            scr >> num_points;
+
+            num_points = ReadPointLine(scr, num_points,
+                                       win.data_state.point_coords,
+                                       cerr);
+
+            win.vs->SetPointLineVisible(true);
+            win.vs->PreparePointLine();
+            MyExpose();
+
+            cout << "Script: pointline: " << num_points << " points" << endl;
          }
          break;
          case Command::Headless:

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -240,6 +240,21 @@ int GLVisCommand::ColorbarNumberFormat(string formatting)
    return 0;
 }
 
+int GLVisCommand::PointLine(std::vector<std::array<double,3>> points)
+{
+   if (lock() < 0)
+   {
+      return -1;
+   }
+   command = Command::POINT_LINE;
+   point_coords = std::move(points);
+   if (signal() < 0)
+   {
+      return -2;
+   }
+   return 0;
+}
+
 int GLVisCommand::Pause()
 {
    if (lock() < 0)
@@ -839,6 +854,17 @@ int GLVisCommand::Execute()
          break;
       }
 
+      case Command::POINT_LINE:
+      {
+         cout << "Command: pointline: " << point_coords.size()
+              << " points" << endl;
+         win.data_state.point_coords = std::move(point_coords);
+         win.vs->SetPointLineVisible(true);
+         win.vs->PreparePointLine();
+         MyExpose();
+         break;
+      }
+
       case Command::QUIT:
       {
          thread_wnd->signalQuit();
@@ -916,6 +942,7 @@ enum class ThreadCommand
    AxisLabels,
    Pause,
    Autopause,
+   PointLine,
    //----------
    Max
 };
@@ -968,6 +995,7 @@ ThreadCommands::ThreadCommands()
    (*this)[ThreadCommand::AxisLabels]           = {"axis_labels", "'<x label>' '<y label>' '<z label>'", "Set labels of the axes."};
    (*this)[ThreadCommand::Pause]                = {"pause", "", "Stop the stream until space is pressed."};
    (*this)[ThreadCommand::Autopause]            = {"autopause", "<0/off/1/on>", "Turns off or on autopause."};
+   (*this)[ThreadCommand::PointLine]            = {"pointline", "<num_points> <x y z>...", "Set point line overlay coordinates."};
 }
 
 communication_thread::communication_thread(StreamCollection _is,
@@ -1592,6 +1620,34 @@ bool communication_thread::execute_one(std::string ident)
          {
             return false;
          }
+      }
+      break;
+      case ThreadCommand::PointLine:
+      {
+         // in parallel, use the point line data from rank 0
+         int num_points;
+         *is[0] >> num_points;
+
+         std::vector<std::array<double,3>> points;
+         num_points = ReadPointLine(*is[0], num_points, points, cerr);
+
+         // assuming that all ranks have sent point data, reads on the remaining
+         // ranks to sync parallel streams
+         for (size_t i = 1; i < is.size(); i++)
+         {
+            *is[i] >> ws >> ident; // 'pointline'
+            int np;
+            *is[i] >> np;
+            for (int j = 0; j < np; j++)
+            {
+               double x, y, z;
+               *is[i] >> x >> y >> z; // ignore
+            }
+         }
+
+         glvis_command->PointLine(std::move(points));
+
+         cout << "Received " << num_points << " points" << endl;
       }
       break;
       case ThreadCommand::Max: //dummy

--- a/lib/threads.cpp
+++ b/lib/threads.cpp
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <algorithm>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -1625,24 +1626,17 @@ bool communication_thread::execute_one(std::string ident)
       case ThreadCommand::PointLine:
       {
          // in parallel, use the point line data from rank 0
-         int num_points;
-         *is[0] >> num_points;
-
          std::vector<std::array<double,3>> points;
-         num_points = ReadPointLine(*is[0], num_points, points, cerr);
+         int num_points = ReadPointLine(*is[0], points, cerr);
 
-         // assuming that all ranks have sent point data, reads on the remaining
-         // ranks to sync parallel streams
+         // assuming that all ranks have sent the same point data, perform dummy
+         // reads on the remaining ranks to sync parallel streams
+         std::vector<std::array<double,3>> dummy_points;
+         std::ostringstream dummy_stream;
          for (size_t i = 1; i < is.size(); i++)
          {
             *is[i] >> ws >> ident; // 'pointline'
-            int np;
-            *is[i] >> np;
-            for (int j = 0; j < np; j++)
-            {
-               double x, y, z;
-               *is[i] >> x >> y >> z; // ignore
-            }
+            ReadPointLine(*is[i], dummy_points, dummy_stream);
          }
 
          glvis_command->PointLine(std::move(points));

--- a/lib/threads.hpp
+++ b/lib/threads.hpp
@@ -12,6 +12,7 @@
 #ifndef GLVIS_THREADS_HPP
 #define GLVIS_THREADS_HPP
 
+#include <array>
 #include <mfem.hpp>
 #include <thread>
 #include <atomic>
@@ -62,6 +63,7 @@ private:
       LEVELLINES,
       AXIS_NUMBERFORMAT,
       COLORBAR_NUMBERFORMAT,
+      POINT_LINE,
       QUIT
    };
 
@@ -97,6 +99,7 @@ private:
    std::string   autopause_mode;
    std::string   axis_formatting;
    std::string   colorbar_formatting;
+   std::vector<std::array<double,3>> point_coords;
 
    // internal variables
    int autopause;
@@ -137,6 +140,7 @@ public:
    int Levellines(double minv, double maxv, int number);
    int AxisNumberFormat(std::string formatting);
    int ColorbarNumberFormat(std::string formatting);
+   int PointLine(std::vector<std::array<double, 3>> points);
    int Camera(const double cam[]);
    int Autopause(const char *mode);
    int Quit();

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -700,9 +700,16 @@ void KeyHPressed()
    cout << vsdata->GetHelpString() << flush;
 }
 
-void KeylPressed()
+void KeylPressed(GLenum state)
 {
-   vsdata -> ToggleLight();
+   if (state & KMOD_CTRL)
+   {
+      vsdata->TogglePointLine();
+   }
+   else
+   {
+      vsdata -> ToggleLight();
+   }
    SendExposeEvent();
 }
 
@@ -1018,6 +1025,18 @@ void VisualizationSceneScalarData::ToggleRuler()
 {
    ruler_on = (ruler_on + 1) % 3;
    PrepareRuler();
+}
+
+void VisualizationSceneScalarData::TogglePointLine()
+{
+   if (win.data_state.point_coords.empty())
+   {
+      cout << "No points loaded. Use -pts <file> to load coordinates." << endl;
+      return;
+   }
+   show_point_line = !show_point_line;
+   cout << "Point line: " << (show_point_line ? "ON" : "OFF") << endl;
+   PreparePointLine();
 }
 
 void VisualizationSceneScalarData::RulerPosition()
@@ -1667,6 +1686,56 @@ void VisualizationSceneScalarData::PrepareAxes()
    coord_cross_buf.addText(0.0f, len, 0.0f, a_label_y);
    coord_cross_buf.addText(0.0f, 0.0f, len, a_label_z);
    updated_bufs.emplace_back(&coord_cross_buf);
+}
+
+void VisualizationSceneScalarData::PreparePointLine()
+{
+   point_line_buf.clear();
+   if (!show_point_line || win.data_state.point_coords.empty())
+   {
+      return;
+   }
+
+   const auto& points = win.data_state.point_coords;
+   // in 2D, elevate the point line above the surface using the value range
+   // in 3D, use the z-coordinates from the points file.
+   const bool is_2d = (mesh->SpaceDimension() == 2);
+   float z_offset = 0.0f;
+   if (is_2d)
+   {
+      const float range = (float)(maxv - minv);
+      const float dz = (range > 0.0f) ? (0.02f * range)
+                       : (0.02f * (float)std::max(1.0, fabs(maxv)));
+      z_offset = (float)maxv + dz;
+   }
+
+   std::vector<gl3::Vertex> line_vertices;
+   line_vertices.reserve((points.size()-1)*2);
+   for (size_t i = 0; i + 1 < points.size(); i++)
+   {
+      float x0 = (float)points[i][0];
+      float y0 = (float)points[i][1];
+      float x1 = (float)points[i+1][0];
+      float y1 = (float)points[i+1][1];
+      float z = is_2d ? z_offset : (float)points[i][2];
+      float z_next = is_2d ? z_offset : (float)points[i+1][2];
+      line_vertices.push_back({x0, y0, z});
+      line_vertices.push_back({x1, y1, z_next});
+   }
+   point_line_buf.addLines<gl3::Vertex>(line_vertices);
+   updated_bufs.emplace_back(&point_line_buf);
+}
+
+void VisualizationSceneScalarData::AddPointLineToScene(
+   gl3::SceneInfo& scene, const gl3::RenderParams& base_params)
+{
+   if (!show_point_line || win.data_state.point_coords.empty()) { return; }
+   gl3::RenderParams params = base_params; // use local parameters
+   params.static_color = {1.0f, 0.0f, 0.0f, 1.0f}; // point line is red
+   params.use_clip_plane = false;
+   params.num_pt_lights = 0;
+   params.contains_translucent = false;
+   scene.queue.emplace_back(params, &point_line_buf);
 }
 
 void VisualizationSceneScalarData::DrawPolygonLevelLines(

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1009,6 +1009,7 @@ void VisualizationSceneScalarData::ToggleLogscale(bool print)
       SetLevelLines(minv, maxv, nl);
       UpdateLevelLines();
       EventUpdateColors();
+      PreparePointLine();
       if (print)
       {
          PrintLogscale(false);

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1704,9 +1704,10 @@ void VisualizationSceneScalarData::PreparePointLine()
    float z_offset = 0.0f;
    if (is_2d)
    {
-      const float range = (float)(maxv - minv);
-      const float dz = (range > 0.0f) ? (0.02f * range)
-                       : (0.02f * (float)std::max(1.0, fabs(maxv)));
+     const auto range = maxv - minv;
+     const float dz = (range > 0.0) ? (0.02 * range)
+                       : (0.02 * std::max(1.0, std::abs(maxv)));
+
       z_offset = (float)maxv + dz;
    }
 

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1704,10 +1704,9 @@ void VisualizationSceneScalarData::PreparePointLine()
    float z_offset = 0.0f;
    if (is_2d)
    {
-     const auto range = maxv - minv;
-     const float dz = (range > 0.0) ? (0.02 * range)
+      const auto range = maxv - minv;
+      const float dz = (range > 0.0) ? (0.02 * range)
                        : (0.02 * std::max(1.0, std::abs(maxv)));
-
       z_offset = (float)maxv + dz;
    }
 
@@ -1721,10 +1720,6 @@ void VisualizationSceneScalarData::PreparePointLine()
       float y1 = points[i+1][1];
       float z = is_2d ? z_offset : points[i][2];
       float z_next = is_2d ? z_offset : points[i+1][2];
-      line_vertices.push_back({x0, y0, z});
-      line_vertices.push_back({x1, y1, z_next});
-      float z = is_2d ? z_offset : (float)points[i][2];
-      float z_next = is_2d ? z_offset : (float)points[i+1][2];
       line_vertices.push_back({x0, y0, z});
       line_vertices.push_back({x1, y1, z_next});
    }

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1714,10 +1714,14 @@ void VisualizationSceneScalarData::PreparePointLine()
    line_vertices.reserve((points.size()-1)*2);
    for (size_t i = 0; i + 1 < points.size(); i++)
    {
-      float x0 = (float)points[i][0];
-      float y0 = (float)points[i][1];
-      float x1 = (float)points[i+1][0];
-      float y1 = (float)points[i+1][1];
+      float x0 = points[i][0];
+      float y0 = points[i][1];
+      float x1 = points[i+1][0];
+      float y1 = points[i+1][1];
+      float z = is_2d ? z_offset : points[i][2];
+      float z_next = is_2d ? z_offset : points[i+1][2];
+      line_vertices.push_back({x0, y0, z});
+      line_vertices.push_back({x1, y1, z_next});
       float z = is_2d ? z_offset : (float)points[i][2];
       float z_next = is_2d ? z_offset : (float)points[i+1][2];
       line_vertices.push_back({x0, y0, z});

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -104,6 +104,7 @@ protected:
    gl3::GlDrawable color_bar;
    gl3::GlDrawable ruler_buf;
    gl3::GlDrawable caption_buf;
+   gl3::GlDrawable point_line_buf;
    int caption_w, caption_h;
 
    void Init();
@@ -119,6 +120,7 @@ protected:
    Autoscale autoscale;
 
    bool logscale;
+   bool show_point_line{false};
 
    bool LogscaleRange() { return (minv > 0.0 && maxv > minv); }
    void PrintLogscale(bool warn);
@@ -311,6 +313,13 @@ public:
          PrepareAxes();
       }
    }
+
+   void PreparePointLine();
+   void TogglePointLine();
+   void SetPointLineVisible(bool visible) { show_point_line = visible; }
+   /// Helper for adding point line overlay in derived classes
+   void AddPointLineToScene(gl3::SceneInfo& scene,
+                            const gl3::RenderParams& params);
 
    void ToggleScaling()
    { scaling = !scaling; SetNewScalingFromBox(); }

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -177,7 +177,7 @@ protected:
    static void KeyaPressed();
    static void Key_Mod_a_Pressed(GLenum state);
    static void KeyHPressed();
-   static void KeylPressed();
+   static void KeylPressed(GLenum state);
    static void KeyLPressed();
    static void KeyrPressed();
    static void KeyRPressed();

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -87,6 +87,7 @@ std::string VisualizationSceneSolution::GetHelpString() const
       << "| Alt+a  - Axes number format        |" << endl
       << "| Alt+c  - Colorbar number format    |" << endl
       << "| Alt+n  - Numberings method         |" << endl
+      << "| Ctrl+l - Toggle point line         |" << endl
       << "| Ctrl+o - Element ordering curve    |" << endl
       << "| Ctrl+p - Print to a PDF file       |" << endl
       << "+------------------------------------+" << endl
@@ -2760,6 +2761,7 @@ gl3::SceneInfo VisualizationSceneSolution::GetSceneObjs()
    {
       scene.queue.emplace_back(params, &order_buf);
    }
+   AddPointLineToScene(scene, params); // point line overlay
    ProcessUpdatedBufs(scene);
 
    return scene;

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -2438,6 +2438,7 @@ void VisualizationSceneSolution::UpdateValueRange(bool prepare)
    bb.z[0] = minv;
    bb.z[1] = maxv;
    PrepareAxes();
+   PreparePointLine();
    if (prepare)
    {
       UpdateLevelLines();

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -87,6 +87,7 @@ std::string VisualizationSceneSolution3d::GetHelpString() const
       << "| \\ -  Set light source position     |" << endl
       << "| Alt+a  - Axes number format        |" << endl
       << "| Alt+c  - Colorbar number format    |" << endl
+      << "| Ctrl+l - Toggle point line         |" << endl
       << "| Ctrl+o - Element ordering curve    |" << endl
       << "| Ctrl+p - Print to a PDF file       |" << endl
       << "+------------------------------------+" << endl
@@ -4284,6 +4285,7 @@ gl3::SceneInfo VisualizationSceneSolution3d::GetSceneObjs()
    {
       scene.queue.emplace_back(params, &order_buf);
    }
+   AddPointLineToScene(scene, params); // point line overlay
    ProcessUpdatedBufs(scene);
    return scene;
 }

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -72,6 +72,7 @@ std::string VisualizationSceneVector::GetHelpString() const
       << "| \\ -  Set light source position     |" << endl
       << "| Alt+a  - Axes number format        |" << endl
       << "| Alt+c  - Colorbar number format    |" << endl
+      << "| Ctrl+l - Toggle point line         |" << endl
       << "| Ctrl+p - Print to a PDF file       |" << endl
       << "+------------------------------------+" << endl
       << "| Function keys                      |" << endl
@@ -1131,6 +1132,7 @@ gl3::SceneInfo VisualizationSceneVector::GetSceneObjs()
       }
       scene.queue.emplace_back(params, &displine_buf);
    }
+   AddPointLineToScene(scene, params); // point line overlay
    ProcessUpdatedBufs(scene);
 
    return scene;

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -84,6 +84,7 @@ std::string VisualizationSceneVector3d::GetHelpString() const
       << "| \\ -  Set light source position     |" << endl
       << "| Alt+a  - Axes number format        |" << endl
       << "| Alt+c  - Colorbar number format    |" << endl
+      << "| Ctrl+l - Toggle point line         |" << endl
       << "| Ctrl+p - Print to a PDF file       |" << endl
       << "+------------------------------------+" << endl
       << "| Function keys                      |" << endl
@@ -1790,6 +1791,7 @@ gl3::SceneInfo VisualizationSceneVector3d::GetSceneObjs()
       params.use_clip_plane = false;
       scene.queue.emplace_back(params, &cplines_buf);
    }
+   AddPointLineToScene(scene, params); // point line overlay
    ProcessUpdatedBufs(scene);
    return scene;
 }

--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -162,6 +162,11 @@ bool Window::GLVisInitVis(StreamCollection input_streams)
          vs->SetValueRange(-mesh_range, mesh_range);
          vs->SetAutoscale(VisualizationSceneScalarData::Autoscale::None);
       }
+      if (!data_state.point_coords.empty())
+      {
+         vs->SetPointLineVisible(true);
+         vs->PreparePointLine();
+      }
       if (data_state.mesh->SpaceDimension() == 2
           && field_type == DataState::FieldType::MESH)
       {


### PR DESCRIPTION
<!--
### Disclaimer

The initial versions of this PR were written with a coding agent 🤖, however:
- I have reviewed, edited and tested all changes before issuing the PR
- I claim to understand the code and pledge to maintain it in the future
-->

### Overview

This PR adds an optional point line overlay (useful e.g. for reference curves), which can be toggled with <kbd>Ctrl</kbd> + <kbd>l</kbd>. 

Points can be loaded from a file with the `-pts` command-line  option, sent via socket with the `pointline` command, or specified in a GLVis scripts. The  points line format is: number of points, followed by `x y z` coordinates.

The overlay appears as a red line connecting the given points. 

<img width="512" height="494" alt="Screenshot 2026-03-09 at 7 21 04 PM" src="https://github.com/user-attachments/assets/5c99aff4-f39a-43df-bb30-9a735250717e" />

### Testing

#### Stand-alone with input from file
Use this [circle_points.txt](https://github.com/user-attachments/files/25857643/circle_points.txt) points file to run
```
./glvis -m ../mfem/data/star-q2.mesh -pts circle_points.txt -k "Aem"
```
and press <kbd>Ctrl</kbd> + <kbd>l</kbd>.

#### Server mode with input from file
Run
```
./glvis -pts circle_points.txt
```
then send a solution via socket, e.g. from `mpirun -np 4 ./ex1p` and press <kbd>Ctrl</kbd> + <kbd>l</kbd>.

#### Server mode with input by socket
Add sample points to the solution socket output in one of the examples, e.g. in `ex1.cpp`:
```c++
int sdim = mesh.SpaceDimension();
Vector bb_min, bb_max;
mesh.GetBoundingBox(bb_min, bb_max);
sol_sock << "pointline\n" << 2 << "\n"
          << bb_min(0) << ' ' << bb_min(1) << ' ' << ((sdim==2) ? 0.0 : bb_min(2)) << "\n"
          << bb_max(0) << ' ' << bb_max(1) << ' ' << ((sdim==2) ? 0.0 : bb_max(2)) << "\n"
          << flush;
```
start a server with `./glvis` and then run `./ex1 -m ../data/escher.mesh`.

The point line should appear by default and can be turned off/on with <kbd>Ctrl</kbd> + <kbd>l</kbd>.

In server mode, input by socket overrides input by file. In parallel, all ranks send point lines, but only the one from rank 0 is considered.

#### GLVis script
Use the files in this archive: [test_pointline.zip](https://github.com/user-attachments/files/25857875/test_pointline.zip) to run
```
./glvis -run test_pointline.glvis
```
Press <kbd>Space</kbd> and rhe point line should appear; it can be turned off/on with <kbd>Ctrl</kbd> + <kbd>l</kbd>.

### Potential improvements
- Add support for comments/blank lines in the points files
- Support multiple point lines (in the same or multiple files)
- Provide options to customize the style of the point line
- Smooth the curve with [NURBS interpolation](https://github.com/mfem/mfem/pull/4841)