### PR TITLE
Bug fix for real attributes in parallel socket input (glvis -a)

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -77,14 +77,14 @@ class Session
 
 public:
    Session(bool fix_elem_orient,
-           bool keep_attr,
            bool save_coloring,
+           bool keep_attr,
            string plot_caption,
            bool headless)
    {
       win.data_state.fix_elem_orient = fix_elem_orient;
-      win.data_state.keep_attr = keep_attr;
       win.data_state.save_coloring = save_coloring;
+      win.data_state.keep_attr = keep_attr;
       win.plot_caption = plot_caption;
       win.headless = headless;
    }
@@ -159,7 +159,7 @@ public:
 };
 
 void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
-                 bool keep_attr, bool save_coloring, string plot_caption,
+                 bool save_coloring, bool keep_attr, string plot_caption,
                  bool headless = false)
 {
    std::vector<Session> current_sessions;
@@ -310,8 +310,8 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
          while (1);
       }
 
-      Session new_session(fix_elem_orient, keep_attr,
-                          save_coloring, plot_caption, headless);
+      Session new_session(fix_elem_orient, save_coloring,
+                          keep_attr, plot_caption, headless);
 
       constexpr int tmp_filename_size = 50;
       char tmp_file[tmp_filename_size];
@@ -696,8 +696,8 @@ int main (int argc, char *argv[])
       // Run server in new thread
       std::thread serverThread{GLVisServer, portnum, save_stream,
                                win.data_state.fix_elem_orient,
-                               win.data_state.keep_attr,
                                win.data_state.save_coloring,
+                               win.data_state.keep_attr,
                                win.plot_caption, win.headless};
 
       // Start message loop in main thread

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -77,11 +77,13 @@ class Session
 
 public:
    Session(bool fix_elem_orient,
+           bool keep_attr,
            bool save_coloring,
            string plot_caption,
            bool headless)
    {
       win.data_state.fix_elem_orient = fix_elem_orient;
+      win.data_state.keep_attr = keep_attr;
       win.data_state.save_coloring = save_coloring;
       win.plot_caption = plot_caption;
       win.headless = headless;
@@ -157,7 +159,8 @@ public:
 };
 
 void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
-                 bool save_coloring, string plot_caption, bool headless = false)
+                 bool keep_attr, bool save_coloring, string plot_caption,
+                 bool headless = false)
 {
    std::vector<Session> current_sessions;
    string data_type;
@@ -307,7 +310,8 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
          while (1);
       }
 
-      Session new_session(fix_elem_orient, save_coloring, plot_caption, headless);
+      Session new_session(fix_elem_orient, keep_attr,
+                          save_coloring, plot_caption, headless);
 
       constexpr int tmp_filename_size = 50;
       char tmp_file[tmp_filename_size];
@@ -692,6 +696,7 @@ int main (int argc, char *argv[])
       // Run server in new thread
       std::thread serverThread{GLVisServer, portnum, save_stream,
                                win.data_state.fix_elem_orient,
+                               win.data_state.keep_attr,
                                win.data_state.save_coloring,
                                win.plot_caption, win.headless};
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -2523,9 +2523,21 @@ void VisualizationSceneSolution::PrepareBoundary()
             T->Loc2.Transform(ir, eir);
             GetRefinedValues(T->Elem2No, eir, vals, pointmat);
             bl.glBegin(GL_LINE_STRIP);
-            for (j = 0; j < vals.Size(); j++)
+            if (drawbdr == 2)
             {
-               bl.glVertex3d(pointmat(0, j), pointmat(1, j), vals(j));
+               const double val = mesh->GetBdrAttribute(i);
+               MySetColor(bl, val, minv, maxv);
+               for (j = 0; j < vals.Size(); j++)
+               {
+                  bl.glVertex3d(pointmat(0, j), pointmat(1, j), val);
+               }
+            }
+            else
+            {
+               for (j = 0; j < vals.Size(); j++)
+               {
+                  bl.glVertex3d(pointmat(0, j), pointmat(1, j), vals(j));
+               }
             }
             bl.glEnd();
          }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -181,6 +181,12 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(gl3::GlDrawable& buf,
    DenseMatrix pointmat1;
    Array<int> vertices1;
 
+   const auto shrink_save = shrink;
+   // If shrink != 1, ShrinkPoints() expects a bdr element index for its second
+   // parameter when dim == 3. Since in the loop below we call ShrinkPoints()
+   // with an element index, we temporarily set shrink to 1.
+   if (mesh->Dimension() == 3) { shrink = 1.0; }
+
    int ne = mesh->GetNE();
    for (int k = 0; k < ne-1; k++)
    {
@@ -223,7 +229,7 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(gl3::GlDrawable& buf,
       double dx = xs1-xs;
       double dy = ys1-ys;
       double dz = zs1-zs;
-      double ds = sqrt(dx*dx+dy*dy+dz*dz);
+      double ds = hypot(dx, dy, dz); // sqrt(dx*dx+dy*dy+dz*dz);
 
       double cval = HUGE_VAL;
       if (color)
@@ -246,6 +252,8 @@ void VisualizationSceneSolution3d::PrepareOrderingCurve1(gl3::GlDrawable& buf,
                 ds,0.0,cval);
       }
    }
+
+   if (mesh->Dimension() == 3) { shrink = shrink_save; }
 
    if (GetMultisample() > 0)
    {


### PR DESCRIPTION
<!--

### Disclaimer

The initial versions of this PR were written with a coding agent 🤖, however:
- I have reviewed, edited and tested all changes before issuing the PR
- I claim to understand the code and pledge to maintain it in the future

-->

### Overview

This is a bug fix for `glvis -a` which did not work correctly for parallel socket input.

### Testing

Start the server with 

```
glvis -a
```

then send a solution via socket, from a mesh with multiple attributes, e.g.

```
mpirun -np 4 ./ex1p -m ../data/beam-quad.mesh
```

and check that <kbd>F11</kbd> pulls apart material subdomains, not processor subdomains.

### Potential improvements
- Add the ability to specify this via a socket command?