### PR TITLE
Added non-exclusive port option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,12 @@
                              https://glvis.org
 
 
+Version 4.5.1 (development)
+===========================
+
+- Added the option ('-no-ex') to run GLVis in non-exclusive setting when the
+  server starts listening on the next available port instead of aborting.
+
 Version 4.5 released on Feb 6, 2026
 ===================================
 

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -157,7 +157,8 @@ public:
 };
 
 void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
-                 bool save_coloring, string plot_caption, bool headless = false)
+                 bool save_coloring, string plot_caption, bool headless = false,
+                 bool exclusive = true)
 {
    std::vector<Session> current_sessions;
    string data_type;
@@ -200,10 +201,26 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
 #endif
 
    const int backlog = 128;
-   socketserver server(portnum, backlog);
-   if (server.good())
+   unique_ptr<socketserver> server;
+   if (!exclusive)
+   {
+      for (;; portnum++)
+      {
+         server = make_unique<socketserver>(portnum, backlog);
+         if (server->good()) { break; }
+      }
+   }
+   else
+   {
+      server = make_unique<socketserver>(portnum, backlog);
+   }
+   if (server->good())
    {
       cout << "Waiting for data on port " << portnum << " ..." << endl;
+      if (!exclusive)
+      {
+         cout << "GLVIS_SERVER_PORT=" << portnum << endl;
+      }
    }
    else
    {
@@ -220,7 +237,7 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
       isock.reset(secure ? new socketstream(*params) : new socketstream(false));
 #endif
       vector<unique_ptr<istream>> input_streams;
-      while (server.accept(*isock) < 0)
+      while (server->accept(*isock) < 0)
       {
 #ifdef GLVIS_DEBUG
          cout << "GLVis: server.accept(...) failed." << endl;
@@ -290,7 +307,7 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
                break;
             }
             // read next available socket stream
-            while (server.accept(*isock) < 0)
+            while (server->accept(*isock) < 0)
             {
 #ifdef GLVIS_DEBUG
                cout << "GLVis: server.accept(...) failed." << endl;
@@ -385,6 +402,7 @@ int main (int argc, char *argv[])
    const char *font_name     = string_default;
    int         portnum       = 19916;
    bool        persistent    = true;
+   bool        exclusive     = true;
    int         multisample   = GetMultisample();
    double      line_width    = GetLineWidth();
    double      ms_line_width = GetLineWidthMS();
@@ -458,6 +476,9 @@ int main (int argc, char *argv[])
    args.AddOption(&persistent, "-pr", "--persistent",
                   "-no-pr", "--no-persistent",
                   "Keep server running after all windows are closed.");
+   args.AddOption(&exclusive, "-ex", "--exclusive",
+                  "-no-ex", "--no-exclusive",
+                  "Exclusively block the given port or take the next available.");
    args.AddOption(&secure, "-sec", "--secure-sockets",
                   "-no-sec", "--standard-sockets",
                   "Enable or disable GnuTLS secure sockets.");
@@ -693,7 +714,8 @@ int main (int argc, char *argv[])
       std::thread serverThread{GLVisServer, portnum, save_stream,
                                win.data_state.fix_elem_orient,
                                win.data_state.save_coloring,
-                               win.plot_caption, win.headless};
+                               win.plot_caption, win.headless,
+                               exclusive};
 
       // Start message loop in main thread
       MainThreadLoop(win.headless, persistent);

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -219,7 +219,7 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
       cout << "Waiting for data on port " << portnum << " ..." << endl;
       if (!exclusive)
       {
-         cout << "GLVIS_SERVER_PORT=" << portnum << endl;
+         cerr << "GLVIS_SERVER_PORT=" << portnum << endl;
       }
    }
    else


### PR DESCRIPTION
Added the option (`-no-ex`) to run GLVis in non-exclusive setting when the server starts listening on the next available port instead of aborting (the default behavior).

This enables (in combination with the non-persistent option) to run applications with their private server (not colliding with other servers or so...). The launching script can look like this:
```bash
#!/bin/bash
GLVIS_EXEC="$(dirname ${BASH_SOURCE})/glvis"
GLVIS_FLAGS="-no-pr -no-ex"
EXEC_FLAGS="-vis"

# Open a log file
GLVIS_LOG="$(mktemp --tmpdir glvis-log.XXXXXX)"
echo "GVis log can be found in: ${GLVIS_LOG}"

# Start GLVis
${GLVIS_EXEC} ${GLVIS_FLAGS} >"${GLVIS_LOG}" 2>&1 &
GLVIS_PID=$!

# Wait for port number
GLVIS_SERVER_PORT=""
until GLVIS_SERVER_PORT="$(
  awk -F= -v k="GLVIS_SERVER_PORT" '
    $1==k { print substr($0, index($0,$2)); exit }
  ' "${GLVIS_LOG}"
)"; [[ -n "${GLVIS_SERVER_PORT}" ]]; do
  sleep 0.05
done

echo "GLVis runs with PID: ${GLVIS_PID} listening on port: ${GLVIS_SERVER_PORT}"

# Run the application
$@ ${EXEC_FLAGS} -p ${GLVIS_SERVER_PORT}

# Kill GLVis if the application aborts, otherwise it should
# be closed automatically when rendering is done
if [[ $? != 0 ]]
then
    kill ${GLVIS_PID}
fi
```
When placed in GLVis folder, you can start for example Navier miniapp like this:
`<GLVIS_DIR>/<SCRIPT_FILE> mpirun -np 4 ./navier_mms`
It runs the miniapp and visualizes the solution independently of other processes 🎉 . When you close the windows, GLVis server closes as well.

Something similar can be achieved from code directly like in [ex1p.cpp](https://github.com/mfem/mfem/blob/glvis-server-example/examples/ex1p.cpp) (from branch `glvis-server-example`). It is then launched: `mpirun -np 4 ./ex1p -vis -vs <GLVIS_BINARY>` 🎉 