### PR TITLE
[BUG] Fixed (and refactored) geometry refiner

### DIFF
--- a/glvis.cpp
+++ b/glvis.cpp
@@ -75,13 +75,6 @@ class Session
    std::thread handler;
 
 public:
-   Session(string plot_caption,
-           bool headless)
-   {
-      win.plot_caption = plot_caption;
-      win.headless = headless;
-   }
-
    Session(Window other_win)
       : win(std::move(other_win))
    { }
@@ -303,7 +296,7 @@ void GLVisServer(int portnum, bool save_stream, bool secure, Window win)
          while (1);
       }
 
-      Session new_session(std::move(win));
+      Session new_session(win.CloneEmpty());
 
       constexpr int tmp_filename_size = 50;
       char tmp_file[tmp_filename_size];

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -66,8 +66,6 @@ enum InputOptions
 };
 int input = INPUT_SERVER_MODE;
 
-thread_local GeometryRefiner GLVisGeometryRefiner;
-
 void PrintSampleUsage(ostream &out);
 
 class Session
@@ -387,7 +385,6 @@ int main (int argc, char *argv[])
    int         multisample   = GetMultisample();
    double      line_width    = GetLineWidth();
    double      ms_line_width = GetLineWidthMS();
-   int         geom_ref_type = Quadrature1D::ClosedUniform;
    bool        legacy_gl_ctx = false;
    bool        enable_hidpi  = true;
 
@@ -446,7 +443,7 @@ int main (int argc, char *argv[])
                   "-ap", "--processor-attributes",
                   "When opening a parallel mesh, use the real mesh attributes"
                   " or replace them with the processor rank.");
-   args.AddOption(&geom_ref_type, "-grt", "--geometry-refiner-type",
+   args.AddOption(&win.data_state.geom_ref_type, "-grt", "--geometry-refiner-type",
                   "Set of points to use when refining geometry:"
                   " 3 = uniform, 1 = Gauss-Lobatto, (see mfem::Quadrature1D).");
    args.AddOption(&win.data_state.save_coloring, "-sc", "--save-coloring",
@@ -610,8 +607,6 @@ int main (int argc, char *argv[])
    {
       BasePalettes.SetDefault(palette_name);
    }
-
-   GLVisGeometryRefiner.SetType(geom_ref_type);
 
    // Load points file if specified (Ctrl+l to toggle)
    if (points_file != string_none)

--- a/glvis.cpp
+++ b/glvis.cpp
@@ -77,15 +77,9 @@ class Session
    std::thread handler;
 
 public:
-   Session(bool fix_elem_orient,
-           bool save_coloring,
-           bool keep_attr,
-           string plot_caption,
+   Session(string plot_caption,
            bool headless)
    {
-      win.data_state.fix_elem_orient = fix_elem_orient;
-      win.data_state.save_coloring = save_coloring;
-      win.data_state.keep_attr = keep_attr;
       win.plot_caption = plot_caption;
       win.headless = headless;
    }
@@ -159,10 +153,7 @@ public:
 
 };
 
-void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
-                 bool save_coloring, bool keep_attr, string plot_caption,
-                 bool secure, std::vector<std::array<double,3>> point_coords,
-                 bool headless = false)
+void GLVisServer(int portnum, bool save_stream, bool secure, Window win)
 {
    std::vector<Session> current_sessions;
    string data_type;
@@ -314,9 +305,7 @@ void GLVisServer(int portnum, bool save_stream, bool fix_elem_orient,
          while (1);
       }
 
-      Session new_session(fix_elem_orient, save_coloring, keep_attr,
-                          plot_caption, headless);
-      if (!point_coords.empty()) { new_session.GetState().point_coords = point_coords; }
+      Session new_session(std::move(win));
 
       constexpr int tmp_filename_size = 50;
       char tmp_file[tmp_filename_size];
@@ -712,21 +701,19 @@ int main (int argc, char *argv[])
    // server mode, read the mesh and the solution from a socket
    if (input == INPUT_SERVER_MODE)
    {
+      // backup the headless flag as the window is moved
+      const bool headless = win.headless;
+
       // Make sure the singleton object returned by GetMainThread() is
       // initialized from the main thread.
-      GetMainThread(win.headless);
+      GetMainThread(headless);
 
       // Run server in new thread
       std::thread serverThread{GLVisServer, portnum, save_stream,
-                               win.data_state.fix_elem_orient,
-                               win.data_state.save_coloring,
-                               win.data_state.keep_attr,
-                               win.plot_caption, secure,
-                               std::move(win.data_state.point_coords),
-                               win.headless};
+                               secure, std::move(win)};
 
       // Start message loop in main thread
-      MainThreadLoop(win.headless, persistent);
+      MainThreadLoop(headless, persistent);
       serverThread.detach();
    }
    else  // input != 1, non-server mode

--- a/lib/aux_js.cpp
+++ b/lib/aux_js.cpp
@@ -24,9 +24,6 @@
 #include <emscripten/html5.h>
 #include <emscripten/val.h>
 
-// used in extern context
-thread_local mfem::GeometryRefiner GLVisGeometryRefiner;
-
 // either bitmap data or png bytes
 std::vector<unsigned char> * screen_state = nullptr;
 

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -94,23 +94,41 @@ int ReadPointLine(std::istream &in,
 }
 
 
-DataState &DataState::operator=(DataState &&ss)
+DataState &DataState::operator=(DataState &&ds)
 {
-   internal = std::move(ss.internal);
+   internal = std::move(ds.internal);
 
-   type = ss.type;
-   cmplx_sol = ss.cmplx_sol;
-   quad_sol = ss.quad_sol;
-   keys = std::move(ss.keys);
+   type = ds.type;
+   cmplx_sol = ds.cmplx_sol;
+   quad_sol = ds.quad_sol;
+   keys = std::move(ds.keys);
 
-   fix_elem_orient = ss.fix_elem_orient;
-   save_coloring = ss.save_coloring;
-   keep_attr = ss.keep_attr;
-   geom_ref_type = ss.geom_ref_type;
-   cmplx_phase = ss.cmplx_phase;
-   point_coords = std::move(ss.point_coords);
+   fix_elem_orient = ds.fix_elem_orient;
+   save_coloring = ds.save_coloring;
+   keep_attr = ds.keep_attr;
+   geom_ref_type = ds.geom_ref_type;
+   cmplx_phase = ds.cmplx_phase;
+   point_coords = std::move(ds.point_coords);
 
    return *this;
+}
+
+DataState DataState::CloneEmpty() const
+{
+   DataState ds;
+   ds.type = type;
+   ds.cmplx_sol = cmplx_sol;
+   ds.quad_sol = quad_sol;
+   ds.keys = keys;
+
+   ds.fix_elem_orient = fix_elem_orient;
+   ds.save_coloring = save_coloring;
+   ds.keep_attr = keep_attr;
+   ds.geom_ref_type = geom_ref_type;
+   ds.cmplx_phase = cmplx_phase;
+   ds.point_coords = point_coords;
+
+   return ds;
 }
 
 void DataState::SetMesh(Mesh *mesh_)

--- a/lib/data_state.cpp
+++ b/lib/data_state.cpp
@@ -106,6 +106,7 @@ DataState &DataState::operator=(DataState &&ss)
    fix_elem_orient = ss.fix_elem_orient;
    save_coloring = ss.save_coloring;
    keep_attr = ss.keep_attr;
+   geom_ref_type = ss.geom_ref_type;
    cmplx_phase = ss.cmplx_phase;
    point_coords = std::move(ss.point_coords);
 

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -139,6 +139,7 @@ public:
    bool fix_elem_orient{false};
    bool save_coloring{false};
    bool keep_attr{false};
+   int geom_ref_type{mfem::Quadrature1D::ClosedUniform}; // geometry refiner type
    double cmplx_phase{0.};
    std::vector<std::array<double,3>> point_coords; // point line (from -pts)
 

--- a/lib/data_state.hpp
+++ b/lib/data_state.hpp
@@ -144,8 +144,9 @@ public:
    std::vector<std::array<double,3>> point_coords; // point line (from -pts)
 
    DataState() = default;
-   DataState(DataState &&ss) { *this = std::move(ss); }
-   DataState& operator=(DataState &&ss);
+   DataState(DataState &&ds) { *this = std::move(ds); }
+   DataState& operator=(DataState &&ds);
+   DataState CloneEmpty() const;
 
    /// Get type of the contained data
    inline FieldType GetType() const { return type; }

--- a/lib/sdl/sdl_main.cpp
+++ b/lib/sdl/sdl_main.cpp
@@ -684,7 +684,7 @@ void SdlMainThread::createWindowImpl(CreateWindowCmd& cmd)
 
    // Detect if we are using a high-dpi display and resize the window unless it
    // was already resized by SDL's underlying backend.
-   if (GetUseHiDPI())
+   //if (GetUseHiDPI())
    {
       SdlWindow* wnd = cmd.wnd;
       int scr_w, scr_h, pix_w, pix_h, wdpi, hdpi;

--- a/lib/sdl/sdl_main.cpp
+++ b/lib/sdl/sdl_main.cpp
@@ -684,7 +684,7 @@ void SdlMainThread::createWindowImpl(CreateWindowCmd& cmd)
 
    // Detect if we are using a high-dpi display and resize the window unless it
    // was already resized by SDL's underlying backend.
-   //if (GetUseHiDPI())
+   if (GetUseHiDPI())
    {
       SdlWindow* wnd = cmd.wnd;
       int scr_w, scr_h, pix_w, pix_h, wdpi, hdpi;

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1377,7 +1377,9 @@ void VisualizationSceneScalarData::SetAutoscale(Autoscale _autoscale,
 }
 
 VisualizationSceneScalarData::VisualizationSceneScalarData(
-   Window &win_, bool init) : VisualizationScene(*win_.wnd), win(win_)
+   Window &win_, bool init)
+   : VisualizationScene(*win_.wnd), win(win_),
+     geom_refiner(win.data_state.geom_ref_type)
 {
    mesh = win.data_state.mesh.get();
    mesh_coarse = win.data_state.mesh_quad.get();

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -82,6 +82,7 @@ protected:
    const DataState::Offsets *offsets{};
 
    Window &win;
+   mfem::GeometryRefiner geom_refiner;
 
    double minv, maxv;
 

--- a/lib/vssolution.cpp
+++ b/lib/vssolution.cpp
@@ -19,7 +19,6 @@ using namespace std;
 using namespace mfem;
 
 thread_local VisualizationSceneSolution *VisualizationSceneSolution::vssol;
-extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 #ifdef GLVIS_ISFINITE
 /* This test for INFs or NaNs is the same as the one used in hypre's PCG and
@@ -1135,8 +1134,8 @@ void VisualizationSceneSolution::FindNewBox(double rx[], double ry[],
       rx[1] = ry[1] = rval[1] = -rx[0];
       for (i = 0; i < ne; i++)
       {
-         RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                            TimesToRefine, EdgeRefineFactor);
+         RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                    TimesToRefine, EdgeRefineFactor);
          GetRefinedValues(i, RefG->RefPts, values, pointmat);
          for (j = 0; j < values.Size(); j++)
          {
@@ -1396,8 +1395,8 @@ void VisualizationSceneSolution::PrepareFlat2()
    {
       if (!el_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
 
-      RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                         TimesToRefine, EdgeRefineFactor);
+      RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                 TimesToRefine, EdgeRefineFactor);
       j = GetRefinedValuesAndNormals(i, RefG->RefPts, values, pointmat,
                                      normals);
       Array<int> &RG = RefG->RefGeoms;
@@ -1733,8 +1732,8 @@ void VisualizationSceneSolution::PrepareLevelCurves2()
    gl3::GlBuilder build = lcurve_buf.createBuilder();
    for (i = 0; i < ne; i++)
    {
-      RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                         TimesToRefine, EdgeRefineFactor);
+      RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                 TimesToRefine, EdgeRefineFactor);
       GetRefinedValues (i, RefG->RefPts, values, pointmat);
       Array<int> &RG = RefG->RefGeoms;
       int sides = mesh->GetElement(i)->GetNVertices();
@@ -2092,7 +2091,7 @@ void VisualizationSceneSolution::PrepareEdgeNumbering()
             std::cerr  << "Only TRIANGLE and SQUARE geometries are supported." << std::endl;
             return;
          }
-         const auto *RefG = GLVisGeometryRefiner.Refine(geom, 2, 2);
+         const auto *RefG = geom_refiner.Refine(geom, 2, 2);
          GetRefinedValues(e, RefG->RefPts, vals, p);
          const int ij3[3] = { 1, 4, 3 }, ie3[3] = { 0, 1, 2 };
          const int ij4[4] = { 1, 3, 5, 7 }, ie4[4] = { 0, 3, 1, 2 };
@@ -2337,8 +2336,8 @@ void VisualizationSceneSolution::PrepareLines2()
    {
       if (!el_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
 
-      RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                         TimesToRefine, EdgeRefineFactor);
+      RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                 TimesToRefine, EdgeRefineFactor);
       GetRefinedValues (i, RefG->RefPts, values, pointmat);
       Array<int> &RG = RefG->RefGeoms;
       int sides = mesh->GetElement(i)->GetNVertices();
@@ -2370,8 +2369,8 @@ void VisualizationSceneSolution::PrepareLines3()
    for (i = 0; i < ne; i++)
    {
       if (!el_attr_to_show[mesh->GetAttribute(i)-1]) { continue; }
-      RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                         TimesToRefine, EdgeRefineFactor);
+      RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                 TimesToRefine, EdgeRefineFactor);
       GetRefinedValues (i, RefG->RefPts, values, pointmat);
       Array<int> &RE = RefG->RefEdges;
 
@@ -2485,8 +2484,8 @@ void VisualizationSceneSolution::PrepareBoundary()
       int en;
       FaceElementTransformations *T;
       RefinedGeometry *RefG =
-         GLVisGeometryRefiner.Refine(Geometry::SEGMENT, TimesToRefine,
-                                     EdgeRefineFactor);
+         geom_refiner.Refine(Geometry::SEGMENT, TimesToRefine,
+                             EdgeRefineFactor);
       IntegrationRule &ir = RefG->RefPts;
       IntegrationRule eir(ir.GetNPoints());
       Vector vals;
@@ -2606,8 +2605,8 @@ void VisualizationSceneSolution::PrepareCP()
 
       for (int i = 0; i < mesh->GetNE(); i++)
       {
-         RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                            TimesToRefine, EdgeRefineFactor);
+         RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                    TimesToRefine, EdgeRefineFactor);
          GetRefinedValues (i, RefG->RefPts, values, pointmat);
          Array<int> &RG = RefG->RefGeoms;
          int sides = mesh->GetElement(i)->GetNVertices();

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1801,10 +1801,10 @@ void VisualizationSceneSolution3d::CutReferenceTriangle(
 // Call CutReferenceTriangle and CutReferenceSquare to update the global
 // variables cut_TriPts, cut_TriGeoms, cut_QuadPts, cut_QuadGeoms.
 void VisualizationSceneSolution3d::CutReferenceElements(
-   int TimesToRefine, double lambda)
+   int TimesToRefine_, double lambda)
 {
    RefinedGeometry *RefG =
-      geom_refiner.Refine(Geometry::SQUARE, TimesToRefine);
+      geom_refiner.Refine(Geometry::SQUARE, TimesToRefine_);
    CutReferenceTriangle(RefG, lambda, cut_TriPts, cut_TriGeoms);
    CutReferenceSquare(RefG, lambda, cut_QuadPts, cut_QuadGeoms);
 }

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -25,15 +25,6 @@ using namespace mfem;
 thread_local VisualizationSceneSolution3d
 *VisualizationSceneSolution3d::vssol3d;
 
-// Reference geometries with a cut in the middle, based on subdivision of
-// geom_refiner in 3-4 quads. Updated when cut_lambda is updated, see
-// keys Ctrl+F3/F4. We need these variables because the geom_refiner
-// caches its RefinedGeometry objects.
-thread_local IntegrationRule cut_QuadPts;
-thread_local Array<int> cut_QuadGeoms;
-thread_local IntegrationRule cut_TriPts;
-thread_local Array<int> cut_TriGeoms;
-
 // Definitions of some more keys
 
 std::string VisualizationSceneSolution3d::GetHelpString() const

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -24,11 +24,10 @@ using namespace mfem;
 
 thread_local VisualizationSceneSolution3d
 *VisualizationSceneSolution3d::vssol3d;
-extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 // Reference geometries with a cut in the middle, based on subdivision of
-// GLVisGeometryRefiner in 3-4 quads. Updated when cut_lambda is updated, see
-// keys Ctrl+F3/F4. We need these variables because the GLVisGeometryRefiner
+// geom_refiner in 3-4 quads. Updated when cut_lambda is updated, see
+// keys Ctrl+F3/F4. We need these variables because the geom_refiner
 // caches its RefinedGeometry objects.
 thread_local IntegrationRule cut_QuadPts;
 thread_local Array<int> cut_QuadGeoms;
@@ -1049,8 +1048,8 @@ void VisualizationSceneSolution3d::FindNewBox(bool prepare)
          if (dim == 3)
          {
             mesh->GetBdrElementFace(i, &fn, &fo);
-            RefG = GLVisGeometryRefiner.Refine(mesh->GetFaceGeometry(fn),
-                                               TimesToRefine);
+            RefG = geom_refiner.Refine(mesh->GetFaceGeometry(fn),
+                                       TimesToRefine);
             Tr = mesh->GetFaceElementTransformations(fn, 5);
             eir.SetSize(RefG->RefPts.GetNPoints());
             Tr->Loc1.Transform(RefG->RefPts, eir);
@@ -1059,8 +1058,8 @@ void VisualizationSceneSolution3d::FindNewBox(bool prepare)
          else
          {
             T = mesh->GetElementTransformation(i);
-            RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                               TimesToRefine);
+            RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                       TimesToRefine);
             T->Transform(RefG->RefPts, pointmat);
          }
          for (int j = 0; j < pointmat.Width(); j++)
@@ -1269,11 +1268,11 @@ void VisualizationSceneSolution3d::DrawRefinedSurf(
    switch (n)
    {
       case 3:
-         RefG = GLVisGeometryRefiner.Refine(Geometry::TRIANGLE, TimesToRefine);
+         RefG = geom_refiner.Refine(Geometry::TRIANGLE, TimesToRefine);
          ip_transf.Transf.SetFE (&TriangleFE);
          break;
       case 4:
-         RefG = GLVisGeometryRefiner.Refine(Geometry::SQUARE, TimesToRefine);
+         RefG = geom_refiner.Refine(Geometry::SQUARE, TimesToRefine);
          ip_transf.Transf.SetFE (&QuadrilateralFE);
          break;
       case 5:
@@ -1697,8 +1696,9 @@ void VisualizationSceneSolution3d::PrepareFlat()
 // square removed: (fl,fl)-(fr,fl)-(fr,fr)-(fl,fr). The input RefG corresponds
 // to the reference square. The value of lambda controls the cut: 0 = no cut, 1
 // = full cut. See keys Ctrl+F3/F4.
-static void CutReferenceSquare(RefinedGeometry *RefG, double lambda,
-                               IntegrationRule &RefPts, Array<int> &RefGeoms)
+void VisualizationSceneSolution3d::CutReferenceSquare(
+   RefinedGeometry *RefG, double lambda, IntegrationRule &RefPts,
+   Array<int> &RefGeoms)
 {
    // lambda * vertex + (1-lambda) * center
    double fl = (1.0-lambda)/2.0; // left corner of the cut frame
@@ -1752,8 +1752,9 @@ static void CutReferenceSquare(RefinedGeometry *RefG, double lambda,
 // triangle removed: (fl,fl)-(fr,fl)-(fl,fr). Note that the input RefG
 // corresponds to a reference square, not reference triangle. The value of
 // lambda controls the cut: 0 = no cut, 1 = full cut. See keys Ctrl+F3/F4.
-static void CutReferenceTriangle(RefinedGeometry *RefG, double lambda,
-                                 IntegrationRule &RefPts, Array<int> &RefGeoms)
+void VisualizationSceneSolution3d::CutReferenceTriangle(
+   RefinedGeometry *RefG, double lambda, IntegrationRule &RefPts,
+   Array<int> &RefGeoms)
 {
    // lambda * vertex + (1-lambda) * center
    double fl = (1.0-lambda)/3.0;     // left corner of the cut frame
@@ -1799,10 +1800,11 @@ static void CutReferenceTriangle(RefinedGeometry *RefG, double lambda,
 
 // Call CutReferenceTriangle and CutReferenceSquare to update the global
 // variables cut_TriPts, cut_TriGeoms, cut_QuadPts, cut_QuadGeoms.
-void CutReferenceElements(int TimesToRefine, double lambda)
+void VisualizationSceneSolution3d::CutReferenceElements(
+   int TimesToRefine, double lambda)
 {
    RefinedGeometry *RefG =
-      GLVisGeometryRefiner.Refine(Geometry::SQUARE, TimesToRefine);
+      geom_refiner.Refine(Geometry::SQUARE, TimesToRefine);
    CutReferenceTriangle(RefG, lambda, cut_TriPts, cut_TriGeoms);
    CutReferenceSquare(RefG, lambda, cut_QuadPts, cut_QuadGeoms);
 }
@@ -1877,8 +1879,8 @@ void VisualizationSceneSolution3d::PrepareFlat2()
       if (dim == 3)
       {
          mesh -> GetBdrElementFace (i, &fn, &fo);
-         RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceGeometry (fn),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh -> GetFaceGeometry (fn),
+                                    TimesToRefine);
          if (!cut_updated)
          {
             // Update the cut version of the reference geometries
@@ -1904,8 +1906,8 @@ void VisualizationSceneSolution3d::PrepareFlat2()
       }
       else
       {
-         RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                    TimesToRefine);
          if (!cut_updated)
          {
             // Update the cut version of the reference geometries
@@ -2324,8 +2326,8 @@ void VisualizationSceneSolution3d::PrepareLines2()
       if (dim == 3)
       {
          mesh -> GetBdrElementFace (i, &fn, &fo);
-         RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceGeometry (fn),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh -> GetFaceGeometry (fn),
+                                    TimesToRefine);
          // di = GridF -> GetFaceValues (fn, 2, RefG->RefPts, values, pointmat);
          di = fo % 2;
          if (di == 1 && !mesh->FaceIsInterior(fn))
@@ -2337,8 +2339,8 @@ void VisualizationSceneSolution3d::PrepareLines2()
       }
       else
       {
-         RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                    TimesToRefine);
          GridF->GetValues(i, RefG->RefPts, values, pointmat);
          ShrinkPoints(pointmat, i, 0, 0);
       }
@@ -3068,7 +3070,7 @@ void VisualizationSceneSolution3d::PrepareCuttingPlane()
          {
             const Geometry::Type geom = mesh->GetElementBaseGeometry(i);
             RefinedGeometry *RefG =
-               GLVisGeometryRefiner.Refine(geom, TimesToRefine);
+               geom_refiner.Refine(geom, TimesToRefine);
             GridF->GetValues(i, RefG->RefPts, vals, pointmat);
             vert_dist.SetSize(pointmat.Width());
             for (int j = 0; j < pointmat.Width(); j++)
@@ -3137,8 +3139,8 @@ void VisualizationSceneSolution3d::PrepareCuttingPlane2()
          }
          else // shading == 2
          {
-            RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceGeometry (i),
-                                               TimesToRefine);
+            RefG = geom_refiner.Refine(mesh -> GetFaceGeometry (i),
+                                       TimesToRefine);
             // partition[e1] is 0 if e1 is behind the cutting plane
             // and 1 otherwise
             int dir = partition[e1];
@@ -3194,7 +3196,7 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines()
             {
                const Geometry::Type geom = mesh->GetFaceGeometry(i);
                RefinedGeometry *RefG =
-                  GLVisGeometryRefiner.Refine(geom, TimesToRefine);
+                  geom_refiner.Refine(geom, TimesToRefine);
                if (FaceShiftScale == 0.0)
                {
                   ElementTransformation *T = mesh->GetFaceTransformation(i);
@@ -3229,7 +3231,7 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines()
             {
                const Geometry::Type geom = mesh->GetElementBaseGeometry(i);
                RefinedGeometry *RefG =
-                  GLVisGeometryRefiner.Refine(geom, TimesToRefine);
+                  geom_refiner.Refine(geom, TimesToRefine);
                GridF->GetValues(i, RefG->RefPts, vals, pointmat);
                vert_dist.SetSize(pointmat.Width());
                for (int j = 0; j < pointmat.Width(); j++)
@@ -3316,8 +3318,8 @@ void VisualizationSceneSolution3d::PrepareCuttingPlaneLines2()
          }
          else // shading == 2
          {
-            RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceGeometry (i),
-                                               TimesToRefine);
+            RefG = geom_refiner.Refine(mesh -> GetFaceGeometry (i),
+                                       TimesToRefine);
             // partition[e1] is 0 if e1 is behind the cutting plane
             // and 1 otherwise
             int di = partition[e1];
@@ -4138,7 +4140,7 @@ void VisualizationSceneSolution3d::PrepareLevelSurf()
       {
          const Geometry::Type geom = mesh->GetElementBaseGeometry(ie);
 
-         RefG = GLVisGeometryRefiner.Refine(geom, TimesToRefine);
+         RefG = geom_refiner.Refine(geom, TimesToRefine);
          GridF->GetValues(ie, RefG->RefPts, vals, pointmat);
 #ifdef GLVIS_SMOOTH_LEVELSURF_NORMALS
          const int map_type = GridF->FESpace()->GetFE(ie)->GetMapType();

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -72,6 +72,13 @@ protected:
                             mfem::Array<int> *idxs = NULL);
    void LiftRefinedSurf (int n, mfem::DenseMatrix &pointmat,
                          mfem::Vector &values, int *RG);
+
+   static void CutReferenceSquare(mfem::RefinedGeometry *RefG, double lambda,
+                                  mfem::IntegrationRule &RefPts, mfem::Array<int> &RefGeoms);
+   static void CutReferenceTriangle(mfem::RefinedGeometry *RefG, double lambda,
+                                    mfem::IntegrationRule &RefPts, mfem::Array<int> &RefGeoms);
+   void CutReferenceElements(int TimesToRefine, double lambda);
+
    void DrawTetLevelSurf(gl3::GlDrawable& target, const mfem::DenseMatrix &verts,
                          const mfem::Vector &vals,
                          const int *ind, const mfem::Array<double> &levels,

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -43,6 +43,15 @@ protected:
 
    mfem::GridFunction *GridF{};
 
+   // Reference geometries with a cut in the middle, based on subdivision of
+   // geom_refiner in 3-4 quads. Updated when cut_lambda is updated, see
+   // keys Ctrl+F3/F4. We need these variables because the geom_refiner
+   // caches its RefinedGeometry objects.
+   mfem::IntegrationRule cut_QuadPts;
+   mfem::Array<int> cut_QuadGeoms;
+   mfem::IntegrationRule cut_TriPts;
+   mfem::Array<int> cut_TriGeoms;
+
    void Init();
 
    void NewMeshAndSolution(mfem::Mesh *new_m, mfem::Mesh *new_mc,

--- a/lib/vsvector.cpp
+++ b/lib/vsvector.cpp
@@ -117,7 +117,6 @@ std::string VisualizationSceneVector::GetHelpString() const
 }
 
 thread_local VisualizationSceneVector  *VisualizationSceneVector::vsvector;
-extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 void VisualizationSceneVector::KeyDPressed()
 {
@@ -724,8 +723,8 @@ void VisualizationSceneVector::PrepareDisplacedMesh()
       for (int i = 0; i < ne; i++)
       {
          RefinedGeometry *RefG =
-            GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                        TimesToRefine, EdgeRefineFactor);
+            geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                TimesToRefine, EdgeRefineFactor);
          VecGridF->GetVectorValues(i, RefG->RefPts, vvals, pm);
 
          Array<int> &RE = RefG->RefEdges;
@@ -757,8 +756,8 @@ void VisualizationSceneVector::PrepareDisplacedMesh()
       for (int i = 0; i < ne; i++)
       {
          RefinedGeometry *RefG =
-            GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                        TimesToRefine, EdgeRefineFactor);
+            geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                TimesToRefine, EdgeRefineFactor);
          VecGridF->GetVectorValues(i, RefG->RefPts, vvals, pm);
 
          vvals += pm;
@@ -828,8 +827,8 @@ void VisualizationSceneVector::PrepareDisplacedMesh()
       for (int i = 0; i < ne; i++)
       {
          RefinedGeometry *RefG =
-            GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                        TimesToRefine, EdgeRefineFactor);
+            geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                TimesToRefine, EdgeRefineFactor);
          VecGridF->GetVectorValues(i, RefG->RefPts, vvals, pm);
 
          {
@@ -996,7 +995,7 @@ void VisualizationSceneVector::PrepareVectorField()
             for (i = 0; i < mesh->GetNE(); i++)
             {
                const IntegrationRule *ir =
-                  GLVisGeometryRefiner.RefineInterior(
+                  geom_refiner.RefineInterior(
                      mesh->GetElementBaseGeometry(i), RefineFactor);
                if (ir == NULL)
                {
@@ -1012,7 +1011,7 @@ void VisualizationSceneVector::PrepareVectorField()
             for (i = 0; i < mesh->GetNEdges(); i++)
             {
                const IntegrationRule *ir =
-                  GLVisGeometryRefiner.RefineInterior(
+                  geom_refiner.RefineInterior(
                      mesh->GetFaceGeometry(i), RefineFactor);
                if (ir == NULL)
                {

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -28,8 +28,6 @@ extern thread_local IntegrationRule cut_QuadPts;
 extern thread_local Array<int> cut_QuadGeoms;
 extern thread_local IntegrationRule cut_TriPts;
 extern thread_local Array<int> cut_TriGeoms;
-extern void CutReferenceElements(int TimesToRefine, double lambda);
-
 
 std::string VisualizationSceneVector3d::GetHelpString() const
 {
@@ -130,7 +128,6 @@ std::string VisualizationSceneVector3d::GetHelpString() const
 
 thread_local VisualizationSceneVector3d
 *VisualizationSceneVector3d::vsvector3d;
-extern thread_local GeometryRefiner GLVisGeometryRefiner;
 
 void VisualizationSceneVector3d::KeyDPressed()
 {
@@ -771,8 +768,8 @@ void VisualizationSceneVector3d::PrepareFlat2()
       if (dim == 3)
       {
          mesh -> GetBdrElementFace (i, &fn, &fo);
-         RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceGeometry (fn),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh -> GetFaceGeometry (fn),
+                                    TimesToRefine);
          if (!cut_updated)
          {
             // Update the cut version of the reference geometries
@@ -807,8 +804,8 @@ void VisualizationSceneVector3d::PrepareFlat2()
       }
       else // dim < 3
       {
-         RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                    TimesToRefine);
          if (!cut_updated)
          {
             // Update the cut version of the reference geometries
@@ -1171,8 +1168,8 @@ void VisualizationSceneVector3d::PrepareLines2()
       if (dim == 3)
       {
          mesh -> GetBdrElementFace (i, &fn, &fo);
-         RefG = GLVisGeometryRefiner.Refine(mesh -> GetFaceGeometry (fn),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh -> GetFaceGeometry (fn),
+                                    TimesToRefine);
          // di = GridF->GetFaceValues(fn, 2, RefG->RefPts, values, pointmat);
          di = fo % 2;
          if (di == 1 && !mesh->FaceIsInterior(fn))
@@ -1190,8 +1187,8 @@ void VisualizationSceneVector3d::PrepareLines2()
       }
       else
       {
-         RefG = GLVisGeometryRefiner.Refine(mesh->GetElementBaseGeometry(i),
-                                            TimesToRefine);
+         RefG = geom_refiner.Refine(mesh->GetElementBaseGeometry(i),
+                                    TimesToRefine);
          GridF->GetValues(i, RefG->RefPts, values, pointmat);
          VecGridF->GetVectorValues(i, RefG->RefPts, vec_vals, pointmat);
          if (ianim > 0)

--- a/lib/vsvector3d.cpp
+++ b/lib/vsvector3d.cpp
@@ -21,14 +21,6 @@
 using namespace mfem;
 using namespace std;
 
-// Reference geometry with a cut in the middle, which subdivides GeometryRefiner
-// when cut_lambda is updated, see keys Ctrl+F3/F4. These variables are defined
-// in lib/vssolution3d.cpp.
-extern thread_local IntegrationRule cut_QuadPts;
-extern thread_local Array<int> cut_QuadGeoms;
-extern thread_local IntegrationRule cut_TriPts;
-extern thread_local Array<int> cut_TriGeoms;
-
 std::string VisualizationSceneVector3d::GetHelpString() const
 {
    std::stringstream os;

--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -30,6 +30,24 @@ Window &Window::operator=(Window &&w)
    return *this;
 }
 
+Window Window::CloneEmpty() const
+{
+   Window w;
+
+   w.data_state = data_state.CloneEmpty();
+
+   w.window_x = window_x;
+   w.window_y = window_y;
+   w.window_w = window_w;
+   w.window_h = window_h;
+   w.window_title = window_title;
+   w.headless = headless;
+   w.plot_caption = plot_caption;
+   w.extra_caption = extra_caption;
+
+   return w;
+}
+
 // Visualize the data in the global variables mesh, sol/grid_f, etc
 bool Window::GLVisInitVis(StreamCollection input_streams)
 {

--- a/lib/window.hpp
+++ b/lib/window.hpp
@@ -52,6 +52,7 @@ public:
    Window() = default;
    Window(Window &&w) { *this = std::move(w); }
    Window& operator=(Window &&w);
+   Window CloneEmpty() const;
 
    /// Visualize the data in the global variables mesh, sol/grid_f, etc
    bool GLVisInitVis(StreamCollection input_streams);


### PR DESCRIPTION
Fixed geometry refiner settings, which was not correctly passed to the worker threads as reported by @v-dobrev . This was to great extent a problem of the poor design of the shared global object. This PR refactors the codebase, moving the `GeometryRefiner` to the base class `VisualizationSceneScalarData`, where it is available to all visualization scenes. The type of the refiner is set in `DataState` along other settings. Moreover, passing of this kind of parameters has been refactored out from `GLVisServer` as the list was growing and growing 😳 .