### PR TITLE
Add direct cutting-plane control to GLVis scripts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,10 @@
 
 Version 4.5.1 (development)
 ===========================
+- Added a 'cutting_plane' script command to set the cutting plane orientation
+  (phi, theta in degrees), translation, kind, and algorithm in a single
+  command: 'cutting_plane <phi> <theta> <translation> [<kind> [<alg>]]'.
+
 - Added an optional point line overlay (useful e.g. for reference curves), which
   can be toggled with 'Ctrl+l'. Points can be loaded from a file with the '-pts'
   option, sent via socket with the 'pointline' command, or specified in a GLVis

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -131,7 +131,7 @@ ScriptCommands::ScriptCommands()
    (*this)[Command::PlotCaption]          = {"plot_caption", "'<caption>'", "Set the plot caption."};
    (*this)[Command::PointLine]            = {"pointline", "<num_points> <x y z>...", "Set point line overlay coordinates."};
    (*this)[Command::Headless]             = {"headless", "", "Change the session to headless."};
-   (*this)[Command::CuttingPlane]         = {"cutting_plane", "<phi> <theta> <translation> <kind:optional, default 1> <alg:optional>", "Set the cutting plane orientation (degrees), translation, kind, and algorithm."};
+   (*this)[Command::CuttingPlane]         = {"cutting_plane", "<phi> <theta> <translation> [<kind> [<alg>]]", "Set the cutting plane orientation (degrees), translation, kind (default: 1), and algorithm."};
 }
 
 int ScriptController::ScriptReadSolution(istream &scr, DataState &state)

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -871,12 +871,12 @@ bool ScriptController::ExecuteScriptCommand()
             int kind = 1, algo = -1;
             scr >> ws;
             int ch = scr.peek();
-            if (ch != std::char_traits<char>::eof() && (isdigit(ch) || ch == '-'))
+            if (isdigit(ch) || ch == '-')
             {
                scr >> kind;
                scr >> ws;
                ch = scr.peek();
-               if (ch != std::char_traits<char>::eof() && (isdigit(ch) || ch == '-'))
+               if (isdigit(ch) || ch == '-')
                {
                   scr >> algo;
                }

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -870,14 +870,29 @@ bool ScriptController::ExecuteScriptCommand()
 
             int kind = 1, algo = -1;
             scr >> ws;
-            if (isdigit((unsigned char)scr.peek()) || scr.peek() == '-')
+            int ch = scr.peek();
+            if (ch != std::char_traits<char>::eof() && (isdigit(ch) || ch == '-'))
             {
                scr >> kind;
                scr >> ws;
-               if (isdigit((unsigned char)scr.peek()) || scr.peek() == '-')
+               ch = scr.peek();
+               if (ch != std::char_traits<char>::eof() && (isdigit(ch) || ch == '-'))
                {
                   scr >> algo;
                }
+            }
+
+            if (kind < -1 || kind > 2)
+            {
+               cerr << "Script: cutting_plane: invalid kind " << kind
+                    << " (expected -1..2)" << endl;
+               kind = 1;
+            }
+            if (algo != -1 && (algo < 0 || algo > 1))
+            {
+               cerr << "Script: cutting_plane: invalid alg " << algo
+                    << " (expected 0 or 1)" << endl;
+               algo = -1;
             }
 
             cout << "Script: cutting_plane: " << phi_deg << ' ' << theta_deg

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -888,10 +888,10 @@ bool ScriptController::ExecuteScriptCommand()
                     << " (expected -1..2)" << endl;
                kind = 1;
             }
-            if (algo != -1 && (algo < 0 || algo > 1))
+            if (algo < -1 || algo > 1)
             {
                cerr << "Script: cutting_plane: invalid alg " << algo
-                    << " (expected 0 or 1)" << endl;
+                    << " (expected -1 (keep current), 0, or 1)" << endl;
                algo = -1;
             }
 

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -20,6 +20,8 @@
 #include <array>
 #include <algorithm>
 #include <thread>
+#include <cmath>
+#include <cctype>
 
 using namespace std;
 using namespace mfem;
@@ -63,6 +65,7 @@ enum class Command
    PlotCaption,
    PointLine,
    Headless,
+   CuttingPlane,
    //----------
    Max
 };
@@ -128,6 +131,7 @@ ScriptCommands::ScriptCommands()
    (*this)[Command::PlotCaption]          = {"plot_caption", "'<caption>'", "Set the plot caption."};
    (*this)[Command::PointLine]            = {"pointline", "<num_points> <x y z>...", "Set point line overlay coordinates."};
    (*this)[Command::Headless]             = {"headless", "", "Change the session to headless."};
+   (*this)[Command::CuttingPlane]         = {"cutting_plane", "<phi> <theta> <translation> <kind:optional> <alg:optional>", "Set the cutting plane orientation (degrees), translation, kind, and algorithm."};
 }
 
 int ScriptController::ScriptReadSolution(istream &scr, DataState &state)
@@ -859,6 +863,35 @@ bool ScriptController::ExecuteScriptCommand()
          case Command::Headless:
             cout << "The session cannot become headless after initialization" << endl;
             break;
+         case Command::CuttingPlane:
+         {
+            double phi_deg, theta_deg, translation;
+            scr >> phi_deg >> theta_deg >> translation;
+
+            int kind = -1, algo = -1;
+            scr >> ws;
+            if (isdigit((unsigned char)scr.peek()) || scr.peek() == '-')
+            {
+               scr >> kind;
+               scr >> ws;
+               if (isdigit((unsigned char)scr.peek()) || scr.peek() == '-')
+               {
+                  scr >> algo;
+               }
+            }
+
+            cout << "Script: cutting_plane: " << phi_deg << ' ' << theta_deg
+                 << ' ' << translation;
+            if (kind != -1) { cout << ' ' << kind; }
+            if (algo != -1) { cout << ' ' << algo; }
+            cout << endl;
+
+            win.vs->SetCuttingPlane(phi_deg * M_PI / 180.0,
+                                    theta_deg * M_PI / 180.0,
+                                    translation, kind, algo);
+            MyExpose();
+         }
+         break;
          case Command::Max: //dummy
             break;
       }

--- a/lib/script_controller.cpp
+++ b/lib/script_controller.cpp
@@ -131,7 +131,7 @@ ScriptCommands::ScriptCommands()
    (*this)[Command::PlotCaption]          = {"plot_caption", "'<caption>'", "Set the plot caption."};
    (*this)[Command::PointLine]            = {"pointline", "<num_points> <x y z>...", "Set point line overlay coordinates."};
    (*this)[Command::Headless]             = {"headless", "", "Change the session to headless."};
-   (*this)[Command::CuttingPlane]         = {"cutting_plane", "<phi> <theta> <translation> <kind:optional> <alg:optional>", "Set the cutting plane orientation (degrees), translation, kind, and algorithm."};
+   (*this)[Command::CuttingPlane]         = {"cutting_plane", "<phi> <theta> <translation> <kind:optional, default 1> <alg:optional>", "Set the cutting plane orientation (degrees), translation, kind, and algorithm."};
 }
 
 int ScriptController::ScriptReadSolution(istream &scr, DataState &state)
@@ -868,7 +868,7 @@ bool ScriptController::ExecuteScriptCommand()
             double phi_deg, theta_deg, translation;
             scr >> phi_deg >> theta_deg >> translation;
 
-            int kind = -1, algo = -1;
+            int kind = 1, algo = -1;
             scr >> ws;
             if (isdigit((unsigned char)scr.peek()) || scr.peek() == '-')
             {
@@ -881,8 +881,7 @@ bool ScriptController::ExecuteScriptCommand()
             }
 
             cout << "Script: cutting_plane: " << phi_deg << ' ' << theta_deg
-                 << ' ' << translation;
-            if (kind != -1) { cout << ' ' << kind; }
+                 << ' ' << translation << ' ' << kind;
             if (algo != -1) { cout << ' ' << algo; }
             cout << endl;
 

--- a/lib/vsdata.cpp
+++ b/lib/vsdata.cpp
@@ -1986,6 +1986,7 @@ Plane::Plane(const double (&eqn_)[4], const VisualizationScene::Box &bb)
    x0 = (x[0]+x[1])/2.0;
    y0 = (y[0]+y[1])/2.0;
    z0 = (z[0]+z[1])/2.0;
+   cx = x0; cy = y0; cz = z0;
 
    phi_step = M_PI / 36;
    theta_step = M_PI / 36;
@@ -2049,4 +2050,20 @@ void Plane::DecreaseDistance()
    z0 += eqn[2] * k;
    eqn[3] -= rho_step;
    CartesianToSpherical();
+}
+
+void Plane::SetPlane(double phi_, double theta_, double translation)
+{
+   phi = phi_;
+   theta = theta_;
+   rho = 1.0;
+
+   double nx = cos(phi) * cos(theta);
+   double ny = cos(phi) * sin(theta);
+   double nz = sin(phi);
+   x0 = cx + translation * nx;
+   y0 = cy + translation * ny;
+   z0 = cz + translation * nz;
+
+   SphericalToCartesian();
 }

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -265,9 +265,16 @@ public:
    virtual void AutoRefine() = 0;
    virtual void ToggleAttributes(mfem::Array<int> &attr_list) = 0;
 
-   // Set the cutting-plane orientation (radians), translation, kind, and
-   // algorithm in one shot. No-op by default; only meaningful for 3D scenes.
-   // kind == -1 / algo == -1 mean "leave unchanged".
+   /// @brief Set the cutting-plane orientation, translation, kind, and
+   /// algorithm in one shot.
+   ///
+   /// No-op by default; only meaningful for 3D scenes.
+   ///
+   /// @param phi Orientation angle, in radians.
+   /// @param theta Orientation angle, in radians.
+   /// @param translation Plane translation.
+   /// @param kind Cutting-plane kind, or -1 to leave unchanged.
+   /// @param algo Cutting-plane algorithm, or -1 to leave unchanged.
    virtual void SetCuttingPlane(double phi, double theta, double translation,
                                 int kind = -1, int algo = -1) { }
 

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -23,6 +23,7 @@ private:
    double eqn[4];
    double phi, theta, rho;
    double x0,y0,z0;
+   double cx, cy, cz; // fixed mesh bounding-box center
    void CartesianToSpherical();
    void SphericalToCartesian();
 
@@ -44,6 +45,7 @@ public:
    void DecreaseTheta();
    void IncreaseDistance();
    void DecreaseDistance();
+   void SetPlane(double phi_, double theta_, double translation);
 };
 
 
@@ -262,6 +264,12 @@ public:
    }
    virtual void AutoRefine() = 0;
    virtual void ToggleAttributes(mfem::Array<int> &attr_list) = 0;
+
+   // Set the cutting-plane orientation (radians), translation, kind, and
+   // algorithm in one shot. No-op by default; only meaningful for 3D scenes.
+   // kind == -1 / algo == -1 mean "leave unchanged".
+   virtual void SetCuttingPlane(double phi, double theta, double translation,
+                                int kind, int algo) { }
 
    virtual void PrintState();
 

--- a/lib/vsdata.hpp
+++ b/lib/vsdata.hpp
@@ -269,7 +269,7 @@ public:
    // algorithm in one shot. No-op by default; only meaningful for 3D scenes.
    // kind == -1 / algo == -1 mean "leave unchanged".
    virtual void SetCuttingPlane(double phi, double theta, double translation,
-                                int kind, int algo) { }
+                                int kind = -1, int algo = -1) { }
 
    virtual void PrintState();
 

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1192,6 +1192,36 @@ void VisualizationSceneSolution3d::ToggleCPAlgorithm()
    }
 }
 
+void VisualizationSceneSolution3d::SetCuttingPlane(double phi, double theta,
+                                                   double translation,
+                                                   int kind, int algo)
+{
+   CuttingPlane->SetPlane(phi, theta, translation);
+   FindNodePos();
+
+   if (kind != -1 && kind != cplane)
+   {
+      if (cplane == 2 && cp_drawmesh == 3)
+      {
+         cp_drawmesh = 2;
+      }
+      cplane = kind;
+   }
+
+   if (algo != -1)
+   {
+      cp_algo = algo;
+   }
+
+   CPPrepare();
+   if (cplane == 0 || cplane == 2)
+   {
+      Prepare();
+      PrepareLines();
+      PrepareOrderingCurve();
+   }
+}
+
 void VisualizationSceneSolution3d::MoveLevelSurf(int move)
 {
    drawlsurf += move;

--- a/lib/vssolution3d.cpp
+++ b/lib/vssolution3d.cpp
@@ -1196,6 +1196,8 @@ void VisualizationSceneSolution3d::SetCuttingPlane(double phi, double theta,
                                                    double translation,
                                                    int kind, int algo)
 {
+   const int old_cplane = cplane;
+
    CuttingPlane->SetPlane(phi, theta, translation);
    FindNodePos();
 
@@ -1214,11 +1216,15 @@ void VisualizationSceneSolution3d::SetCuttingPlane(double phi, double theta,
    }
 
    CPPrepare();
-   if (cplane == 0 || cplane == 2)
+   if (old_cplane == 2 || cplane == 2)
    {
       Prepare();
       PrepareLines();
-      PrepareOrderingCurve();
+
+      if (cplane != old_cplane)
+      {
+         PrepareOrderingCurve();
+      }
    }
 }
 

--- a/lib/vssolution3d.hpp
+++ b/lib/vssolution3d.hpp
@@ -218,6 +218,8 @@ public:
    void ToggleCPDrawElems();
    void ToggleCPDrawMesh();
    void ToggleCPAlgorithm();
+   void SetCuttingPlane(double phi, double theta, double translation,
+                        int kind, int algo) override;
    void MoveLevelSurf(int);
    void NumberOfLevelSurf(int);
    void EventUpdateColors() override;


### PR DESCRIPTION
## Motivation
Today, the only way to position the 3D cutting plane from a GLVis script is to replay raw keystrokes via keys. Even a modest plane orientation requires several keystrokes:
```
keys xxxxxyyyyyyyyi
```
(5 `x` presses to rotate `phi` by 25°, 8 `y` presses to rotate `theta` by 40°, then `i` to enable the plane). Each individual keystroke triggers a full cutting-plane geometry recomputation, not just the final one. On a large mesh that's a lot of wasted computation just to reach a state that could be stated directly in one line.

## What this adds
A single script command:
```
cutting_plane <phi> <theta> <translation> <kind:optional> <alg:optional>
```
which sets the plane's orientation (degrees), translation, kind (cut-through-elements / solid-cut-behind / off), and algorithm (accurate / fast) directly, in one shot reproducing exactly what the equivalent keystroke sequence would have produced, without the redundant intermediate recomputations. `kind` defaults to 1 (cut through elements) so the plane is visible immediately; `alg` is optional and leaves the current value unchanged when omitted.

## Implementation
- `Plane::SetPlane` : new direct setter on the existing `Plane` class (previously only relative `Increase/Decrease` mutators existed).
- `VisualizationSceneScalarData::SetCuttingPlane` : empty-default virtual hook (2D scenes no-op safely).
`VisualizationSceneSolution3d::SetCuttingPlane` — override combining plane move + kind + algorithm changes, mirroring the existing key-handler logic.
- `cutting_plane` registered in the script command table.